### PR TITLE
feat(audit): system_admin producers for Better Auth admin endpoints

### DIFF
--- a/apps/web/src/lib/server/auth-audit.test.ts
+++ b/apps/web/src/lib/server/auth-audit.test.ts
@@ -1,9 +1,12 @@
 import { Effect } from 'effect'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  adminAuditInput,
   authAuditInput,
+  isAdminAuthExchange,
   isAuditedAuthExchange,
   recordAuthAudit,
+  type AdminAuditContext,
   type AuthAuditOutcome,
   type RunAuditCapabilities
 } from './auth-audit'
@@ -291,5 +294,237 @@ describe('recordAuthAudit', () => {
       status: 200
     })
     await expect(runRecordAuthAudit(request, response)).resolves.toBe('dropped')
+  })
+
+  it('skips admin paths when no admin context was gathered', async () => {
+    const request = new Request('http://localhost/api/auth/admin/set-role', {
+      method: 'POST'
+    })
+    const response = new Response(JSON.stringify({ user: { id: 'usr_dev' } }), {
+      status: 200
+    })
+    const clone = vi.spyOn(response, 'clone')
+    await expect(runRecordAuthAudit(request, response)).resolves.toBe('skipped')
+    expect(clone).not.toHaveBeenCalled()
+  })
+})
+
+describe('isAdminAuthExchange', () => {
+  it('accepts the audited admin mutations', () => {
+    for (const suffix of [
+      '/admin/set-role',
+      '/admin/ban-user',
+      '/admin/unban-user',
+      '/admin/create-user',
+      '/admin/remove-user',
+      '/admin/set-user-password',
+      '/admin/impersonate-user',
+      '/admin/stop-impersonating',
+      '/admin/revoke-user-session',
+      '/admin/revoke-user-sessions'
+    ]) {
+      expect(
+        isAdminAuthExchange({ method: 'POST', pathname: `/api/auth${suffix}` })
+      ).toBe(true)
+    }
+  })
+
+  it('rejects reads and non-admin auth traffic', () => {
+    expect(
+      isAdminAuthExchange({ method: 'GET', pathname: '/api/auth/admin/list-users' })
+    ).toBe(false)
+    expect(
+      isAdminAuthExchange({ method: 'POST', pathname: '/api/auth/sign-in/email' })
+    ).toBe(false)
+    expect(
+      isAdminAuthExchange({ method: 'POST', pathname: '/api/auth/admin/list-users' })
+    ).toBe(false)
+  })
+})
+
+describe('adminAuditInput', () => {
+  const pathname = '/api/auth/admin/set-role'
+
+  it('maps a successful role change to an attributed system_admin event', () => {
+    expect(
+      adminAuditInput({
+        pathname,
+        status: 200,
+        actorUserId: 'usr_martin',
+        targetUserId: 'usr_dev'
+      })
+    ).toEqual({
+      workspaceId: null,
+      actorUserId: 'usr_martin',
+      eventType: 'system_admin.user_role_changed',
+      targetType: 'user',
+      targetId: 'usr_dev',
+      metadata: { statusCode: 200 }
+    })
+  })
+
+  it('keeps the actor on failure — the session predates the judgment', () => {
+    const input = adminAuditInput({
+      pathname,
+      status: 400,
+      actorUserId: 'usr_martin',
+      targetUserId: 'usr_dev'
+    })
+    expect(input?.eventType).toBe('system_admin.user_role_change_failed')
+    expect(input?.actorUserId).toBe('usr_martin')
+  })
+
+  it('covers the full success/failure pair per endpoint from one table', () => {
+    const pairs: ReadonlyArray<readonly [string, string, string]> = [
+      [
+        '/api/auth/admin/create-user',
+        'system_admin.user_created',
+        'system_admin.user_creation_failed'
+      ],
+      [
+        '/api/auth/admin/remove-user',
+        'system_admin.user_removed',
+        'system_admin.user_removal_failed'
+      ],
+      [
+        '/api/auth/admin/ban-user',
+        'system_admin.user_banned',
+        'system_admin.user_ban_failed'
+      ],
+      [
+        '/api/auth/admin/unban-user',
+        'system_admin.user_unbanned',
+        'system_admin.user_unban_failed'
+      ],
+      [
+        '/api/auth/admin/set-user-password',
+        'system_admin.user_password_set',
+        'system_admin.user_password_set_failed'
+      ],
+      [
+        '/api/auth/admin/impersonate-user',
+        'system_admin.impersonation_started',
+        'system_admin.impersonation_start_failed'
+      ],
+      [
+        '/api/auth/admin/stop-impersonating',
+        'system_admin.impersonation_stopped',
+        'system_admin.impersonation_stop_failed'
+      ],
+      [
+        '/api/auth/admin/revoke-user-sessions',
+        'system_admin.user_session_revoked',
+        'system_admin.user_session_revocation_failed'
+      ]
+    ]
+    for (const [path, success, failure] of pairs) {
+      expect(
+        adminAuditInput({
+          pathname: path,
+          status: 200,
+          actorUserId: 'a',
+          targetUserId: null
+        })?.eventType
+      ).toBe(success)
+      expect(
+        adminAuditInput({
+          pathname: path,
+          status: 500,
+          actorUserId: 'a',
+          targetUserId: null
+        })?.eventType
+      ).toBe(failure)
+    }
+  })
+
+  it('targets an unknown user for stop-impersonating (no id in its request)', () => {
+    const input = adminAuditInput({
+      pathname: '/api/auth/admin/stop-impersonating',
+      status: 200,
+      actorUserId: 'usr_martin',
+      targetUserId: null
+    })
+    expect(input?.targetType).toBe('user')
+    expect(input?.targetId).toBeNull()
+  })
+
+  it('ignores non-admin traffic', () => {
+    expect(
+      adminAuditInput({
+        pathname: '/api/auth/sign-in/email',
+        status: 200,
+        actorUserId: 'usr_martin',
+        targetUserId: 'usr_dev'
+      })
+    ).toBeNull()
+  })
+})
+
+describe('recordAuthAudit with an admin context', () => {
+  function runAdminAudit(
+    request: Request,
+    response: Response,
+    admin: AdminAuditContext
+  ): Promise<AuthAuditOutcome> {
+    return Effect.runPromise(
+      Effect.scoped(recordAuthAudit(request, response, runCapabilities, admin))
+    )
+  }
+
+  it('records a role change attributed to the acting admin, target from the body', async () => {
+    const request = new Request('http://localhost/api/auth/admin/set-role', {
+      method: 'POST',
+      body: JSON.stringify({ userId: 'usr_dev', role: 'admin' }),
+      headers: { 'content-type': 'application/json' }
+    })
+    const response = new Response(JSON.stringify({ user: { id: 'usr_dev' } }), {
+      status: 200
+    })
+    await expect(
+      runAdminAudit(request, response, {
+        actorUserId: 'usr_martin',
+        request: request.clone()
+      })
+    ).resolves.toBe('recorded')
+    expect(runCapabilities).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the response body for create-user, whose request names no user', async () => {
+    const request = new Request('http://localhost/api/auth/admin/create-user', {
+      method: 'POST'
+    })
+    const response = new Response(JSON.stringify({ user: { id: 'usr_new' } }), {
+      status: 201
+    })
+    await expect(
+      runAdminAudit(request, response, { actorUserId: 'usr_martin' })
+    ).resolves.toBe('recorded')
+  })
+
+  it('records a rejected admin mutation with the failure event', async () => {
+    const request = new Request('http://localhost/api/auth/admin/ban-user', {
+      method: 'POST'
+    })
+    const response = new Response(JSON.stringify({ message: 'nope' }), { status: 403 })
+    await expect(
+      runAdminAudit(request, response, {
+        actorUserId: 'usr_martin',
+        request: request.clone()
+      })
+    ).resolves.toBe('recorded')
+  })
+
+  it('reports a dropped admin write instead of throwing', async () => {
+    runCapabilities.mockRejectedValueOnce(new Error('d1 down'))
+    const request = new Request('http://localhost/api/auth/admin/unban-user', {
+      method: 'POST'
+    })
+    const response = new Response('{}', { status: 200 })
+    await expect(
+      runAdminAudit(request, response, {
+        actorUserId: 'usr_martin',
+        request: request.clone()
+      })
+    ).resolves.toBe('dropped')
   })
 })

