### PR TITLE
feat(auth): wire the Better Auth organization plugin onto workspace tables

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -182,6 +182,7 @@
     "packages/auth": {
       "name": "@b2b-saas-starter/auth",
       "dependencies": {
+        "@b2b-saas-starter/authz": "workspace:*",
         "@b2b-saas-starter/db": "workspace:*",
         "better-auth": "catalog:",
         "effect": "catalog:",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@b2b-saas-starter/authz": "workspace:*",
     "@b2b-saas-starter/db": "workspace:*",
     "better-auth": "catalog:",
     "effect": "catalog:",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,5 +1,6 @@
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { admin } from 'better-auth/plugins/admin'
+import { organization } from 'better-auth/plugins/organization'
 import { username } from 'better-auth/plugins/username'
 import { tanstackStartCookies } from 'better-auth/tanstack-start'
 import { Context, Effect } from 'effect'
@@ -8,6 +9,7 @@ import {
   service,
   type Session as InferredSession
 } from 'effectful-better-auth'
+import { accessControl, workspaceRoleAccess } from '@b2b-saas-starter/authz'
 import type { Database } from '@b2b-saas-starter/db/client'
 import * as schema from '@b2b-saas-starter/db/schema'
 
@@ -66,6 +68,69 @@ export function makeAuthOptions(options: AuthConfigInterface) {
       admin({
         adminRoles: ['admin']
       }),
+      organization({
+        // One statement set, one role table, shared with every non-plugin
+        // permission check. `requirePermission` reads the same objects, so the
+        // plugin's own endpoints and the starter's guard can never disagree.
+        ac: accessControl,
+        roles: workspaceRoleAccess,
+        // Off, and stated rather than left to the default. Turning teams on
+        // adds two tables and makes `session.activeTeamId` required, neither of
+        // which the schema has. `dynamicAccessControl` is absent for the same
+        // reason: it wants an `organizationRole` table. Static roles are enough
+        // for a starter.
+        teams: { enabled: false },
+        // `modelName` is the *drizzle schema export key*, not the SQL table
+        // name — the adapter resolves models with `schema[modelName]`
+        // (@better-auth/drizzle-adapter `getSchema`). The starter's domain word
+        // stays `workspace`, so the plugin's three models point at the
+        // workspace tables and nothing above this package learns the plugin's
+        // vocabulary.
+        schema: {
+          organization: {
+            modelName: 'workspaces',
+            // The plugin's organization model has no `updatedAt`, and `planId`
+            // is the starter's own. Both are declared here rather than stuffed
+            // into `metadata`: a column the plugin does not know about is
+            // stripped from every endpoint response. `input: false` keeps them
+            // off the create/update body — a plan change is billing's job, not
+            // a caller's.
+            additionalFields: {
+              planId: {
+                type: 'string',
+                required: false,
+                input: false,
+                defaultValue: 'starter'
+              },
+              updatedAt: {
+                type: 'date',
+                required: false,
+                input: false,
+                // Better Auth calls these outside any Effect, so `Clock` cannot
+                // reach them — this file is the platform adapter the rule's own
+                // message exempts. Without `onUpdate` the column keeps its
+                // insert value forever, which is worse than an untestable
+                // clock: a field named `updatedAt` that never updates.
+                // oxlint-disable-next-line effect/noGlobals -- plugin callback runs outside Effect; no Clock available
+                defaultValue: () => new Date(),
+                // oxlint-disable-next-line effect/noGlobals -- plugin callback runs outside Effect; no Clock available
+                onUpdate: () => new Date()
+              }
+            }
+          },
+          // The plugin names its foreign key `organizationId`; the column is
+          // `workspaceId`. Every other field name already matches, so this is
+          // the only rename the mapping needs.
+          member: {
+            modelName: 'workspaceMembers',
+            fields: { organizationId: 'workspaceId' }
+          },
+          invitation: {
+            modelName: 'workspaceInvitations',
+            fields: { organizationId: 'workspaceId' }
+          }
+        }
+      }),
       // Better Auth requires cookie-integration plugins last so cookies set by
       // other plugins' hooks are forwarded to the framework cookie store.
       tanstackStartCookies()
@@ -88,4 +153,23 @@ export const Auth = service(
   })
 )
 
+/**
+ * `Session` does not carry the active workspace, and nothing should read
+ * `session.activeOrganizationId` from it. The plugin declares that field
+ * unconditionally and writes it on create, accept, and set-active — no option
+ * turns it off — but the starter resolves the workspace from the request slug
+ * through `liveWorkspaceContext`. Two sources of truth for "which workspace" is
+ * how a user ends up looking at one workspace's URL and another's data; the
+ * slug wins because it is the one the address bar shows.
+ */
 export type Session = InferredSession<AuthOptions>
+
+/**
+ * Compile-time guard for plugin schema inference, and the reason `plugins(...)`
+ * wraps the array above. A widened plugin array drops every plugin-added field
+ * from `Session` while the endpoints keep working — a break no runtime test can
+ * see, because the data is still there. Indexing the type is the assertion: if
+ * inference breaks, `role` stops existing and `tsc --noEmit` fails on this
+ * line. `requireAdmin` in apps/web reads this field.
+ */
+export type SessionUserRole = Session['user']['role']

--- a/packages/auth/src/live-auth.test.ts
+++ b/packages/auth/src/live-auth.test.ts
@@ -1,0 +1,244 @@
+import { Effect, Layer } from 'effect'
+import { eq } from 'drizzle-orm'
+import type { Service } from 'effectful-better-auth'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createDb, type Database } from '@b2b-saas-starter/db/client'
+import { user, workspaceInvitations, workspaces } from '@b2b-saas-starter/db/schema'
+import { provisionTestD1, type TestD1 } from '@b2b-saas-starter/db/testing'
+import { Auth, AuthConfig, type AuthOptions } from './index.ts'
+
+// The organization plugin is only observable through a real database: its
+// `modelName` overrides, its `additionalFields`, and its role table all resolve
+// inside Better Auth and reach D1 as SQL. Asserting the options object instead
+// would pass even if no endpoint ever found a table, so this suite drives
+// `Auth.api` against a local D1 (workerd) with every committed migration
+// applied.
+
+type AuthService = Service<AuthOptions>
+
+let testD1: TestD1
+let db: Database
+let authLayer: Layer.Layer<AuthService>
+
+// oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
+beforeAll(
+  () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        testD1 = yield* Effect.promise(() => provisionTestD1())
+        db = createDb(testD1.d1)
+        authLayer = Auth.layer.pipe(
+          Layer.provide(
+            Layer.sync(AuthConfig)(() => ({
+              db,
+              secret: 'test-secret-at-least-32-characters-long',
+              baseURL: 'http://localhost:3071',
+              trustedOrigins: [],
+              github: null
+            }))
+          )
+        )
+      })
+    ),
+  60_000
+)
+
+// oxlint-disable-next-line effect/noTestLifecycleHooks -- disposes the workerd process
+afterAll(() => testD1.dispose())
+
+function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
+  return Effect.runPromise(Effect.provide(effect, authLayer))
+}
+
+/** The plugin needs an existing user to own the workspace it creates. */
+function seedUser(id: string, email: string) {
+  return Effect.promise(() => db.insert(user).values({ id, email, name: email }).run())
+}
+
+/**
+ * A real session cookie. `createOrganization` accepts a `userId` body field and
+ * runs headerless, but the invitation and permission endpoints are
+ * `requireHeaders`, so those tests sign a user up and reuse the cookie Better
+ * Auth sets. `instance` is the escape hatch for the raw headers — the effectful
+ * `api` collapses to the data branch.
+ */
+function signUpSession(email: string) {
+  return Effect.gen(function* () {
+    const auth = yield* Auth.Tag
+    const { headers, response } = yield* Effect.promise(() =>
+      auth.instance.api.signUpEmail({
+        body: { email, name: email, password: 'correct-horse-battery-staple' },
+        returnHeaders: true
+      })
+    )
+    const cookie = headers.get('set-cookie')
+    if (cookie === null) return yield* Effect.die(`sign-up set no cookie for ${email}`)
+    return { headers: new Headers({ cookie }), userId: response.user.id }
+  })
+}
+
+describe('organization plugin', () => {
+  it('creates a workspace through the remapped organization model', () =>
+    run(
+      Effect.gen(function* () {
+        yield* seedUser('usr_acme_owner', 'owner@acme.test')
+        const auth = yield* Auth.Tag
+
+        const created = yield* auth.api.createOrganization({
+          body: { name: 'Acme', slug: 'acme', userId: 'usr_acme_owner' }
+        })
+
+        expect(created.slug).toBe('acme')
+
+        const rows = yield* Effect.promise(() =>
+          db.select().from(workspaces).where(eq(workspaces.slug, 'acme'))
+        )
+        expect(rows).toHaveLength(1)
+        expect(rows[0]?.name).toBe('Acme')
+      })
+    ))
+
+  it('carries planId and updatedAt as organization additional fields', () =>
+    run(
+      Effect.gen(function* () {
+        yield* seedUser('usr_plan_owner', 'owner@plan.test')
+        const auth = yield* Auth.Tag
+
+        const created = yield* auth.api.createOrganization({
+          body: { name: 'Plan Co', slug: 'plan-co', userId: 'usr_plan_owner' }
+        })
+
+        // A column the plugin does not declare is stripped from every endpoint
+        // response, so reading these back proves they are declared, not merely
+        // defaulted by SQLite.
+        expect(created.planId).toBe('starter')
+        expect(created.updatedAt).toBeInstanceOf(Date)
+      })
+    ))
+
+  it('creates an invitation through the remapped invitation model', () =>
+    run(
+      Effect.gen(function* () {
+        const { headers } = yield* signUpSession('inviter@invite.test')
+        const auth = yield* Auth.Tag
+
+        const workspace = yield* auth.api.createOrganization({
+          body: { name: 'Invite Co', slug: 'invite-co' },
+          headers
+        })
+        const invitation = yield* auth.api.createInvitation({
+          body: {
+            email: 'newcomer@invite.test',
+            role: 'member',
+            organizationId: workspace.id
+          },
+          headers
+        })
+
+        expect(invitation.email).toBe('newcomer@invite.test')
+
+        const rows = yield* Effect.promise(() =>
+          db
+            .select()
+            .from(workspaceInvitations)
+            .where(eq(workspaceInvitations.email, 'newcomer@invite.test'))
+        )
+        expect(rows).toHaveLength(1)
+        expect(rows[0]?.status).toBe('pending')
+        expect(rows[0]?.workspaceId).toBe(workspace.id)
+      })
+    ))
+
+  it('answers hasPermission from the starter statement set', () =>
+    run(
+      Effect.gen(function* () {
+        const { headers } = yield* signUpSession('owner@perm.test')
+        const auth = yield* Auth.Tag
+
+        const workspace = yield* auth.api.createOrganization({
+          body: { name: 'Perm Co', slug: 'perm-co' },
+          headers
+        })
+        // `apiToken` is a starter resource. The plugin's own statement set has
+        // no such resource, so a true answer can only come from packages/authz.
+        const result = yield* auth.api.hasPermission({
+          body: {
+            organizationId: workspace.id,
+            permissions: { apiToken: ['create'] }
+          },
+          headers
+        })
+
+        expect(result.success).toBe(true)
+      })
+    ))
+
+  // The two below guard configuration that is correct today; they exist to fail
+  // if it is changed, not because they drove it.
+
+  it('keeps the plugin default statements working under the starter roles', () =>
+    run(
+      Effect.gen(function* () {
+        const owner = yield* signUpSession('owner@roles.test')
+        const member = yield* signUpSession('member@roles.test')
+        const auth = yield* Auth.Tag
+
+        const workspace = yield* auth.api.createOrganization({
+          body: { name: 'Roles Co', slug: 'roles-co' },
+          headers: owner.headers
+        })
+        yield* auth.api.addMember({
+          body: {
+            userId: member.userId,
+            organizationId: workspace.id,
+            role: 'member'
+          }
+        })
+
+        const ownerUpdates = yield* auth.api.hasPermission({
+          body: {
+            organizationId: workspace.id,
+            permissions: { organization: ['update'] }
+          },
+          headers: owner.headers
+        })
+        const memberUpdates = yield* auth.api.hasPermission({
+          body: {
+            organizationId: workspace.id,
+            permissions: { organization: ['update'] }
+          },
+          headers: member.headers
+        })
+        const memberReadsModules = yield* auth.api.hasPermission({
+          body: {
+            organizationId: workspace.id,
+            permissions: { module: ['read'] }
+          },
+          headers: member.headers
+        })
+
+        // `organization:update` is the plugin's own statement — a custom role
+        // table that dropped it would break the plugin's endpoints, not just a
+        // starter permission. `module:read` is the starter's, and only
+        // `memberRole` grants it. Together they prove the two sets merged
+        // rather than one replacing the other.
+        expect(ownerUpdates.success).toBe(true)
+        expect(memberUpdates.success).toBe(false)
+        expect(memberReadsModules.success).toBe(true)
+      })
+    ))
+
+  it('exposes no team endpoints', () =>
+    run(
+      Effect.gen(function* () {
+        const auth = yield* Auth.Tag
+        // Read from `instance`, not the effectful `api`: the latter is a Proxy
+        // that answers every property, so it can never disprove one.
+        const endpoints = Object.keys(auth.instance.api)
+
+        expect(endpoints).toContain('createOrganization')
+        expect(endpoints).not.toContain('createTeam')
+        expect(endpoints).not.toContain('setActiveTeam')
+      })
+    ))
+})


