### PR TITLE
ci: auto-merge catalog dependency PRs behind required checks

### DIFF
--- a/.catalog-updaterc.json
+++ b/.catalog-updaterc.json
@@ -4,6 +4,8 @@
   "maxOpenPrs": 20,
   "concurrency": 10,
   "packageManager": "bun",
+  "minReleaseAgeDays": 3,
+  "autoMerge": { "enabled": true, "mergeMethod": "squash" },
   "groups": [
     { "name": "react", "patterns": ["react", "react-dom"] },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     branches: [master]
   workflow_dispatch:
 
+# Untrusted PR dependencies run in these jobs, so the default write token
+# would be theirs too. Only checkout needs the token, and only to read.
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Makes the daily `catalog-update` dependency PRs merge themselves once CI passes, and requires `ci` and `e2e` to pass on every PR into `master`.

Two commits:

1. **`ci(catalog)`** — turns on `autoMerge` in `.catalog-updaterc.json`, using the option added in `catalog-update-action@0.11.0`. Also sets `minReleaseAgeDays: 3`.
2. **`ci`** — narrows the CI workflow to `permissions: contents: read`.

Repository settings changed outside this diff, since they cannot live in the repo:

- **Allow auto-merge** turned on. It was off, so arming auto-merge would have failed.
- New ruleset **"master: require CI and e2e"**, requiring the `ci` and `e2e` check runs from GitHub Actions. No bypass actors.

## Why the action arms auto-merge, not a workflow here

The obvious approach is a `pull_request` workflow in this repo that calls `gh pr merge --auto` when the head branch starts with `catalog-update`. I wrote that first, then threw it away.

That gate is a branch name, which is not an authenticated signal. Anyone with push access can open a PR named `catalog-update/x` carrying arbitrary code and have it merge with no review once checks pass. Gating on the author does not help either, because the workflow creates PRs with `secrets.CI_PAT`, so their author is a human account.

[catalog-update-action#8](https://github.com/brandhaug/catalog-update-action/pull/8) moves the work into the action, which arms auto-merge on PRs it just created. Identity instead of a name.

## Notes for reviewers

**On the ruleset.** `strict_required_status_checks_policy` is off, so branches do not need to be up to date with `master`. With it on, every merge would make the other open catalog PRs stale and stall them.

Required status checks also apply to direct pushes to `master`, so those are now rejected and everything goes through a PR. That is broader than "require checks on PRs", so worth a conscious nod.

**On what auto-merge exposes.** Dependency changes now reach `master` with no human read. What limits the blast radius:

- `minReleaseAgeDays: 3` keeps same-day releases out, which is the window a compromised package depends on.
- `bun audit --audit-level=high` still runs in `ci`, though it only catches *known* advisories.
- Bun does not run lifecycle scripts without `trustedDependencies`.
- `deploy` is `workflow_dispatch`-only, so nothing reaches production on its own.
- PRs carrying non-bot commits are skipped by the action, so pushing to a catalog branch yourself takes it out of auto-merge handling.

One residual hole, unchanged by this PR and worth knowing: for `pull_request`, the workflow that runs is the one in the PR. A PR can hollow out `ci.yml` and still report `ci` and `e2e` as green. Deleting a job does not work, since a missing required check blocks the merge. This needs push access, so today it means you.

**Not done.** No ADR. Say if you want one; this felt like a settings change rather than an architectural decision.

## Checklist

- [x] `bun run check` and `bun run build` pass locally
- [ ] Tests added or updated for behavioural changes — n/a, no application code
- [ ] Storybook stories added or updated for UI changes — n/a
- [ ] [CONTEXT.md](../CONTEXT.md) updated if new domain language was introduced — n/a
- [ ] ADR added under [docs/adr](../docs/adr) if this is an architectural decision — see above