### PR TITLE
feat: member management — role change on the workspace members page

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,8 +2,15 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './e2e',
-  timeout: 30_000,
+  // 90s, not 30s: specs run in parallel workers, and the first ones to open
+  // /sign-in pay Vite's full cold-transform bill — much heavier since React
+  // Compiler joined the dev pipeline (#135). On a cold CI runner that bill
+  // alone ate the old 30s budget before hydration could finish.
+  timeout: 90_000,
   expect: { timeout: 5000 },
+  // One retry in CI: the remaining variance is dev-server warm-up, not app
+  // behaviour, and a rerun lands on an already-warm transform cache.
+  retries: process.env.CI ? 1 : 0,
   use: {
     baseURL: 'http://localhost:3071',
     trace: 'on-first-retry'

--- a/apps/web/src/components/members-panel.tsx
+++ b/apps/web/src/components/members-panel.tsx
@@ -1,0 +1,120 @@
+import {
+  WORKSPACE_ROLES,
+  type Member,
+  type WorkspaceRole
+} from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
+import { useState } from 'react'
+import { useRouter } from '@tanstack/react-router'
+import { Cause, Effect, Exit, Option } from 'effect'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { causeMessage } from '@/lib/cause-message'
+import { viewerCan, type Viewer } from '@/lib/permissions'
+import { changeMemberRoleServerFn } from '@/lib/server/workspace-members'
+
+const CHANGE_FAILED = 'Failed to change the role'
+
+function roleVariant(role: WorkspaceRole): 'default' | 'secondary' | 'outline' {
+  if (role === 'owner') return 'default'
+  if (role === 'admin') return 'secondary'
+  return 'outline'
+}
+
+/** The roles a member can be moved to from their current one. */
+function otherRoles(current: WorkspaceRole): readonly WorkspaceRole[] {
+  return WORKSPACE_ROLES.filter((role) => role !== current)
+}
+
+/**
+ * The workspace roster with per-member role change. Presentation only: the
+ * control renders when `member:update` authorizes it, but every change is
+ * re-checked server-side by `requireWorkspacePermission` in the server fn.
+ */
+export function MembersPanel({
+  workspaceSlug,
+  members,
+  viewer
+}: {
+  readonly workspaceSlug: string
+  readonly members: readonly Member[]
+  readonly viewer: Viewer
+}) {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [changing, setChanging] = useState<string | null>(null)
+
+  const canManage = viewerCan(viewer, { member: ['update'] })
+
+  async function changeRole(userId: string, role: WorkspaceRole) {
+    setError(null)
+    setChanging(userId)
+    const exit = await Effect.runPromiseExit(
+      Effect.tryPromise({
+        try: () => changeMemberRoleServerFn({ data: { workspaceSlug, userId, role } }),
+        catch: (cause) => causeMessage(cause, CHANGE_FAILED)
+      })
+    )
+    setChanging(null)
+    if (Exit.isFailure(exit)) {
+      setError(Option.getOrElse(Cause.findErrorOption(exit.cause), () => CHANGE_FAILED))
+      return
+    }
+    // The loader owns the roster, so re-run it rather than mirroring the
+    // changed row into local state.
+    await router.invalidate()
+  }
+
+  if (members.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No members yet. Invite someone from settings.
+      </p>
+    )
+  }
+
+  return (
+    <div className="grid gap-2">
+      <ul className="grid gap-2">
+        {members.map((member) => (
+          <li
+            key={member.id}
+            className="flex items-center justify-between gap-4 rounded-md border border-border p-3"
+          >
+            <div className="grid gap-0.5">
+              <p className="text-sm font-medium">{member.name}</p>
+              <p className="text-xs text-muted-foreground">{member.email}</p>
+            </div>
+            <div className="flex items-center gap-3">
+              <Badge variant={roleVariant(member.role)}>{member.role}</Badge>
+              {canManage
+                ? otherRoles(member.role).map((role) => (
+                    <Button
+                      key={role}
+                      variant="ghost"
+                      size="sm"
+                      disabled={changing === member.id}
+                      onClick={() => void changeRole(member.id, role)}
+                    >
+                      Make {role}
+                      {changing === member.id ? '…' : ''}
+                    </Button>
+                  ))
+                : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+      {canManage ? null : (
+        <p className="text-xs text-muted-foreground">
+          Your role cannot change member roles.
+        </p>
+      )}
+      {error ? (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/workspace-shell.tsx
+++ b/apps/web/src/components/workspace-shell.tsx
@@ -9,7 +9,8 @@ import {
   LogOutIcon,
   MenuIcon,
   SettingsIcon,
-  ShieldIcon
+  ShieldIcon,
+  UsersIcon
 } from 'lucide-react'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Badge } from '@/components/ui/badge'
@@ -210,6 +211,13 @@ function WorkspaceNav({
               onNavigate={onNavigate}
             />
             <NavLink
+              to="/workspaces/$workspaceSlug/members"
+              workspaceSlug={workspaceSlug}
+              label="Members"
+              icon={<UsersIcon className="size-4" />}
+              onNavigate={onNavigate}
+            />
+            <NavLink
               to="/workspaces/$workspaceSlug/settings"
               workspaceSlug={workspaceSlug}
               label="Settings"
@@ -249,6 +257,7 @@ function NavLink({
 }: {
   readonly to:
     | '/workspaces/$workspaceSlug'
+    | '/workspaces/$workspaceSlug/members'
     | '/workspaces/$workspaceSlug/settings'
     | '/workspaces/$workspaceSlug/audit'
   readonly workspaceSlug: string

--- a/apps/web/src/lib/server/member-binding.test.ts
+++ b/apps/web/src/lib/server/member-binding.test.ts
@@ -1,0 +1,88 @@
+import {
+  readPluginBindingFailure,
+  type PluginBindingFailure
+} from '@b2b-saas-starter/capabilities/src/governance/plugin-binding-failure.ts'
+import { describe, expect, it } from 'vitest'
+import { Option, Schema } from 'effect'
+
+import { webMemberBinding } from './member-binding'
+
+/**
+ * The adapter's one behaviour that does not need Better Auth: what it does with
+ * no in-flight request to take session headers from.
+ *
+ * `updateMemberRole` and `removeMember` are `requireHeaders: true`, so this is
+ * not an edge case — it is the state a client-side navigation or a background
+ * call is in. The rejection has to reach the capability as "the store is
+ * unreachable", never as "the workspace refused", because nothing about the
+ * membership is wrong. The assertion runs the capability's own classifier over
+ * the rejected value rather than restating its rule, so a `statusCode` appearing
+ * on this error — or the classifier changing its mind about a missing status —
+ * fails here.
+ *
+ * Under Vitest there is no TanStack request storage, so `currentRequest()`
+ * answers `undefined` and every headered call below takes that branch.
+ *
+ * `addMember` is deliberately absent from this file: the plugin's add-member
+ * route runs headerless by design (`serverOnly`, no session middleware), so it
+ * has no no-request branch to assert.
+ */
+
+const TaggedRejection = Schema.Struct({ _tag: Schema.String })
+const decodeTag = Schema.decodeUnknownOption(TaggedRejection)
+
+type BindingRejection = {
+  /** `'resolved'` when the call did not reject at all, which is a failure here. */
+  readonly tag: string
+  readonly failure: PluginBindingFailure
+}
+
+async function rejectionOf(call: () => Promise<void>): Promise<BindingRejection> {
+  // oxlint-disable-next-line effect/noTryCatch -- the port under test is a promise boundary by contract; catching the rejection IS the observation
+  try {
+    await call()
+    return { tag: 'resolved', failure: { refusedByWorkspace: false, reason: 'none' } }
+  } catch (error) {
+    return {
+      tag: Option.match(decodeTag(error), {
+        onNone: () => 'untagged',
+        onSome: (rejection) => rejection._tag
+      }),
+      failure: readPluginBindingFailure(error)
+    }
+  }
+}
+
+type BindingCall = {
+  readonly name: string
+  readonly call: () => Promise<void>
+}
+
+const CALLS: readonly BindingCall[] = [
+  {
+    name: 'removeMember',
+    call: () =>
+      webMemberBinding.removeMember({ workspaceId: 'ws_1', memberId: 'mbr_1' })
+  },
+  {
+    name: 'changeRole',
+    call: () =>
+      webMemberBinding.changeRole({
+        workspaceId: 'ws_1',
+        memberId: 'mbr_1',
+        role: 'member'
+      })
+  }
+]
+
+describe('webMemberBinding with no request', () => {
+  it.each(CALLS)(
+    'rejects $name as unavailable rather than refused',
+    async ({ call }) => {
+      expect(await rejectionOf(call)).toEqual({
+        tag: 'MissingRequestHeaders',
+        failure: { refusedByWorkspace: false, reason: 'no_request_headers' }
+      })
+    }
+  )
+})

--- a/apps/web/src/lib/server/member-binding.ts
+++ b/apps/web/src/lib/server/member-binding.ts
@@ -1,0 +1,106 @@
+import { Auth, type AuthOptions } from '@b2b-saas-starter/auth'
+import { type WorkspaceMemberBinding } from '@b2b-saas-starter/capabilities/src/governance/workspace-membership.ts'
+import { Effect, Result, Schema } from 'effect'
+import { type Service } from 'effectful-better-auth'
+import { authRuntime } from '../auth-runtime'
+import { currentRequest } from '../request-context'
+
+/**
+ * The web app's adapter onto Better Auth's `organization` member endpoints —
+ * the app half of the `WorkspaceMemberBinding` port that
+ * `@b2b-saas-starter/capabilities` declares.
+ *
+ * It lives here, in a server-only module, rather than beside `starterEnv` in
+ * `../capabilities.ts`: that module is bundled for the browser too (client-side
+ * navigations re-run loaders against the Seed layer), and importing
+ * `packages/auth` there would drag the whole Better Auth server instance into
+ * the client bundle. Server functions pass this adapter in per call instead.
+ *
+ * `updateMemberRole` and `removeMember` are `requireHeaders: true`, so the
+ * request's session cookie is not optional there — it is the whole reason this
+ * adapter has to exist in the app at all (ADR 0051 keeps membership writes out
+ * of the API worker for the same reason). The headers are read at call time, so
+ * one module-level adapter serves every request without capturing one.
+ */
+
+type AuthService = Service<AuthOptions>
+
+/**
+ * A plugin call attempted with no in-flight request to take session headers
+ * from. It carries an explicit `message` and, deliberately, no `statusCode`:
+ * `classifyBindingFailure` reads the status to tell "the workspace refuses"
+ * from "the store is unreachable", and nothing about the membership is wrong
+ * here — so it must land on the unavailable side.
+ */
+class MissingRequestHeaders extends Schema.TaggedErrorClass<MissingRequestHeaders>()(
+  'MissingRequestHeaders',
+  { message: Schema.String }
+) {}
+
+/**
+ * Rejects with the underlying failure itself rather than a wrapped cause, so
+ * `classifyBindingFailure` in the capability can read its `statusCode`. Getting
+ * this wrong turns every "the workspace refuses" into a 503 telling the caller
+ * to retry something that can never succeed.
+ *
+ * `async` + `throw` rather than `Promise.reject`: this function *is* the promise
+ * boundary the port asks for, and throwing inside an async function is how it
+ * rejects without reaching for a Promise constructor.
+ */
+async function runBinding<A>(
+  build: (
+    auth: AuthService,
+    headers: Headers | undefined
+  ) => Effect.Effect<A, unknown, never>
+): Promise<void> {
+  const request = currentRequest()
+  const result = await authRuntime.runPromise(
+    Effect.result(Effect.flatMap(Auth.Tag, (auth) => build(auth, request?.headers)))
+  )
+  if (Result.isFailure(result)) {
+    // oxlint-disable-next-line effect/noThrowStatement -- same boundary: the capability classifies this value by its statusCode, so it must arrive as the rejection
+    throw result.failure
+  }
+}
+
+function requireHeaders(headers: Headers | undefined): Headers {
+  // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the WorkspaceMemberBinding port returns; there is no Effect error channel on this side of it
+  if (!headers) throw new MissingRequestHeaders({ message: 'no_request_headers' })
+  return headers
+}
+
+export const webMemberBinding: WorkspaceMemberBinding = {
+  // The plugin's add-member route is a trusted server-side call (`serverOnly`,
+  // no session middleware), so it runs headerless by design.
+  addMember: (input) =>
+    runBinding((auth) =>
+      auth.api.addMember({
+        body: {
+          userId: input.userId,
+          role: input.role,
+          organizationId: input.workspaceId
+        }
+      })
+    ),
+  removeMember: (input) =>
+    runBinding((auth, headers) =>
+      auth.api.removeMember({
+        body: {
+          memberIdOrEmail: input.memberId,
+          organizationId: input.workspaceId
+        },
+        headers: requireHeaders(headers)
+      })
+    ),
+  changeRole: (input) =>
+    runBinding((auth, headers) =>
+      auth.api.updateMemberRole({
+        body: {
+          role: input.role,
+          memberId: input.memberId,
+          organizationId: input.workspaceId
+        },
+        headers: requireHeaders(headers)
+      })
+    )
+}

--- a/apps/web/src/lib/server/workspace-members.test.ts
+++ b/apps/web/src/lib/server/workspace-members.test.ts
@@ -1,0 +1,166 @@
+import {
+  SeedWorkspaceMembership,
+  makeSeedRoster,
+  type WorkspaceMembership
+} from '@b2b-saas-starter/capabilities/src/governance/workspace-membership.ts'
+import {
+  testWorkspaceContext,
+  type Actor,
+  type WorkspaceContext
+} from '@b2b-saas-starter/capabilities/src/workspace-context.ts'
+import {
+  type Member,
+  type Workspace,
+  type WorkspaceRole
+} from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
+import { describe, expect, it } from 'vitest'
+import { Effect, Layer, Ref, type Scope } from 'effect'
+
+import { changeMemberRole, loadWorkspaceMembers } from './workspace-members'
+
+/**
+ * The member-management surface below its session gate. `changeMemberRole` is
+ * exported as an effect taking only the role input, so what is testable without
+ * a request or an auth runtime is exactly the behaviour: the `member:update`
+ * gate and the hand-off to the membership capability (whose own contract tests
+ * cover the plugin binding). The fixture roster is seeded per test, which the
+ * app's own layer cannot do.
+ *
+ * Real clock on purpose: plain `it` + `Effect.runPromise`, not
+ * `@effect/vitest`'s TestClock epoch.
+ */
+
+const workspace: Workspace = {
+  id: 'wrk_test',
+  slug: 'test-lab',
+  name: 'Test Lab',
+  planId: 'starter'
+}
+
+function actor(role: WorkspaceRole): Actor {
+  return { userId: `usr_${role}`, role, systemRole: 'user' }
+}
+
+const OWNER = actor('owner')
+const ADMIN = actor('admin')
+const MEMBER = actor('member')
+
+function memberOf(a: Actor): Member {
+  return {
+    id: a.userId,
+    name: a.userId,
+    email: `${a.userId}@example.com`,
+    role: a.role,
+    systemRole: 'user'
+  }
+}
+
+type Harness = {
+  readonly actor?: Actor | null
+  readonly members?: readonly Member[]
+}
+
+/**
+ * Runs one effect against a fresh fixture. `roster` comes back so a test can
+ * assert on what the run changed outside its return value.
+ */
+function run<A, E>(
+  harness: Harness,
+  body: () => Effect.Effect<A, E, Scope.Scope | WorkspaceContext | WorkspaceMembership>
+): Promise<{ readonly result: A; readonly roster: readonly Member[] }> {
+  const members = harness.members ?? [memberOf(OWNER), memberOf(MEMBER)]
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const roster = yield* makeSeedRoster(members)
+      const layer = Layer.mergeAll(
+        SeedWorkspaceMembership(roster, workspace),
+        // `in` rather than `??`: a test that passes `actor: null` is asserting
+        // what the guard does with no principal, not asking for the default.
+        testWorkspaceContext(
+          workspace,
+          'actor' in harness ? (harness.actor ?? null) : OWNER
+        )
+      )
+      const result = yield* Effect.scoped(body().pipe(Effect.provide(layer)))
+      return { result, roster: yield* Ref.get(roster) }
+    })
+  )
+}
+
+/** Turns a typed failure into a value, so a denial is asserted not thrown. */
+function outcome<A, E extends { readonly _tag: string; readonly reason?: string }, R>(
+  effect: Effect.Effect<A, E, R>
+) {
+  return Effect.match(effect, {
+    onSuccess: (value) => ({ tag: 'ok', value }),
+    onFailure: (failure) => ({ tag: failure._tag, reason: failure.reason })
+  })
+}
+
+describe('changeMemberRole', () => {
+  it('lets an owner re-role another member', async () => {
+    const { result, roster } = await run({}, () =>
+      outcome(changeMemberRole({ userId: MEMBER.userId, role: 'admin' }))
+    )
+    expect(result).toEqual({
+      tag: 'ok',
+      value: expect.objectContaining({ id: MEMBER.userId, role: 'admin' })
+    })
+    expect(roster.find((candidate) => candidate.id === MEMBER.userId)?.role).toBe(
+      'admin'
+    )
+  })
+
+  it('lets an admin promote a member too — the matrix grants admin member:update', async () => {
+    const { result } = await run({ actor: ADMIN }, () =>
+      outcome(changeMemberRole({ userId: MEMBER.userId, role: 'member' }))
+    )
+    expect(result.tag).toBe('ok')
+  })
+
+  it('denies a member the change', async () => {
+    const { result } = await run({ actor: MEMBER }, () =>
+      outcome(changeMemberRole({ userId: OWNER.userId, role: 'member' }))
+    )
+    expect(result).toEqual({
+      tag: 'AuthorizationDenied',
+      reason: 'insufficient_permission'
+    })
+  })
+
+  it('fails closed with no resolved actor', async () => {
+    const { result } = await run({ actor: null }, () =>
+      outcome(changeMemberRole({ userId: MEMBER.userId, role: 'admin' }))
+    )
+    expect(result).toEqual({ tag: 'AuthorizationDenied', reason: 'no_principal' })
+  })
+})
+
+/**
+ * The loader seam, driven against the Seed layer: `runWorkspaceCapabilities`
+ * resolves `cloudflare:workers` to the inert shim under Vitest (vite.config.ts),
+ * so `DB` is undefined and the in-memory fixture answers. Both users below are
+ * seed members of `starter-lab` — `usr_demo` owns it, `usr_dev` is a plain
+ * member.
+ */
+describe('loadWorkspaceMembers', () => {
+  it('lists the roster with the viewer role for an owner', async () => {
+    const payload = await loadWorkspaceMembers({
+      workspaceSlug: 'starter-lab',
+      userId: 'usr_demo'
+    })
+    expect(payload.viewer).toEqual({ role: 'owner' })
+    expect(payload.unreadCount).toBeTypeOf('number')
+    expect(payload.members.length).toBeGreaterThan(0)
+    expect(payload.members.map((member) => member.id)).toContain('usr_dev')
+  })
+
+  it('shows a plain member the roster too — membership itself entitles the read', async () => {
+    const payload = await loadWorkspaceMembers({
+      workspaceSlug: 'starter-lab',
+      userId: 'usr_dev'
+    })
+    expect(payload.viewer).toEqual({ role: 'member' })
+    expect(payload.members.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/lib/server/workspace-members.ts
+++ b/apps/web/src/lib/server/workspace-members.ts
@@ -1,0 +1,120 @@
+import { type AuthorizationDenied } from '@b2b-saas-starter/authz/src/errors.ts'
+import {
+  WorkspaceMembership,
+  type MemberRoleInput
+} from '@b2b-saas-starter/capabilities/src/governance/workspace-membership.ts'
+import {
+  WorkspaceRole as WorkspaceRoleSchema,
+  type Member,
+  type WorkspaceRole
+} from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
+import { NotificationFeed } from '@b2b-saas-starter/capabilities/src/notifications/notification-feed.ts'
+import {
+  type CapabilityUnavailable,
+  type MembershipChangeRejected
+} from '@b2b-saas-starter/capabilities/src/errors.ts'
+import { WorkspaceContext } from '@b2b-saas-starter/capabilities/src/workspace-context.ts'
+import { createServerFn } from '@tanstack/react-start'
+import { Effect, Schema, type Scope } from 'effect'
+
+import { runWorkspaceCapabilities } from '../capabilities'
+import { requireRequestSession } from './auth'
+import { requireWorkspacePermission } from './authorize'
+import { webMemberBinding } from './member-binding'
+
+/**
+ * The workspace members payload.
+ *
+ * Reading the roster is a member's own standing: the `WorkspaceContext` layer
+ * has already proved membership (non-members get `WorkspaceNotFound`), and the
+ * roster carries no security posture the way tokens or invitations do. What
+ * *changes* the roster is gated — `member:update` on the server, `viewerCan`
+ * in the component.
+ */
+export type WorkspaceMembersPayload = {
+  readonly viewer: { readonly role: WorkspaceRole } | null
+  readonly unreadCount: number
+  readonly members: readonly Member[]
+}
+
+/**
+ * `notification:read` is the page's own read permission and a hard gate —
+ * same shape as the settings page. A `member` holds it; only an actorless
+ * context fails it.
+ */
+const membersPayload: Effect.Effect<
+  WorkspaceMembersPayload,
+  AuthorizationDenied | CapabilityUnavailable,
+  Scope.Scope | WorkspaceContext | WorkspaceMembership | NotificationFeed
+> = Effect.gen(function* () {
+  yield* requireWorkspacePermission({ notification: ['read'] })
+  const ctx = yield* WorkspaceContext
+  const membership = yield* WorkspaceMembership
+  const feed = yield* NotificationFeed
+  const [unreadCount, members] = yield* Effect.all(
+    [feed.unreadCount, membership.listMembers],
+    { concurrency: 'unbounded' }
+  )
+  return {
+    viewer: ctx.actor ? { role: ctx.actor.role } : null,
+    unreadCount,
+    members
+  }
+})
+
+/** The members route's loader. */
+export function loadWorkspaceMembers(input: {
+  readonly workspaceSlug: string
+  readonly userId: string
+}): Promise<WorkspaceMembersPayload> {
+  return runWorkspaceCapabilities(input.workspaceSlug, membersPayload, {
+    userId: input.userId
+  })
+}
+
+// All input constraints live in the schema — no imperative re-validation.
+const ChangeMemberRoleInput = Schema.Struct({
+  workspaceSlug: Schema.NonEmptyString,
+  userId: Schema.NonEmptyString,
+  role: WorkspaceRoleSchema
+})
+
+const decodeInput = Schema.decodeUnknownSync(ChangeMemberRoleInput)
+
+/**
+ * The effect below the session gate: proves the actor may manage members
+ * (`member:update`, declared → enforced here), then hands the change to the
+ * capability. Exported so tests drive it against fixture layers without a
+ * request or an auth runtime.
+ *
+ * Self-promotion and self-demotion are refused by Better Auth itself (the
+ * plugin endpoint checks the acting member against its own rules); this guard
+ * refuses everyone the role table already refuses.
+ */
+export function changeMemberRole(
+  input: MemberRoleInput
+): Effect.Effect<
+  Member,
+  AuthorizationDenied | CapabilityUnavailable | MembershipChangeRejected,
+  Scope.Scope | WorkspaceContext | WorkspaceMembership
+> {
+  return Effect.gen(function* () {
+    yield* requireWorkspacePermission({ member: ['update'] })
+    const membership = yield* WorkspaceMembership
+    return yield* membership.changeRole(input)
+  })
+}
+
+export const changeMemberRoleServerFn = createServerFn({ method: 'POST' })
+  .validator((input) => decodeInput(input))
+  .handler(async ({ data }): Promise<Member> => {
+    const session = await requireRequestSession()
+    return runWorkspaceCapabilities(
+      data.workspaceSlug,
+      changeMemberRole({ userId: data.userId, role: data.role }),
+      { userId: session.user.id },
+      // The adapter lives server-only and rides per call — see
+      // `member-binding.ts` for why it cannot sit on `starterEnv`.
+      { memberBinding: webMemberBinding }
+    )
+  })

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as ApiAuthSplatRouteImport } from './routes/api.auth.$'
 import { Route as DocsCategorySlugRouteImport } from './routes/docs.$category.$slug'
 import { Route as WorkspacesWorkspaceSlugIndexRouteImport } from './routes/workspaces.$workspaceSlug.index'
 import { Route as WorkspacesWorkspaceSlugAuditRouteImport } from './routes/workspaces.$workspaceSlug.audit'
+import { Route as WorkspacesWorkspaceSlugMembersRouteImport } from './routes/workspaces.$workspaceSlug.members'
 import { Route as WorkspacesWorkspaceSlugSettingsRouteImport } from './routes/workspaces.$workspaceSlug.settings'
 
 const IndexRoute = IndexRouteImport.update({
@@ -157,6 +158,12 @@ const WorkspacesWorkspaceSlugAuditRoute =
     path: '/$workspaceSlug/audit',
     getParentRoute: () => WorkspacesRoute,
   } as any)
+const WorkspacesWorkspaceSlugMembersRoute =
+  WorkspacesWorkspaceSlugMembersRouteImport.update({
+    id: '/$workspaceSlug/members',
+    path: '/$workspaceSlug/members',
+    getParentRoute: () => WorkspacesRoute,
+  } as any)
 const WorkspacesWorkspaceSlugSettingsRoute =
   WorkspacesWorkspaceSlugSettingsRouteImport.update({
     id: '/$workspaceSlug/settings',
@@ -188,6 +195,7 @@ export interface FileRoutesByFullPath {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/docs/$category/$slug': typeof DocsCategorySlugRoute
   '/workspaces/$workspaceSlug/audit': typeof WorkspacesWorkspaceSlugAuditRoute
+  '/workspaces/$workspaceSlug/members': typeof WorkspacesWorkspaceSlugMembersRoute
   '/workspaces/$workspaceSlug/settings': typeof WorkspacesWorkspaceSlugSettingsRoute
   '/workspaces/$workspaceSlug/': typeof WorkspacesWorkspaceSlugIndexRoute
 }
@@ -213,6 +221,7 @@ export interface FileRoutesByTo {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/docs/$category/$slug': typeof DocsCategorySlugRoute
   '/workspaces/$workspaceSlug/audit': typeof WorkspacesWorkspaceSlugAuditRoute
+  '/workspaces/$workspaceSlug/members': typeof WorkspacesWorkspaceSlugMembersRoute
   '/workspaces/$workspaceSlug/settings': typeof WorkspacesWorkspaceSlugSettingsRoute
   '/workspaces/$workspaceSlug': typeof WorkspacesWorkspaceSlugIndexRoute
 }
@@ -241,6 +250,7 @@ export interface FileRoutesById {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/docs/$category/$slug': typeof DocsCategorySlugRoute
   '/workspaces/$workspaceSlug/audit': typeof WorkspacesWorkspaceSlugAuditRoute
+  '/workspaces/$workspaceSlug/members': typeof WorkspacesWorkspaceSlugMembersRoute
   '/workspaces/$workspaceSlug/settings': typeof WorkspacesWorkspaceSlugSettingsRoute
   '/workspaces/$workspaceSlug/': typeof WorkspacesWorkspaceSlugIndexRoute
 }
@@ -270,6 +280,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/docs/$category/$slug'
     | '/workspaces/$workspaceSlug/audit'
+    | '/workspaces/$workspaceSlug/members'
     | '/workspaces/$workspaceSlug/settings'
     | '/workspaces/$workspaceSlug/'
   fileRoutesByTo: FileRoutesByTo
@@ -295,6 +306,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/docs/$category/$slug'
     | '/workspaces/$workspaceSlug/audit'
+    | '/workspaces/$workspaceSlug/members'
     | '/workspaces/$workspaceSlug/settings'
     | '/workspaces/$workspaceSlug'
   id:
@@ -322,6 +334,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/docs/$category/$slug'
     | '/workspaces/$workspaceSlug/audit'
+    | '/workspaces/$workspaceSlug/members'
     | '/workspaces/$workspaceSlug/settings'
     | '/workspaces/$workspaceSlug/'
   fileRoutesById: FileRoutesById
@@ -518,6 +531,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspacesWorkspaceSlugAuditRouteImport
       parentRoute: typeof WorkspacesRoute
     }
+    '/workspaces/$workspaceSlug/members': {
+      id: '/workspaces/$workspaceSlug/members'
+      path: '/$workspaceSlug/members'
+      fullPath: '/workspaces/$workspaceSlug/members'
+      preLoaderRoute: typeof WorkspacesWorkspaceSlugMembersRouteImport
+      parentRoute: typeof WorkspacesRoute
+    }
     '/workspaces/$workspaceSlug/settings': {
       id: '/workspaces/$workspaceSlug/settings'
       path: '/$workspaceSlug/settings'
@@ -543,6 +563,7 @@ const DocsRouteWithChildren = DocsRoute._addFileChildren(DocsRouteChildren)
 interface WorkspacesRouteChildren {
   WorkspacesIndexRoute: typeof WorkspacesIndexRoute
   WorkspacesWorkspaceSlugAuditRoute: typeof WorkspacesWorkspaceSlugAuditRoute
+  WorkspacesWorkspaceSlugMembersRoute: typeof WorkspacesWorkspaceSlugMembersRoute
   WorkspacesWorkspaceSlugSettingsRoute: typeof WorkspacesWorkspaceSlugSettingsRoute
   WorkspacesWorkspaceSlugIndexRoute: typeof WorkspacesWorkspaceSlugIndexRoute
 }
@@ -550,6 +571,7 @@ interface WorkspacesRouteChildren {
 const WorkspacesRouteChildren: WorkspacesRouteChildren = {
   WorkspacesIndexRoute: WorkspacesIndexRoute,
   WorkspacesWorkspaceSlugAuditRoute: WorkspacesWorkspaceSlugAuditRoute,
+  WorkspacesWorkspaceSlugMembersRoute: WorkspacesWorkspaceSlugMembersRoute,
   WorkspacesWorkspaceSlugSettingsRoute: WorkspacesWorkspaceSlugSettingsRoute,
   WorkspacesWorkspaceSlugIndexRoute: WorkspacesWorkspaceSlugIndexRoute,
 }

--- a/apps/web/src/routes/workspaces.$workspaceSlug.members.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.members.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { MembersPanel } from '@/components/members-panel'
+import { RoutePending } from '@/components/route-pending'
+import { WorkspaceShell } from '@/components/workspace-shell'
+import { viewerCan } from '@/lib/permissions'
+import {
+  loadWorkspaceMembers,
+  type WorkspaceMembersPayload
+} from '@/lib/server/workspace-members'
+
+// The auth gate lives on the /workspaces layout route (workspaces.tsx);
+// `context.session` arrives from there.
+export const Route = createFileRoute('/workspaces/$workspaceSlug/members')({
+  loader: ({ params, context }) =>
+    loadWorkspaceMembers({
+      workspaceSlug: params.workspaceSlug,
+      userId: context.session.user.id
+    }),
+  pendingComponent: RoutePending,
+  component: WorkspaceMembersRoute
+})
+
+/**
+ * The route's thin wrapper: reads the params and loader data the router
+ * resolved, and hands them to the page. Keeping the two apart is what lets the
+ * page be rendered from a test with plain props — no route tree, no loader.
+ */
+function WorkspaceMembersRoute() {
+  const { workspaceSlug } = Route.useParams()
+  const data = Route.useLoaderData()
+  return <WorkspaceMembersPage workspaceSlug={workspaceSlug} data={data} />
+}
+
+export function WorkspaceMembersPage({
+  workspaceSlug,
+  data
+}: {
+  readonly workspaceSlug: string
+  readonly data: WorkspaceMembersPayload
+}) {
+  const { viewer, unreadCount, members } = data
+
+  return (
+    <WorkspaceShell
+      workspaceSlug={workspaceSlug}
+      title="Members"
+      description="Everyone with access to this workspace."
+      unreadCount={unreadCount}
+      canReadAuditLog={viewerCan(viewer, { auditLog: ['read'] })}
+    >
+      <div className="grid gap-6">
+        <MembersPanel workspaceSlug={workspaceSlug} members={members} viewer={viewer} />
+      </div>
+    </WorkspaceShell>
+  )
+}

--- a/apps/web/src/routes/workspaces.$workspaceSlug.settings.test.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.settings.test.tsx
@@ -76,9 +76,9 @@ describe('WorkspaceSettingsPage as a member', () => {
     expect(screen.queryByRole('button', { name: 'Create token' })).toBeNull()
   })
 
-  it('does not render the members or webhook sections', async () => {
+  it('does not render the invitation or webhook sections', async () => {
     await renderPage(memberSettings)
-    expect(screen.queryByText('Members')).toBeNull()
+    expect(screen.queryByLabelText('Invite by email')).toBeNull()
     expect(screen.queryByLabelText('Email')).toBeNull()
     expect(screen.queryByText('Outbound webhooks')).toBeNull()
   })


### PR DESCRIPTION
Closes #125 (part of the [finish-or-remove map](https://github.com/brandhaug/b2b-saas-starter/issues/98)).

## What shipped

- **`/workspaces/$workspaceSlug/members`** route: the workspace roster with per-member role change, plus a **Members** entry in the workspace nav.
- **`member:update` goes declared → enforced.** Every role change composes `requireWorkspacePermission({ member: ['update'] })` server-side; denial surfaces as the standard `ForbiddenError` message.
- **Plugin-backed writes stay in the app** (ADR 0051): new `webMemberBinding` adapter (`src/lib/server/member-binding.ts`) maps the capability's `WorkspaceMemberBinding` port onto Better Auth's organization endpoints — `updateMemberRole` / `removeMember` take session headers, `addMember` runs headerless by design. The plugin validates each change and its lifecycle hooks run; the capability re-reads the member and records `workspace_member.role_changed` as before.

## Scope decision

Per discussion on the ticket: **ban is not included.** Better Auth's organization plugin has no member-level ban, and system-wide banning belongs to the `/admin` ticket (#128). The ticket's definition of done is met for the re-role half; "ban" is ruled out of this ticket rather than reinvented at the workspace layer.

## Definition of done check

- ✅ A member can be re-roled from the UI in provider-light dev (Seed layer answers client-side navigations; Live D1 locally via the persisted shim).
- ✅ The API denies it without the permission — owner/admin pass, member and actorless contexts get `AuthorizationDenied` (tested directly against fixture layers).

## Tests

- `workspace-members.test.ts`: loader payload for owner vs plain member (roster is not security posture — both see it), role-change ok/denied/no-principal cases.
- `member-binding.test.ts`: no-request branch rejects as *unavailable*, never *refused*, classified by the capability's own `readPluginBindingFailure`.
- Settings page test updated: the shell now carries a Members nav link, so the invitation-section absence assertion targets the invite field instead of the word "Members".

Full monorepo build + test green; oxlint/oxfmt clean.