### PR DESCRIPTION
## What

This PR turns on the Better Auth organization plugin and points it at the workspace tables that already exist in the schema.

- The plugin's organization, member, and invitation models now map to `workspaces`, `workspaceMembers`, and `workspaceInvitations`. The starter keeps its own word, `workspace`; the plugin does not change that.
- The plugin uses the same access-control statements and role table as `requirePermission`. One set of rules, shared everywhere. The plugin's own checks and the starter's guard can never give different answers.
- Teams stay off. The schema has no team tables, so this avoids two extra tables and a required `activeTeamId` field the starter does not use.
- `planId` and `updatedAt` are added as extra fields on the organization model, since the plugin does not know about either column on its own.
- `Session` still does not carry an active workspace. The app keeps reading the active workspace from the URL slug, not from the plugin's `activeOrganizationId`.

## Checklist

- [x] `bun run check` and `bun run build` pass locally
- [x] Tests added or updated for behavioural changes
- [ ] Storybook stories added or updated for UI changes
- [ ] [CONTEXT.md](../CONTEXT.md) updated if new domain language was introduced
- [ ] ADR added under [docs/adr](../docs/adr) if this is an architectural decision

## Notes for reviewers

- No UI changed, so no Storybook stories were needed.
- No new domain word was introduced. `workspace` already existed; this PR only connects it to the plugin.
- This wiring is a meaningful architecture choice (one shared permission model between Better Auth and the starter's own guard). Flag if you want an ADR added under `docs/adr` before merge.
- `packages/auth/src/live-auth.test.ts` runs the plugin against a real local D1 instance (workerd), not against mocked options. This is the only way to prove the model remapping, the extra fields, and the merged permission set actually resolve to real tables and real answers.
- Teams and `dynamicAccessControl` are intentionally left off. Turning either on later needs new tables that do not exist yet.