--- a/apps/web/src/lib/server/auth-audit.ts
+++ b/apps/web/src/lib/server/auth-audit.ts
@@ -1,6 +1,7 @@
 import { Effect, Result, Schema, type Scope } from 'effect'
 import {
   AuditEventLog,
+  type AuditEventType,
   type CapabilityUnavailable,
   type RecordAuditEventInput
 } from '@b2b-saas-starter/capabilities'
@@ -118,7 +119,7 @@ function locationCarriesError(location: string | null): boolean {
 function authExchangeEventType(
   kind: AuthExchangeKind,
   success: boolean
-): string | null {
+): AuditEventType | null {
   switch (kind) {
     case 'sign_in': {
       return success ? 'auth.sign_in' : 'auth.sign_in_failed'
@@ -138,6 +139,150 @@ function authExchangeEventType(
     case 'email_verified': {
       return success ? 'auth.email_verified' : 'auth.email_verification_failed'
     }
+  }
+}
+
+/**
+ * The Better Auth admin endpoints the auth catchall audits, as a path→event
+ * table: one row per mutation endpoint, naming its success/failure event pair
+ * from the `system_admin.` taxonomy namespace. This is the shared mapper — the
+ * account-lifecycle table above and this one are both plain data, so adding a
+ * producer (the remaining auth surface) is a row here, not a new predicate.
+ *
+ * All of these are system-level: no workspace scope, target is the user the
+ * endpoint acts on (`targetId` parsed from the request body or response).
+ */
+const ADMIN_EXCHANGE_EVENTS: ReadonlyArray<{
+  readonly suffix: string
+  readonly success: AuditEventType
+  readonly failure: AuditEventType
+  /** Whether the endpoint's 2xx response carries the acted-on user as `{ user: { id } }` (create-user's body has no id to parse). */
+  readonly namesUserInResponse?: boolean
+}> = [
+  {
+    suffix: '/admin/create-user',
+    success: 'system_admin.user_created',
+    failure: 'system_admin.user_creation_failed',
+    namesUserInResponse: true
+  },
+  {
+    suffix: '/admin/remove-user',
+    success: 'system_admin.user_removed',
+    failure: 'system_admin.user_removal_failed'
+  },
+  {
+    suffix: '/admin/set-role',
+    success: 'system_admin.user_role_changed',
+    failure: 'system_admin.user_role_change_failed'
+  },
+  {
+    suffix: '/admin/ban-user',
+    success: 'system_admin.user_banned',
+    failure: 'system_admin.user_ban_failed'
+  },
+  {
+    suffix: '/admin/unban-user',
+    success: 'system_admin.user_unbanned',
+    failure: 'system_admin.user_unban_failed'
+  },
+  {
+    suffix: '/admin/set-user-password',
+    success: 'system_admin.user_password_set',
+    failure: 'system_admin.user_password_set_failed'
+  },
+  {
+    suffix: '/admin/impersonate-user',
+    success: 'system_admin.impersonation_started',
+    failure: 'system_admin.impersonation_start_failed'
+  },
+  // Stop-impersonating resolves the impersonated user from the session server
+  // side; its request names nobody, so the event targets an unknown user.
+  {
+    suffix: '/admin/stop-impersonating',
+    success: 'system_admin.impersonation_stopped',
+    failure: 'system_admin.impersonation_stop_failed'
+  },
+  {
+    suffix: '/admin/revoke-user-session',
+    success: 'system_admin.user_session_revoked',
+    failure: 'system_admin.user_session_revocation_failed'
+  },
+  {
+    suffix: '/admin/revoke-user-sessions',
+    success: 'system_admin.user_session_revoked',
+    failure: 'system_admin.user_session_revocation_failed'
+  }
+]
+
+/** Whether an auth catchall exchange is one of the audited admin mutations. */
+export function isAdminAuthExchange(exchange: {
+  readonly method: string
+  readonly pathname: string
+}): boolean {
+  return (
+    exchange.method === 'POST' &&
+    ADMIN_EXCHANGE_EVENTS.some((row) => exchange.pathname.endsWith(row.suffix))
+  )
+}
+
+function adminExchangeRow(pathname: string) {
+  return ADMIN_EXCHANGE_EVENTS.find((row) => pathname.endsWith(row.suffix)) ?? null
+}
+
+/**
+ * The request-body fields of admin endpoints this audit path reads.
+ */
+const AdminRequestBody = Schema.Struct({
+  userId: Schema.optionalKey(Schema.String)
+})
+
+const decodeAdminRequestBody = Schema.decodeUnknownSync(AdminRequestBody)
+
+/**
+ * Reads the acted-on user id off an admin request body. Mirrors
+ * `readActorUserId`: the body is an untrusted boundary value, decoded rather
+ * than asserted.
+ */
+function readTargetUserId(request: {
+  readonly json: <T>() => Promise<T>
+}): Effect.Effect<string | null, AuthAuditBodyUnreadable> {
+  return Effect.tryPromise({
+    try: async () => {
+      const body = decodeAdminRequestBody(await request.json())
+      return body.userId ?? null
+    },
+    catch: (cause) =>
+      new AuthAuditBodyUnreadable({
+        reason: causeMessage(cause, BODY_UNREADABLE_REASON)
+      })
+  })
+}
+
+/**
+ * Pure mapping for an audited admin exchange. The actor is always the acting
+ * system admin (read from the request session before the handler ran); the
+ * target is the user the endpoint acts on. Unlike the account-lifecycle
+ * events — where a failed sign-in has no trustworthy actor — the session was
+ * already resolved before Better Auth judged the request, so failures keep
+ * their actor.
+ */
+export function adminAuditInput(exchange: {
+  readonly pathname: string
+  readonly status: number
+  readonly actorUserId: string | null
+  /** `userId` off the request body, when it carried one. */
+  readonly targetUserId: string | null
+}): RecordAuditEventInput | null {
+  const row = adminExchangeRow(exchange.pathname)
+  if (row === null) return null
+  const success = exchange.status >= 200 && exchange.status < 300
+  return {
+    workspaceId: null,
+    actorUserId: exchange.actorUserId,
+    eventType: success ? row.success : row.failure,
+    targetType: 'user',
+    targetId: exchange.targetUserId,
+    metadata: { statusCode: exchange.status }
   }
 }
 
@@ -216,9 +361,24 @@ function writeAuditEvent(
 }
 
 /**
+ * Everything the admin-endpoint audit needs that only the caller can supply:
+ * the acting system admin's user id, read from the request session BEFORE the
+ * handler ran (admin responses never name their actor), and a clone of the
+ * request — Better Auth consumes the original body.
+ */
+export type AdminAuditContext = {
+  readonly actorUserId: string
+  /** A clone of the request, gathered before the handler consumed the body. Only `json()` is read. */
+  readonly request?: { readonly json: <T>() => Promise<T> }
+}
+
+/**
  * Best-effort audit recording for the auth catchall: it never fails, so a D1
  * hiccup can't fail an auth exchange that Better Auth already answered. Under
  * the Seed layer (no DB binding) `record` is a no-op by design.
+ *
+ * Pass an `AdminAuditContext` to also audit the Better Auth admin mutations
+ * (`POST /api/auth/admin/*`); without one they are skipped.
  *
  * "Best effort" applies to the auth response, not to the failure itself — an
  * audit path must never drop a failure silently. Both failure modes are
@@ -229,11 +389,17 @@ function writeAuditEvent(
 export function recordAuthAudit(
   request: Request,
   response: Response,
-  run: RunAuditCapabilities = runCapabilities
+  run: RunAuditCapabilities = runCapabilities,
+  admin?: AdminAuditContext
 ): Effect.Effect<AuthAuditOutcome, never, Scope.Scope> {
   return Effect.gen(function* () {
     const method = request.method
     const pathname = new URL(request.url).pathname
+
+    if (admin !== undefined && isAdminAuthExchange({ method, pathname })) {
+      return yield* recordAdminAudit({ pathname, response, run, admin })
+    }
+
     const kind = authExchangeKind({ method, pathname })
     if (kind === null) return 'skipped'
 
@@ -272,4 +438,70 @@ export function recordAuthAudit(
     }
     return 'recorded'
   })
+}
+
+/**
+ * The admin half of the catchall audit: same best-effort contract, same
+ * tagged-error annotations, but the actor comes from the caller's session
+ * read (admin responses never name their actor) and the target from the
+ * request body — or, for create-user, from the response it answers with.
+ */
+function recordAdminAudit(args: {
+  readonly pathname: string
+  readonly response: Response
+  readonly run: RunAuditCapabilities
+  readonly admin: AdminAuditContext
+}): Effect.Effect<AuthAuditOutcome, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const { pathname, response, run, admin } = args
+    if (adminExchangeRow(pathname) === null) return 'skipped'
+
+    let targetUserId: string | null = null
+    if (admin.request !== undefined) {
+      const parsed = yield* Effect.result(readTargetUserId(admin.request))
+      if (Result.isFailure(parsed)) {
+        // A request body that does not parse still records an event — just an
+        // untargeted one — with the reason on the wide event.
+        yield* annotateWide({
+          authAuditBodyError: parsed.failure.reason,
+          authAuditBodyErrorTag: parsed.failure._tag
+        })
+      } else {
+        targetUserId = parsed.success
+      }
+    }
+    if (targetUserId === null && response.ok && rowNamesUserInResponse(pathname)) {
+      const actor = yield* Effect.result(readActorUserId(response))
+      if (Result.isFailure(actor)) {
+        yield* annotateWide({
+          authAuditBodyError: actor.failure.reason,
+          authAuditBodyErrorTag: actor.failure._tag
+        })
+      } else {
+        targetUserId = actor.success
+      }
+    }
+
+    const input = adminAuditInput({
+      pathname,
+      status: response.status,
+      actorUserId: admin.actorUserId,
+      targetUserId
+    })
+    if (!input) return 'skipped'
+
+    const written = yield* Effect.result(writeAuditEvent(input, run))
+    if (Result.isFailure(written)) {
+      yield* annotateWide({
+        authAuditError: written.failure.reason,
+        authAuditErrorTag: written.failure._tag
+      })
+      return 'dropped'
+    }
+    return 'recorded'
+  })
+}
+
+function rowNamesUserInResponse(pathname: string): boolean {
+  return adminExchangeRow(pathname)?.namesUserInResponse === true
 }

