### PR TITLE
test(capabilities): cover binding-failure classification and live layer selection

### DIFF
--- a/packages/capabilities/src/live-layers.test.ts
+++ b/packages/capabilities/src/live-layers.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from 'effect'
+import { Context, Effect, Layer } from 'effect'
 import { describe, expect, layer } from '@effect/vitest'
 import { count, eq } from 'drizzle-orm'
 import {
@@ -42,6 +42,11 @@ import {
   LiveCatalogRefreshHistory
 } from './catalog/catalog-refresh-history.ts'
 import { makeLiveCapabilitiesLayer, type CapabilityServices } from './layers.ts'
+import {
+  selectCapabilitiesLayer,
+  selectWorkspaceLayer,
+  type StarterEnv
+} from './runtime.ts'
 import { liveWorkspaceContext, WorkspaceContext } from './workspace-context.ts'
 import {
   CapabilityUnavailable,
@@ -134,6 +139,16 @@ const insertFixtureRows = Effect.gen(function* () {
  * The provisioned D1 is this file's fixture: acquired once and released when
  * the test layer's scope closes, so no test lifecycle hooks are needed.
  */
+/**
+ * The raw D1 binding behind `TestDatabase`. Every suite but one is handed a
+ * ready-made `Database`; the `StarterEnv` suite is not — it exercises the
+ * selection that *builds* that layer, so it needs the binding an app would put
+ * on `StarterEnv.DB`.
+ */
+class TestD1 extends Context.Service<TestD1, NonNullable<StarterEnv['DB']>>()(
+  '@b2b-saas-starter/capabilities/test/TestD1'
+) {}
+
 const TestDatabase = Layer.unwrap(
   Effect.gen(function* () {
     const provisioned = yield* Effect.acquireRelease(
@@ -142,7 +157,7 @@ const TestDatabase = Layer.unwrap(
     )
     const database = layerFromD1(provisioned.d1)
     yield* insertFixtureRows.pipe(Effect.provide(database))
-    return database
+    return Layer.merge(database, Layer.succeed(TestD1)(provisioned.d1))
   })
 )
 
@@ -757,6 +772,219 @@ layer(TestDatabase, { timeout: '120 seconds' })('live capability layers', (it) =
         expect(error instanceof CapabilityUnavailable && error.reason).toBe(
           'no_invitation_binding'
         )
+      })
+    )
+  })
+
+  // Decision 23: a rejected binding call is classified by its HTTP status.
+  // Nothing above reaches this code — every rejection those suites produce is
+  // raised by the capability itself, before the binding is ever called — so the
+  // classifier that separates "the workspace refuses" (409, do not retry) from
+  // "the store is unreachable" (503, retry) is exercised only here.
+  describe('live binding failure classification', () => {
+    /**
+     * The plugin rejects with its own `APIError`: an `Error` carrying a numeric
+     * `statusCode`. Built by hand rather than imported, because `capabilities`
+     * never names Better Auth — the port is structural and so is its failure.
+     */
+    function pluginRejection(statusCode: number, message: string) {
+      return Object.assign(new Error(message), { statusCode })
+    }
+
+    /** A member binding whose every endpoint rejects with the same cause. */
+    function rejectingMemberBinding(cause: unknown): WorkspaceMemberBinding {
+      function reject() {
+        return Promise.reject(cause)
+      }
+      return { addMember: reject, removeMember: reject, changeRole: reject }
+    }
+
+    it.effect('reads a 4xx rejection as a refusal the caller must not retry', () =>
+      Effect.gen(function* () {
+        const error = yield* inWorkspace(
+          'live-lab',
+          Effect.gen(function* () {
+            const membership = yield* WorkspaceMembership
+            return yield* Effect.flip(
+              membership.addMember({ userId: 'usr_joiner', role: 'member' })
+            )
+          }),
+          { userId: 'usr_owner' },
+          {
+            memberBinding: rejectingMemberBinding(
+              pluginRejection(403, 'user is already a member')
+            )
+          }
+        )
+
+        expect(error).toBeInstanceOf(MembershipChangeRejected)
+        expect(error.reason).toBe('user is already a member')
+      })
+    )
+
+    it.effect('reads a 5xx rejection as the store failing, not a refusal', () =>
+      Effect.gen(function* () {
+        const error = yield* inWorkspace(
+          'live-lab',
+          Effect.gen(function* () {
+            const membership = yield* WorkspaceMembership
+            return yield* Effect.flip(
+              membership.addMember({ userId: 'usr_joiner', role: 'member' })
+            )
+          }),
+          { userId: 'usr_owner' },
+          {
+            memberBinding: rejectingMemberBinding(
+              pluginRejection(502, 'upstream unavailable')
+            )
+          }
+        )
+
+        // 503, so the caller retries. A 409 here would tell them to give up on
+        // a change that would have succeeded a moment later.
+        expect(error).toBeInstanceOf(CapabilityUnavailable)
+        expect(error instanceof CapabilityUnavailable && error.capability).toBe(
+          'workspace-membership'
+        )
+        expect(error.reason).toBe('upstream unavailable')
+      })
+    )
+
+    it.effect('reads a rejection carrying no status as the store failing', () =>
+      Effect.gen(function* () {
+        const error = yield* inWorkspace(
+          'live-lab',
+          Effect.gen(function* () {
+            const membership = yield* WorkspaceMembership
+            return yield* Effect.flip(
+              membership.addMember({ userId: 'usr_joiner', role: 'member' })
+            )
+          }),
+          { userId: 'usr_owner' },
+          {
+            memberBinding: rejectingMemberBinding(new TypeError('fetch failed'))
+          }
+        )
+
+        // A dropped connection or a thrown TypeError from the adapter itself.
+        // Nothing said the workspace refused, so the classifier must not decide
+        // it did.
+        expect(error).toBeInstanceOf(CapabilityUnavailable)
+        expect(error.reason).toBe('fetch failed')
+      })
+    )
+
+    /** The invitation port's counterpart, rejecting the same way. */
+    function rejectingInvitationBinding(cause: unknown): WorkspaceInvitationBinding {
+      function reject() {
+        return Promise.reject(cause)
+      }
+      return { create: reject, cancel: reject, accept: reject }
+    }
+
+    // `workspace-invitations.ts` carries its own copy of `classifyBindingFailure`
+    // — same rule, different capability name — so the invitation port needs its
+    // own cases rather than inheriting the ones above.
+    it.effect('applies the same rule to a refused invitation', () =>
+      Effect.gen(function* () {
+        const error = yield* inWorkspace(
+          'live-lab',
+          Effect.gen(function* () {
+            const invitations = yield* WorkspaceInvitations
+            return yield* Effect.flip(
+              invitations.create({ email: 'refused@live-invite.test', role: 'member' })
+            )
+          }),
+          { userId: 'usr_owner' },
+          {
+            invitationBinding: rejectingInvitationBinding(
+              pluginRejection(400, 'already invited')
+            )
+          }
+        )
+
+        expect(error).toBeInstanceOf(MembershipChangeRejected)
+        expect(error.reason).toBe('already invited')
+      })
+    )
+
+    it.effect('names its own capability when the invitation store fails', () =>
+      Effect.gen(function* () {
+        const error = yield* inWorkspace(
+          'live-lab',
+          Effect.gen(function* () {
+            const invitations = yield* WorkspaceInvitations
+            return yield* Effect.flip(
+              invitations.create({
+                email: 'unreachable@live-invite.test',
+                role: 'member'
+              })
+            )
+          }),
+          { userId: 'usr_owner' },
+          {
+            invitationBinding: rejectingInvitationBinding(
+              pluginRejection(500, 'invitation store down')
+            )
+          }
+        )
+
+        expect(error).toBeInstanceOf(CapabilityUnavailable)
+        expect(error instanceof CapabilityUnavailable && error.capability).toBe(
+          'workspace-invitations'
+        )
+      })
+    )
+  })
+
+  // Decision 25: an app hands its plugin bindings to these selectors per call,
+  // not on a module-level env, because `apps/web/src/lib/capabilities.ts` is
+  // bundled for the browser as well as the worker. Every other suite in this
+  // file is handed a layer already built — these two exercise the selection an
+  // app actually makes, and so are the only cases that prove a binding put on
+  // `StarterEnv` reaches the capability at all.
+  describe('live layer selection from StarterEnv', () => {
+    it.effect('carries the invitation binding into the workspace layer', () =>
+      Effect.gen(function* () {
+        const db = yield* Database
+        const d1 = yield* TestD1
+        const { binding, calls } = fakeInvitationBinding(db)
+
+        const created = yield* Effect.provide(
+          Effect.flatMap(WorkspaceInvitations, (invitations) =>
+            invitations.create({ email: 'selected@live-invite.test', role: 'member' })
+          ),
+          selectWorkspaceLayer({ DB: d1, invitationBinding: binding }, 'live-lab', {
+            userId: 'usr_owner'
+          })
+        )
+
+        expect(created.email).toBe('selected@live-invite.test')
+        // The workspace id comes from the slug the selector resolved, so this
+        // also proves the live `WorkspaceContext` was the one selected.
+        expect(calls).toEqual([
+          {
+            workspaceId: 'wrk_live',
+            email: 'selected@live-invite.test',
+            role: 'member'
+          }
+        ])
+      })
+    )
+
+    it.effect('selects the live layer for an identity-keyed read', () =>
+      Effect.gen(function* () {
+        const d1 = yield* TestD1
+        const memberships = yield* Effect.provide(
+          Effect.flatMap(WorkspaceMembership, (membership) =>
+            membership.listWorkspacesForUser('usr_owner')
+          ),
+          selectCapabilitiesLayer({ DB: d1 })
+        )
+
+        // `live-lab` exists only in D1. Had the selector fallen to the Seed
+        // branch this would be empty, because no fixture member is `usr_owner`.
+        expect(memberships.map((each) => each.workspace.slug)).toContain('live-lab')
       })
     )
   })

--- a/packages/capabilities/vitest.config.ts
+++ b/packages/capabilities/vitest.config.ts
@@ -10,10 +10,10 @@ export default defineConfig({
       // Ratchet, not target: set just below current coverage so CI fails on
       // decay. Raise alongside new tests; never lower to make a build pass.
       thresholds: {
-        lines: 75,
-        statements: 75,
-        functions: 65,
-        branches: 60
+        lines: 86,
+        statements: 85,
+        functions: 82,
+        branches: 74
       }
     }
   }


### PR DESCRIPTION
Ticket 07 of [the workspace membership map](https://github.com/brandhaug/b2b-saas-starter/issues/50). Closes #57.

Two paths this map built were never exercised by a test.

## Binding-failure classification — decision 23

`readPluginBindingFailure` sat at **20% statements, 0% branches**. It owns the rule that separates "the workspace refuses" (409, do not retry) from "the store is unreachable" (503, retry). Getting it backwards tells a caller to retry a request that can never succeed.

Nothing reached it. Every rejection the existing suites produce is raised by the capability *before* the binding is called — `resolveMemberId` fails `not_a_member`, or no binding is configured at all. A binding that actually rejects had never been driven through.

Four cases, at the capability's public interface with a rejecting stub binding:

| Rejection | Becomes |
|---|---|
| `statusCode: 403` | `MembershipChangeRejected` |
| `statusCode: 502` | `CapabilityUnavailable` (`workspace-membership`) |
| `TypeError`, no status | `CapabilityUnavailable` |
| `statusCode: 400` on the invitation port | `MembershipChangeRejected` |
| `statusCode: 500` on the invitation port | `CapabilityUnavailable` (`workspace-invitations`) |

`workspace-membership.ts` and `workspace-invitations.ts` each carry their own copy of `classifyBindingFailure`, so the invitation port gets its own cases rather than inheriting the membership ones. Breaking either copy fails a test.

## Live layer selection — decision 25

`runtime.ts` sat at **33%**. Nothing proved a binding placed on `StarterEnv` reaches the capability, which is the whole mechanism decision 25 settled: the app passes an adapter per call because `apps/web/src/lib/capabilities.ts` is bundled for the browser too.

Every other suite in `live-layers.test.ts` is handed a layer already built. Two new cases exercise the selection an app actually makes — `selectWorkspaceLayer` carrying an invitation binding through to a real D1 write, and `selectCapabilitiesLayer` on an identity-keyed read that would come back empty had the Seed branch been chosen.

The test harness now exposes the raw D1 behind `TestDatabase`, because these selectors build the `Database` layer themselves rather than accepting one.

## Coverage

| | Before | After |
|---|---|---|
| `plugin-binding-failure.ts` stmts / branches | 20% / 0% | 90% / 83% |
| `runtime.ts` statements | 33% | 89% |
| package lines | 83.84% | 86.38% |

Ratchet raised from 75/75/65/60 to **86/85/82/74**, set just under the new measured numbers.

## Verification

`turbo test typecheck build` — 41/41 green, uncached. `oxlint --type-aware` and `oxfmt --check` clean.

Every new test was proven red before being kept: the classifier, its status range, the no-status branch, the invitation copy, and both selectors were each broken in turn and the matching test failed.

Seed-backed tests are untouched and still need no D1 — capabilities invariant 4.