### PR TITLE
ci: add catalog-update-action workflow

### DIFF
--- a/.github/workflows/catalog-update.yml
+++ b/.github/workflows/catalog-update.yml
@@ -1,0 +1,30 @@
+name: Catalog Updates
+
+# Dependency updates for Bun's `catalog:` protocol. Groups, branch limits, and
+# ignores live in .catalog-updaterc.json at the repo root.
+on:
+  schedule:
+    - cron: '0 6 * * *' # Every day at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The action compares branches against the full history to close
+          # stale PRs and rebuild conflicting ones.
+          fetch-depth: 0
+          token: ${{ secrets.CI_PAT }}
+
+      - uses: brandhaug/catalog-update-action@v1
+        with:
+          config: '.catalog-updaterc.json'
+          dry-run: 'false'
+          # A PAT (not the default GITHUB_TOKEN) so the created PRs trigger CI.
+          token: ${{ secrets.CI_PAT }}


### PR DESCRIPTION
## What

Adds `.github/workflows/catalog-update.yml`, which runs [brandhaug/catalog-update-action](https://github.com/brandhaug/catalog-update-action) daily at 06:00 UTC and on demand.

The root `.catalog-updaterc.json` was already present and tuned for this repo (groups for react, tanstack, effect, tailwind, vite, oxc, testing-library, zod, mdx, plus a patch-only catch-all). Only the workflow was missing.

## Required before it works

The repository has no `CI_PAT` secret yet. Add a fine-grained PAT scoped to this repo with `Contents: read/write`, `Pull requests: read/write`, `Metadata: read`:

```bash
gh secret set CI_PAT -R brandhaug/b2b-saas-starter
```

A PAT is used instead of the default `GITHUB_TOKEN` because PRs opened with `GITHUB_TOKEN` do not start `ci.yml`.

## Notes

- The `catalog-update.yml` removed in 0cb9671 was the domain `catalog:refresh` template, not dependency updates. No overlap.
- The action also opens `overrides` PRs for vulnerable transitive dependencies, which matches the `bun audit --audit-level=high` gate in `ci.yml`.