### PR TITLE
fix(e2e): stop a hung workerd proxy from silently timing out the run

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -11,8 +11,20 @@ export default defineConfig({
   webServer: {
     command: 'bun run dev',
     url: 'http://localhost:3071',
-    reuseExistingServer: true,
-    timeout: 120_000
+    // Locally a dev server on :3071 is usually already running and reusing it
+    // saves a cold start. CI always starts its own: a process still holding
+    // the port there is a leak from an earlier step, and silently testing
+    // against it would hide the real state of the branch.
+    reuseExistingServer: !process.env.CI,
+    // The dev server answers in ~5s locally and ~9s on CI. The headroom is for
+    // the workerd proxy behind the `DB` binding (see
+    // src/lib/cloudflare-workers-shim-dev.ts), which is the slow part of a
+    // cold start.
+    timeout: 180_000,
+    // Vite writes its ready banner and the D1 attach notice to stdout, which
+    // Playwright drops by default. Without them a startup timeout says only
+    // that the URL never answered.
+    stdout: 'pipe'
   },
   projects: [
     {

--- a/apps/web/src/lib/cloudflare-workers-shim-dev.ts
+++ b/apps/web/src/lib/cloudflare-workers-shim-dev.ts
@@ -4,8 +4,9 @@
 // state (created by `bun run db:migrate:local`), that database is exposed as
 // the `DB` binding through wrangler's getPlatformProxy, so credential sign-in
 // and the Live capability layers run against the seeded data. Without that
-// state this module behaves exactly like the base shim: `DB` stays undefined
-// and the app runs provider-light on the Seed layer (CLAUDE.md rule 3).
+// state — or when the proxy misses its boot deadline — this module behaves
+// exactly like the base shim: `DB` stays undefined and the app runs
+// provider-light on the Seed layer (CLAUDE.md rule 3).
 //
 // The dev module graph also serves this file to the browser (route modules
 // import server helpers that reach `cloudflare:workers`), so everything
@@ -14,6 +15,12 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import { env as baseEnv } from './cloudflare-workers-shim.ts'
 
+// How long the workerd proxy gets to boot. This module is awaited at the top
+// level, so every SSR request blocks until it settles: without a limit a
+// workerd process that never comes up hangs the dev server with no output, and
+// the e2e run reports only that the URL never answered.
+const PROXY_BOOT_TIMEOUT_MS = 30_000
+
 async function provisionLocalD1(): Promise<D1Database | undefined> {
   if (!import.meta.env.SSR) return undefined
   const { join } = await import('node:path')
@@ -21,10 +28,31 @@ async function provisionLocalD1(): Promise<D1Database | undefined> {
     await import('./local-d1-state.ts')
   if (!hasLocalD1State()) return undefined
   const { getPlatformProxy } = await import('wrangler')
-  const proxy = await getPlatformProxy<{ DB: D1Database }>({
+  const { setTimeout: delay } = await import('node:timers/promises')
+  const pending = getPlatformProxy<{ DB: D1Database }>({
     configPath: join(dbPackageDir, 'wrangler.jsonc'),
     persist: { path: localD1PersistPath }
   })
+  // The deadline is aborted as soon as the race settles, so a dev server that
+  // booted normally does not hold an idle timer for the rest of the window.
+  // Only the abort rejection is caught — it can arrive after the race only.
+  const deadline = new AbortController()
+  const expired = delay(PROXY_BOOT_TIMEOUT_MS, undefined, {
+    signal: deadline.signal
+  }).catch(() => undefined)
+  // oxlint-disable-next-line effect/noNewPromise -- platform boundary: this module is awaited before any Effect runtime exists, and wrangler's getPlatformProxy hands back a bare Promise with no interruption channel
+  const proxy = await Promise.race([pending, expired])
+  deadline.abort()
+  if (!proxy) {
+    // A proxy that arrives after the limit would leave an orphan workerd
+    // process behind, so shut it down. Nothing reads it any more.
+    void pending.then((late) => late.dispose()).catch(() => undefined)
+    // oxlint-disable-next-line no-console -- dev-server terminal is the intended surface for this notice
+    console.warn(
+      `[dev] local D1 did not attach within ${PROXY_BOOT_TIMEOUT_MS / 1000}s — continuing on the Seed layer (credential sign-in will not work)`
+    )
+    return undefined
+  }
   // oxlint-disable-next-line no-console -- dev-server terminal is the intended surface for this one-time notice
   console.log('[dev] local D1 attached from packages/db/.wrangler (seeded state)')
   return proxy.env.DB


### PR DESCRIPTION
## Problem

The `e2e` job failed at random with one line and nothing else:

```
Error: Timed out waiting 120000ms from config.webServer.
```

No test ran. It hit 2 of the last ~10 runs, on branches whose diff cannot change runtime behaviour:

- `catalog-update/posthog-js` (#47) — a catalog version bump for a package that no workspace depends on.
- `catalog-update-override/vulnerability-fixes` — a lockfile override.

A re-run of #47 passed with no code change, which confirms the failure is environmental.

## Cause

`apps/web/src/lib/cloudflare-workers-shim-dev.ts` awaits `getPlatformProxy` at the top level of the module. Every SSR request blocks until workerd is up. If workerd never comes up, the dev server answers nothing, prints nothing, and Playwright waits out its full window.

The log gives no clue, because Playwright drops webServer stdout by default. The vite ready banner and the `[dev] local D1 attached` notice are missing from passing runs too.

## Changes

**1. A boot deadline on the workerd proxy** (`cloudflare-workers-shim-dev.ts`)

The proxy gets 30 seconds. Past that the shim falls back to `DB: undefined` and the Seed layer — the same state it already reaches with no local D1 state (CLAUDE.md rule 3). A proxy that arrives late is disposed, so no orphan workerd process is left behind.

This does not hide a broken D1. The e2e sign-in test gates on `hasLocalD1State()`, not on the binding, so in CI it still runs and still fails — with a real assertion message instead of a silent 120-second stall.

**2. Piped webServer stdout** (`playwright.config.ts`)

So the next startup failure says where it stopped.

**3. Timeout and reuse** (`playwright.config.ts`)

The window goes to 180s. `reuseExistingServer` is now off in CI: a process holding `:3071` there is a leak from an earlier step, and testing against it would hide the real state of the branch.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run format:check` — pass.
- `CI=1 bun run test:e2e` — 4 passed. Piped stdout confirmed in the output.
- Fallback path checked with the deadline temporarily set to 1 ms: the dev server answered in 2 s and printed
  `[dev] local D1 did not attach within 0.001s — continuing on the Seed layer (credential sign-in will not work)`
  instead of hanging.