--- a/apps/web/src/routes/api.auth.$.ts
+++ b/apps/web/src/routes/api.auth.$.ts
@@ -8,7 +8,47 @@ import { annotateWide } from '@b2b-saas-starter/logger'
 import { authRuntime } from '@/lib/auth-runtime'
 import { withWebRequestScope } from '@/lib/observability'
 import { clientKey, makeRateLimiterLayer, RateLimiter } from '@/lib/rate-limit'
-import { recordAuthAudit } from '@/lib/server/auth-audit'
+import { runCapabilities } from '@/lib/capabilities'
+import {
+  isAdminAuthExchange,
+  recordAuthAudit,
+  type AdminAuditContext
+} from '@/lib/server/auth-audit'
+
+/**
+ * Everything the admin-endpoint audit needs, gathered BEFORE the auth handler
+ * consumes the request: the acting system admin's session user id (admin
+ * responses never name their actor) and a clone of the JSON body (`userId`
+ * target). `undefined` for anything that is not an audited admin mutation or
+ * carries no session — anonymous probes are rate-limited noise.
+ */
+async function readAdminAuditContext(
+  request: Request
+): Promise<AdminAuditContext | undefined> {
+  const pathname = new URL(request.url).pathname
+  if (
+    request.method !== 'POST' ||
+    !isAdminAuthExchange({ method: request.method, pathname })
+  ) {
+    return undefined
+  }
+  // The clone is taken before the handler runs — Better Auth consumes the
+  // original request's body. A failed session read must never fail the auth
+  // request it observes.
+  const requestClone = request.clone()
+  const session = await authRuntime
+    .runPromise(
+      withWebRequestScope(
+        { event: 'auth.session' },
+        Effect.flatMap(Auth.Tag, (auth) =>
+          auth.api.getSession({ headers: request.headers })
+        )
+      )
+    )
+    .catch(() => null)
+  if (!session) return undefined
+  return { actorUserId: session.user.id, request: requestClone }
+}
 
 async function handleAuth(request: Request): Promise<Response> {
   const bucket = request.method === 'POST' ? 'auth_write' : 'auth_read'
@@ -33,6 +73,10 @@ async function handleAuth(request: Request): Promise<Response> {
             headers: { 'content-type': 'application/json; charset=utf-8' }
           })
         }
