### PR TITLE
chore(deps): upgrade Bun to 1.4.0 across the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A starter repository for shipping a B2B SaaS on Cloudflare's platform without ma
 
 ## Quick Start
 
-Requires [Bun](https://bun.sh) >= 1.3.3.
+Requires [Bun](https://bun.sh) >= 1.4.0.
 
 ```bash
 bun install

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -322,9 +322,15 @@
     "brace-expansion": "5.0.9",
     "fast-uri": "3.1.5",
     "hono": "4.12.27",
-    "hono@<4.12.34": "4.12.34",
-    "hono@>=3.8.0 <4.12.34": "4.12.34",
-    "hono@>=4.12.0 <4.12.34": "4.12.34",
+    "hono@<4.12.34": {
+      ".": "4.12.34",
+    },
+    "hono@>=3.8.0 <4.12.34": {
+      ".": "4.12.34",
+    },
+    "hono@>=4.12.0 <4.12.34": {
+      ".": "4.12.34",
+    },
     "ip-address": "10.5.0",
     "js-yaml": "4.3.1",
     "nanoid": "3.3.18",
@@ -384,7 +390,7 @@
     "alchemy": "2.0.0-beta.40",
     "babel-plugin-react-compiler": "1.0.0",
     "better-auth": "1.6.29",
-    "bun-types": "1.3.14",
+    "bun-types": "1.4.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
@@ -1720,7 +1726,7 @@
 
     "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -2176,7 +2182,7 @@
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
-    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+    "hono": ["hono@4.12.34", "", {}, "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,7 +2,7 @@
 
 ## Local development
 
-Requires [Bun](https://bun.sh) >= 1.3.3.
+Requires [Bun](https://bun.sh) >= 1.4.0.
 
 ```bash
 git clone git@github.com:brandhaug/b2b-saas-starter.git

--- a/package.json
+++ b/package.json
@@ -96,9 +96,9 @@
     "ws": "8.21.0"
   },
   "engines": {
-    "bun": ">=1.3.14"
+    "bun": ">=1.4.0"
   },
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "catalog": {
     "@base-ui/react": "1.7.0",
     "@cloudflare/vite-plugin": "1.52.1",
@@ -147,7 +147,7 @@
     "alchemy": "2.0.0-beta.40",
     "babel-plugin-react-compiler": "1.0.0",
     "better-auth": "1.6.29",
-    "bun-types": "1.3.14",
+    "bun-types": "1.4.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",


### PR DESCRIPTION
## Summary

- Bump `packageManager` pin from `bun@1.3.14` to `bun@1.4.0` — this also drives CI, which installs Bun via `bun-version-file: package.json` in `.github/actions/setup`
- Raise `engines.bun` requirement to `>=1.4.0`
- Bump `bun-types` catalog entry from `1.3.14` to `1.4.0`
- Update the documented Bun requirement (`>= 1.4.0`) in `README.md` and `docs/setup.md`

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes
- [x] `bun run build` passes