+        // Admin audit context before the handler: it reads the session and a
+        // body clone that Better Auth's consumption of the request would
+        // otherwise make unreadable.
+        const admin = yield* Effect.promise(() => readAdminAuditContext(request))
         // The effectful-better-auth mount: toWeb → auth.handler → fromWeb.
         // The Auth service comes from authRuntime's layer; only the request
         // is provided per call.
@@ -47,7 +91,12 @@ async function handleAuth(request: Request): Promise<Response> {
         // best-effort by contract, so it can't fail the auth response. It
         // annotates its own failure reason onto this wide event; the outcome is
         // added below.
-        const authAudit = yield* recordAuthAudit(request, response)
+        const authAudit = yield* recordAuthAudit(
+          request,
+          response,
+          runCapabilities,
+          admin
+        )
         if (authAudit !== 'skipped') {
           yield* annotateWide({ authAudit })
         }

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.ts
@@ -7,6 +7,7 @@ import {
   webhookEndpoints
 } from '@b2b-saas-starter/db'
 import { AuditEventLog } from '../governance/audit-event-log.ts'
+import { type AuditEventType } from '../governance/audit-event-taxonomy.ts'
 import { type CapabilityUnavailable } from '../errors.ts'
 import { randomHex } from '../internal/crypto.ts'
 import { newCapabilityId } from '../internal/ids.ts'
@@ -64,7 +65,10 @@ export type WebhookDeliveryAttemptInput = {
  * out of the governance log. Naming follows the `auth.sign_in` /
  * `auth.sign_in_failed` convention from the web app's auth audit.
  */
-export const terminalDeliveryAuditEventType = new Map<WebhookDeliveryStatus, string>([
+export const terminalDeliveryAuditEventType = new Map<
+  WebhookDeliveryStatus,
+  AuditEventType
+>([
   ['failed_permanent', 'webhook.delivery_failed'],
   ['dead_lettered', 'webhook.delivery_dead_lettered']
 ])
@@ -246,7 +250,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
       S extends Partial<typeof webhookEndpoints.$inferInsert>
     >(
       input: { readonly endpointId: string; readonly actorUserId?: string },
-      eventType: string,
+      eventType: AuditEventType,
       makeSet: () => S
     ): Effect.Effect<Option.Option<S>, CapabilityUnavailable, WorkspaceContext> {
       return Effect.gen(function* () {

--- a/packages/capabilities/src/governance/audit-event-log.AGENTS.md
+++ b/packages/capabilities/src/governance/audit-event-log.AGENTS.md
@@ -29,7 +29,7 @@ Append-only stream of workspace and system events for compliance, security revie
 - **Workspace admin** — role changes, member invites, member removals, plan changes.
 - **Webhook lifecycle** — endpoint create/update/disable, secret rotation ([`webhook-endpoints`](../developer-platform/webhook-endpoints.AGENTS.md)).
 
-API token lifecycle is wired today — see [`api-token-registry`](../developer-platform/api-token-registry.AGENTS.md). When the producer list grows, consider tightening `eventType`/`targetType` to a tagged union at the capability boundary while keeping the wire shape stringly-typed.
+API token lifecycle is wired today — see [`api-token-registry`](../developer-platform/api-token-registry.AGENTS.md). The event/target vocabulary now lives in [`audit-event-taxonomy`](src/governance/audit-event-taxonomy.ts) and is enforced here at the write boundary; add new producer names to the module first (the read path stays stringly by design).
 
 ## Anti-patterns
 

--- a/packages/capabilities/src/governance/audit-event-log.ts
+++ b/packages/capabilities/src/governance/audit-event-log.ts
@@ -9,6 +9,7 @@ import {
 } from '@b2b-saas-starter/db'
 import { type CapabilityUnavailable } from '../errors.ts'
 import { orUnavailable } from '../internal/unavailable.ts'
+import { type AuditEventType, type AuditTargetType } from './audit-event-taxonomy.ts'
 import { newCapabilityId } from '../internal/ids.ts'
 import { WorkspaceContext } from '../workspace-context.ts'
 
@@ -79,8 +80,12 @@ export type SeedAuditEventRow = AuditEvent & {
 export type RecordAuditEventInput = {
   readonly workspaceId?: string | null
   readonly actorUserId?: string | null
-  readonly eventType: string
-  readonly targetType: string
+  /**
+   * From the taxonomy module — the write boundary is where the vocabulary is
+   * enforced. The read path stays a lenient `Schema.String`.
+   */
+  readonly eventType: AuditEventType
+  readonly targetType: AuditTargetType
   readonly targetId?: string | null
   /**
    * Per-event-type detail (token name + scopes, webhook url + events, delivery

--- a/packages/capabilities/src/governance/audit-event-taxonomy.ts
+++ b/packages/capabilities/src/governance/audit-event-taxonomy.ts
@@ -1,0 +1,97 @@
+/**
+ * The audit event vocabulary (ADR 0025's taxonomy decision): the single source
+ * every producer, the seed fixture, and the capability write boundary import
+ * from.
+ *
+ * Naming is `<namespace>.<past_tense_verb>`, snake_case, with a `_failed`
+ * suffix for the failure half of a success/failure pair. Namespaces follow the
+ * bounded contexts: `auth.` (account lifecycle over the auth catchall),
+ * `api_token.` / `webhook_endpoint.` (developer platform),
+ * `workspace.` / `workspace_member.` / `workspace_invitation.` (governance),
+ * `system_admin.` (Better Auth admin endpoints — system-level, no workspace).
+ *
+ * The unions are enforced at the WRITE boundary (`AuditEventLog.record` /
+ * `prepareRecord` input). The read path stays lenient (`Schema.String` on the
+ * wire) so legacy or unknown rows never break listing; UI owns a human label
+ * map keyed off these constants and prettifies anything unknown.
+ */
+
+/**
+ * Preserves literal element types on a string list without an `as const`
+ * assertion (which the lint rules disallow), so the exported unions derive
+ * exactly from these tuples.
+ */
+function literalTuple<T extends readonly string[]>(...values: T): T {
+  return values
+}
+
+/** Every audit event type, for UI dropdowns; the union derives from it. */
+export const AUDIT_EVENT_TYPES = literalTuple(
+  // developer-platform
+  'api_token.created',
+  'api_token.revoked',
+  'webhook_endpoint.created',
+  'webhook_endpoint.disabled',
+  'webhook_endpoint.secret_rotated',
+  'webhook.delivery_failed',
+  'webhook.delivery_dead_lettered',
+  // governance — workspace lifecycle
+  'workspace.created',
+  'workspace.renamed',
+  'workspace.deleted',
+  // governance — membership
+  'workspace_member.added',
+  'workspace_member.removed',
+  'workspace_member.role_changed',
+  // governance — invitations
+  'workspace_invitation.sent',
+  'workspace_invitation.canceled',
+  'workspace_invitation.accepted',
+  // account lifecycle over the auth catchall
+  'auth.sign_in',
+  'auth.sign_in_failed',
+  'auth.sign_up',
+  'auth.sign_up_failed',
+  'auth.password_reset_requested',
+  'auth.password_reset',
+  'auth.password_reset_failed',
+  'auth.email_verified',
+  'auth.email_verification_failed',
+  // Better Auth admin endpoints (system-level)
+  'system_admin.user_created',
+  'system_admin.user_creation_failed',
+  'system_admin.user_removed',
+  'system_admin.user_removal_failed',
+  'system_admin.user_role_changed',
+  'system_admin.user_role_change_failed',
+  'system_admin.user_banned',
+  'system_admin.user_ban_failed',
+  'system_admin.user_unbanned',
+  'system_admin.user_unban_failed',
+  'system_admin.user_password_set',
+  'system_admin.user_password_set_failed',
+  'system_admin.impersonation_started',
+  'system_admin.impersonation_start_failed',
+  'system_admin.impersonation_stopped',
+  'system_admin.impersonation_stop_failed',
+  'system_admin.user_session_revoked',
+  'system_admin.user_session_revocation_failed'
+)
+
+export type AuditEventType = (typeof AUDIT_EVENT_TYPES)[number]
+
+/**
+ * Every audit target type. The union is derived from this tuple, same as the
+ * event vocabulary above.
+ */
+export const AUDIT_TARGET_TYPES = literalTuple(
+  'user',
+  'session',
+  'api_token',
+  'webhook_endpoint',
+  'workspace',
+  'workspace_member',
+  'workspace_invitation'
+)
+
+export type AuditTargetType = (typeof AUDIT_TARGET_TYPES)[number]

--- a/packages/capabilities/src/index.ts
+++ b/packages/capabilities/src/index.ts
@@ -10,6 +10,7 @@ export * from './developer-platform/webhook-url.ts'
 
 // governance
 export * from './governance/audit-event-log.ts'
+export * from './governance/audit-event-taxonomy.ts'
 export * from './governance/plugin-binding-failure.ts'
 export * from './governance/workspace-identity.ts'
 export * from './governance/workspace-invitations.ts'

--- a/packages/capabilities/src/live-layers.test.ts
+++ b/packages/capabilities/src/live-layers.test.ts
@@ -379,8 +379,8 @@ layer(TestDatabase, { timeout: '120 seconds' })('live capability layers', (it) =
             const audit = yield* AuditEventLog
             yield* audit.record({
               workspaceId: 'wrk_other',
-              eventType: 'isolation.check',
-              targetType: 'test'
+              eventType: 'workspace.created',
+              targetType: 'workspace'
             })
           })
         )
@@ -391,9 +391,9 @@ layer(TestDatabase, { timeout: '120 seconds' })('live capability layers', (it) =
             return (yield* audit.list()).events
           })
         )
-        expect(liveEvents.some((event) => event.eventType === 'isolation.check')).toBe(
-          false
-        )
+        expect(
+          liveEvents.some((event) => event.eventType === 'workspace.created')
+        ).toBe(false)
         const otherEvents = yield* inWorkspace(
           'other-lab',
           Effect.gen(function* () {
@@ -401,9 +401,9 @@ layer(TestDatabase, { timeout: '120 seconds' })('live capability layers', (it) =
             return (yield* audit.list()).events
           })
         )
-        expect(otherEvents.some((event) => event.eventType === 'isolation.check')).toBe(
-          true
-        )
+        expect(
+          otherEvents.some((event) => event.eventType === 'workspace.created')
+        ).toBe(true)
       })
     )
   })


### PR DESCRIPTION
Closes #90 (part of the #85 wayfinder map)

## What

Two pieces, one commit:

1. **Audit event taxonomy module** (`packages/capabilities/src/governance/audit-event-taxonomy.ts`) — the single source the taxonomy decision (#87) called for, which had never landed as code:
   - `AUDIT_EVENT_TYPES` / `AUDIT_TARGET_TYPES` const tuples (for UI dropdowns), with `AuditEventType` / `AuditTargetType` unions **derived from** the tuples so they cannot drift.
   - Enforced at the write boundary: `RecordAuditEventInput.eventType/targetType` are taxonomy-typed. The read path stays a lenient `Schema.String`, so legacy rows never break listing.
   - Existing producers typecheck against it unchanged; webhook-endpoints' update helper and delivery-event map become taxonomy-typed; two ad-hoc test event names migrated.

2. **`system_admin` producer for Better Auth admin endpoints** — a path→event table (`ADMIN_EXCHANGE_EVENTS`) in `auth-audit.ts`, one row per admin mutation (create/remove user, set-role, ban/unban, set-user-password, impersonate/stop-impersonating, revoke-user-session(s)) naming its success/failure pair per the `<namespace>.<past_tense_verb>` + `_failed` convention. Built as the **shared mapper**: #91 (remaining auth surface) extends this table shape rather than adding a parallel predicate.

## Design points

- **Actor** — read from the session BEFORE the handler runs (`readAdminAuditContext` in the catchall route); admin responses never name their actor. Unlike account-lifecycle events, failures keep the actor — the session predates Better Auth's judgment. Anonymous probes skip.
- **Target** — `userId` parsed from a request-body clone taken before Better Auth consumes it; create-user falls back to its response body; stop-impersonating records an untargeted user event. Unparseable body → untargeted event with the reason annotated on the wide event.
- **Best-effort contract unchanged** — dropped writes annotate `authAuditError` / `authAuditBodyError`; no admin endpoint can fail because of auditing.
- Docs: `audit-event-log.AGENTS.md` leaf node updated; new module sits beside it under `governance/`.

## Tests

29 passing in `auth-audit.test.ts`: admin table acceptance/rejection, full success/failure pair enumeration per endpoint, attributed/kept-actor mapping, body-vs-response target resolution, recorded/dropped/skipped outcomes through `recordAuthAudit`. Full repo build, all 25 test tasks, oxlint and oxfmt clean.