### PR TITLE
refactor: deslop — dedup repeated logic and consolidate duplicated types

### DIFF
--- a/apps/api/src/handlers.ts
+++ b/apps/api/src/handlers.ts
@@ -308,6 +308,41 @@ export function workspaceGroup(env: ApiEnv) {
 }
 
 export function apiTokenGroup(env: ApiEnv) {
+  // `revoke` and `delete` are the same operation on this registry — the schema
+  // keeps both routes for REST-shape compatibility, and both answer
+  // identically. Only the wide-event name distinguishes them.
+  function revokeOrDelete(
+    event: 'api-tokens.revoke' | 'api-tokens.delete',
+    params: { readonly slug: string; readonly tokenId: string },
+    request: HttpServerRequest.HttpServerRequest
+  ) {
+    return observed(
+      env,
+      request,
+      event,
+      { workspaceSlug: params.slug },
+      Effect.gen(function* () {
+        yield* enforceRateLimit(request, 'rest_write')
+        yield* enforcePermission(request, { apiToken: ['revoke'] }, params.slug)
+        yield* provideWorkspace(
+          env,
+          params.slug,
+          Effect.gen(function* () {
+            const tokens = yield* ApiTokenRegistry
+            const revoked = yield* tokens.revoke({ tokenId: params.tokenId })
+            if (revoked) {
+              yield* publishWebhookEvent({
+                eventType: 'api_token.revoked',
+                payload: { tokenId: params.tokenId }
+              })
+            }
+          })
+        )
+        return TOKEN_REVOKED
+      })
+    )
+  }
+
   return HttpApiBuilder.group(StarterApi, 'api-token-registry', (handlers) =>
     handlers
       .handle('create', ({ params, payload, request }) =>
@@ -347,58 +382,10 @@ export function apiTokenGroup(env: ApiEnv) {
         )
       )
       .handle('revoke', ({ params, request }) =>
-        observed(
-          env,
-          request,
-          'api-tokens.revoke',
-          { workspaceSlug: params.slug },
-          Effect.gen(function* () {
-            yield* enforceRateLimit(request, 'rest_write')
-            yield* enforcePermission(request, { apiToken: ['revoke'] }, params.slug)
-            yield* provideWorkspace(
-              env,
-              params.slug,
-              Effect.gen(function* () {
-                const tokens = yield* ApiTokenRegistry
-                const revoked = yield* tokens.revoke({ tokenId: params.tokenId })
-                if (revoked) {
-                  yield* publishWebhookEvent({
-                    eventType: 'api_token.revoked',
-                    payload: { tokenId: params.tokenId }
-                  })
-                }
-              })
-            )
-            return TOKEN_REVOKED
-          })
-        )
+        revokeOrDelete('api-tokens.revoke', params, request)
       )
       .handle('delete', ({ params, request }) =>
-        observed(
-          env,
-          request,
-          'api-tokens.delete',
-          { workspaceSlug: params.slug },
-          Effect.gen(function* () {
-            yield* enforceRateLimit(request, 'rest_write')
-            yield* enforcePermission(request, { apiToken: ['revoke'] }, params.slug)
-            yield* provideWorkspace(
-              env,
-              params.slug,
-              Effect.gen(function* () {
-                const tokens = yield* ApiTokenRegistry
-                const revoked = yield* tokens.revoke({ tokenId: params.tokenId })
-                if (revoked) {
-                  yield* publishWebhookEvent({
-                    eventType: 'api_token.revoked',
-                    payload: { tokenId: params.tokenId }
-                  })
-                }
-              })
-            )
-            return TOKEN_REVOKED
-          })
-        )
+        revokeOrDelete('api-tokens.delete', params, request)
       )
   )
 }

--- a/apps/background/src/index.ts
+++ b/apps/background/src/index.ts
@@ -7,6 +7,7 @@ import {
   WideEventLoggerLive,
   withTriggerScope
 } from '@b2b-saas-starter/logger'
+import { bytesToHex } from '@b2b-saas-starter/capabilities/src/crypto.ts'
 import {
   selectCapabilitiesLayer,
   type StarterEnv
@@ -171,12 +172,6 @@ function nextAttemptAt(
   return null
 }
 
-function bytesToHex(bytes: ArrayBuffer): string {
-  return Array.from(new Uint8Array(bytes), (byte) =>
-    byte.toString(16).padStart(2, '0')
-  ).join('')
-}
-
 /**
  * Stripe-style signature: HMAC-SHA256 over `"<timestamp>.<body>"` with the
  * endpoint's plaintext signing secret, hex-encoded. Signing the timestamp
@@ -229,6 +224,59 @@ const WebhookDeliveryBody = Schema.Struct({
 const encodeDeliveryBody = Schema.encodeSync(Schema.fromJsonString(WebhookDeliveryBody))
 
 /**
+ * The envelope-decode preamble both consumers share: decode at the boundary,
+ * and on a malformed body annotate `skipReason: 'malformed_message'` on the
+ * wide event with the consumer's own outcome and yield nothing — there is no
+ * trusted endpointId for a delivery row, so the message is acked.
+ */
+function decodeEnvelope(
+  envelope: WebhookQueueEnvelope,
+  outcome: string
+): Effect.Effect<WebhookMessage | undefined, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const decoded = decodeWebhookQueueMessage(envelope.body)
+    if (Result.isFailure(decoded)) {
+      yield* annotateWide({ outcome, skipReason: 'malformed_message' })
+      return
+    }
+    return decoded.success
+  })
+}
+
+/** Fields every consumer stamps onto its wide event once decoded. */
+function annotateMessageFields(message: WebhookMessage) {
+  return annotateWide({
+    endpointId: message.endpointId,
+    workspaceId: message.workspaceId,
+    eventType: message.eventType
+  })
+}
+
+/**
+ * A terminal delivery row: no HTTP response to record and no next attempt.
+ * Shared by the invalid-URL branch of `processWebhookMessage` and
+ * `processDeadLetterMessage`.
+ */
+function terminalAttemptRow(input: {
+  readonly deliveryId: string
+  readonly endpointId: string
+  readonly message: WebhookMessage
+  readonly attempts: number
+  readonly status: 'failed_permanent' | 'dead_lettered'
+}) {
+  return {
+    id: input.deliveryId,
+    endpointId: input.endpointId,
+    workspaceId: input.message.workspaceId,
+    eventType: input.message.eventType,
+    status: input.status,
+    attempts: input.attempts,
+    responseStatus: null,
+    nextAttemptAt: null
+  }
+}
+
+/**
  * Delivers one webhook message: resolve the dispatch target, re-check the
  * SSRF guard, sign, POST, persist the attempt row, and decide ack/retry.
  * Capability and HTTP requirements stay open so tests inject stub
@@ -249,21 +297,10 @@ export function processWebhookMessage(
     // there is no trusted endpointId to attach a delivery row to, so it is
     // recorded on the wide event only and acked — mirroring how permanent
     // delivery failures ack instead of retrying forever.
-    const decoded = decodeWebhookQueueMessage(envelope.body)
-    if (Result.isFailure(decoded)) {
-      yield* annotateWide({
-        outcome: 'failed_permanent',
-        skipReason: 'malformed_message'
-      })
-      return 'ack' satisfies DeliveryOutcome
-    }
-    const message = decoded.success
+    const message = yield* decodeEnvelope(envelope, 'failed_permanent')
+    if (!message) return 'ack' satisfies DeliveryOutcome
     const attempts = envelope.attempts
-    yield* annotateWide({
-      endpointId: message.endpointId,
-      workspaceId: message.workspaceId,
-      eventType: message.eventType
-    })
+    yield* annotateMessageFields(message)
     const webhooks = yield* WebhookEndpoints
     // The workspace ID from the message is verified inside the capability:
     // a cross-workspace mismatch resolves null, same as a disabled or deleted
@@ -283,16 +320,15 @@ export function processWebhookMessage(
     // starter (see validateWebhookUrl).
     const urlCheck = validateWebhookUrl(target.url)
     if (!urlCheck.valid) {
-      yield* webhooks.recordDeliveryAttempt({
-        id: yield* newDeliveryId,
-        endpointId: target.id,
-        workspaceId: message.workspaceId,
-        eventType: message.eventType,
-        status: 'failed_permanent',
-        attempts,
-        responseStatus: null,
-        nextAttemptAt: null
-      })
+      yield* webhooks.recordDeliveryAttempt(
+        terminalAttemptRow({
+          deliveryId: yield* newDeliveryId,
+          endpointId: target.id,
+          message,
+          attempts,
+          status: 'failed_permanent'
+        })
+      )
       yield* annotateWide({
         outcome: 'failed_permanent',
         skipReason: `invalid_url: ${urlCheck.reason}`
@@ -394,31 +430,19 @@ export function processDeadLetterMessage(
   return Effect.gen(function* () {
     // Same boundary decode as `processWebhookMessage`: a malformed dead letter
     // has no trusted endpointId for a delivery row, so log-and-ack only.
-    const decoded = decodeWebhookQueueMessage(envelope.body)
-    if (Result.isFailure(decoded)) {
-      yield* annotateWide({
-        outcome: 'dead_lettered',
-        skipReason: 'malformed_message'
-      })
-      return
-    }
-    const message = decoded.success
-    yield* annotateWide({
-      endpointId: message.endpointId,
-      workspaceId: message.workspaceId,
-      eventType: message.eventType
-    })
+    const message = yield* decodeEnvelope(envelope, 'dead_lettered')
+    if (!message) return
+    yield* annotateMessageFields(message)
     const webhooks = yield* WebhookEndpoints
-    yield* webhooks.recordDeliveryAttempt({
-      id: yield* newDeliveryId,
-      endpointId: message.endpointId,
-      workspaceId: message.workspaceId,
-      eventType: message.eventType,
-      status: 'dead_lettered',
-      attempts: envelope.attempts,
-      responseStatus: null,
-      nextAttemptAt: null
-    })
+    yield* webhooks.recordDeliveryAttempt(
+      terminalAttemptRow({
+        deliveryId: yield* newDeliveryId,
+        endpointId: message.endpointId,
+        message,
+        attempts: envelope.attempts,
+        status: 'dead_lettered'
+      })
+    )
     yield* annotateWide({ outcome: 'dead_lettered' })
   })
 }

--- a/apps/web/src/components/auth/auth-submit-button.tsx
+++ b/apps/web/src/components/auth/auth-submit-button.tsx
@@ -1,0 +1,49 @@
+import { type ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * The only part of the form API the submit button reads. Structural so it
+ * accepts any `useForm` result regardless of its value/validator generics
+ * (`AnyFormApi` does not expose `Subscribe`).
+ */
+type SubscribableForm = {
+  readonly Subscribe: (props: {
+    readonly selector: (state: {
+      readonly canSubmit: boolean
+      readonly isSubmitting: boolean
+    }) => readonly [boolean, boolean]
+    readonly children: (state: readonly [boolean, boolean]) => ReactNode
+  }) => ReactNode | Promise<ReactNode>
+}
+
+/**
+ * The submit button every auth form renders: disabled until the form can
+ * submit, with a submitting label while it is in flight.
+ */
+export function AuthSubmitButton({
+  form,
+  icon,
+  label,
+  submittingLabel
+}: {
+  readonly form: SubscribableForm
+  readonly icon?: ReactNode
+  readonly label: string
+  readonly submittingLabel: string
+}) {
+  return (
+    <form.Subscribe
+      selector={(state): readonly [boolean, boolean] => [
+        state.canSubmit,
+        state.isSubmitting
+      ]}
+    >
+      {([canSubmit, isSubmitting]) => (
+        <Button type="submit" disabled={!canSubmit}>
+          {icon}
+          {isSubmitting ? submittingLabel : label}
+        </Button>
+      )}
+    </form.Subscribe>
+  )
+}

--- a/apps/web/src/components/auth/auth-validators.ts
+++ b/apps/web/src/components/auth/auth-validators.ts
@@ -1,0 +1,19 @@
+/**
+ * The field validators shared by the auth forms. Kept out of
+ * `auth-submit-button.tsx` so that file stays a components-only module.
+ */
+
+/**
+ * The email validator: required, and shaped like an address. Deliberately
+ * shallow — Better Auth owns the real check.
+ */
+export function emailValidator({ value }: { value: string }): string | undefined {
+  if (value.length === 0) return 'Email is required'
+  if (!value.includes('@')) return 'Enter a valid email'
+  return
+}
+
+/** The password validator: at least 8 characters. */
+export function passwordValidator({ value }: { value: string }): string | undefined {
+  return value.length < 8 ? 'Password must be at least 8 characters' : undefined
+}

--- a/apps/web/src/lib/permissions.ts
+++ b/apps/web/src/lib/permissions.ts
@@ -1,9 +1,9 @@
 import {
   authorize,
   memberPrincipal,
-  type PermissionRequest,
-  type WorkspaceRole
+  type PermissionRequest
 } from '@b2b-saas-starter/authz/src/client.ts'
+import { type WorkspaceViewer } from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
 
 /**
  * Client-side permission checks for workspace UI.
@@ -17,7 +17,7 @@ import {
  * is the enforcement, and every mutation still goes through
  * `requireWorkspacePermission` on the server.
  */
-export type Viewer = { readonly role: WorkspaceRole } | null
+export type Viewer = WorkspaceViewer | null
 
 export function viewerCan(viewer: Viewer, permission: PermissionRequest): boolean {
   if (!viewer) return false

--- a/apps/web/src/lib/server/auth-audit.ts
+++ b/apps/web/src/lib/server/auth-audit.ts
@@ -469,6 +469,48 @@ export type AuthAuditContext = {
  * (`authAuditError` / `authAuditBodyError`) before the outcome is returned, so
  * a dropped write is always queryable.
  */
+/**
+ * Reads an untrusted body value, reporting a decode failure on the wide event
+ * (`authAuditBodyError`) instead of failing: a body that does not parse still
+ * records an event — just an unattributed or untargeted one.
+ */
+function readAndReportBody<A>(
+  reader: Effect.Effect<A, AuthAuditBodyUnreadable>
+): Effect.Effect<A | null, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const parsed = yield* Effect.result(reader)
+    if (Result.isFailure(parsed)) {
+      yield* annotateWide({
+        authAuditBodyError: parsed.failure.reason,
+        authAuditBodyErrorTag: parsed.failure._tag
+      })
+      return null
+    }
+    return parsed.success
+  })
+}
+
+/**
+ * Writes one audit event best-effort: a failed write is annotated on the wide
+ * event (`authAuditError`) and reported as `dropped` rather than thrown.
+ */
+function writeAndReport(
+  input: RecordAuditEventInput,
+  run: RunAuditCapabilities
+): Effect.Effect<'recorded' | 'dropped', never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const written = yield* Effect.result(writeAuditEvent(input, run))
+    if (Result.isFailure(written)) {
+      yield* annotateWide({
+        authAuditError: written.failure.reason,
+        authAuditErrorTag: written.failure._tag
+      })
+      return 'dropped'
+    }
+    return 'recorded'
+  })
+}
+
 export function recordAuthAudit(
   request: Request,
   response: Response,
@@ -492,18 +534,10 @@ export function recordAuthAudit(
       // session read, or the event records unattributed.
       userId = context?.actorUserId ?? null
     } else if (response.ok && row.namesUserInResponse === true) {
-      const actor = yield* Effect.result(readActorUserId(response))
-      if (Result.isFailure(actor)) {
-        // A 2xx lifecycle response with a non-JSON body is unexpected. The
-        // event is still recorded, unattributed, and the reason lands on the
-        // wide event.
-        yield* annotateWide({
-          authAuditBodyError: actor.failure.reason,
-          authAuditBodyErrorTag: actor.failure._tag
-        })
-      } else {
-        userId = actor.success
-      }
+      // A 2xx lifecycle response with a non-JSON body is unexpected. The
+      // event is still recorded, unattributed, and the reason lands on the
+      // wide event.
+      userId = yield* readAndReportBody(readActorUserId(response))
     }
 
     const input = authAuditInput({
@@ -515,15 +549,7 @@ export function recordAuthAudit(
     })
     if (!input) return 'skipped'
 
-    const written = yield* Effect.result(writeAuditEvent(input, run))
-    if (Result.isFailure(written)) {
-      yield* annotateWide({
-        authAuditError: written.failure.reason,
-        authAuditErrorTag: written.failure._tag
-      })
-      return 'dropped'
-    }
-    return 'recorded'
+    return yield* writeAndReport(input, run)
   })
 }
 
@@ -545,28 +571,12 @@ function recordAdminAudit(args: {
 
     let targetUserId: string | null = null
     if (admin.request !== undefined) {
-      const parsed = yield* Effect.result(readTargetUserId(admin.request))
-      if (Result.isFailure(parsed)) {
-        // A request body that does not parse still records an event — just an
-        // untargeted one — with the reason on the wide event.
-        yield* annotateWide({
-          authAuditBodyError: parsed.failure.reason,
-          authAuditBodyErrorTag: parsed.failure._tag
-        })
-      } else {
-        targetUserId = parsed.success
-      }
+      // A request body that does not parse still records an event — just an
+      // untargeted one — with the reason on the wide event.
+      targetUserId = yield* readAndReportBody(readTargetUserId(admin.request))
     }
     if (targetUserId === null && response.ok && rowNamesUserInResponse(pathname)) {
-      const actor = yield* Effect.result(readActorUserId(response))
-      if (Result.isFailure(actor)) {
-        yield* annotateWide({
-          authAuditBodyError: actor.failure.reason,
-          authAuditBodyErrorTag: actor.failure._tag
-        })
-      } else {
-        targetUserId = actor.success
-      }
+      targetUserId = yield* readAndReportBody(readActorUserId(response))
     }
 
     const input = adminAuditInput({
@@ -577,15 +587,7 @@ function recordAdminAudit(args: {
     })
     if (!input) return 'skipped'
 
-    const written = yield* Effect.result(writeAuditEvent(input, run))
-    if (Result.isFailure(written)) {
-      yield* annotateWide({
-        authAuditError: written.failure.reason,
-        authAuditErrorTag: written.failure._tag
-      })
-      return 'dropped'
-    }
-    return 'recorded'
+    return yield* writeAndReport(input, run)
   })
 }
 

--- a/apps/web/src/lib/server/auth-emails.ts
+++ b/apps/web/src/lib/server/auth-emails.ts
@@ -25,7 +25,14 @@ import { type ReactElement } from 'react'
  * The log-mode dispatcher never fails; only a real, broken `EMAIL` binding
  * can, and failing loudly there is the honest behavior.
  */
-function emailDispatcherLayer() {
+/**
+ * Provider-light by the same selector the invitation flow uses (`invitations.ts`
+ * imports this): with no `EMAIL` binding configured this is the logging
+ * dispatcher, so password reset and email verification work end to end locally
+ * without an email provider — the link lands in the console log instead of an
+ * inbox.
+ */
+export function emailDispatcherLayer() {
   return selectEmailDispatcherLayer({
     EMAIL: cloudflareEnv.EMAIL,
     EMAIL_FROM_ADDRESS: cloudflareEnv.CLOUDFLARE_EMAIL_FROM

--- a/apps/web/src/lib/server/invitations.ts
+++ b/apps/web/src/lib/server/invitations.ts
@@ -14,13 +14,13 @@ import {
   type CapabilityUnavailable,
   type MembershipChangeRejected
 } from '@b2b-saas-starter/capabilities/src/errors.ts'
-import { EmailDispatcher, selectEmailDispatcherLayer } from '@b2b-saas-starter/email'
+import { EmailDispatcher } from '@b2b-saas-starter/email'
 import { WorkspaceInvitationEmail } from '@b2b-saas-starter/email/src/templates.tsx'
-import { env as cloudflareEnv } from 'cloudflare:workers'
 import { createServerFn } from '@tanstack/react-start'
 import { Effect, Option, Result, Schema, type Scope } from 'effect'
 import { runCapabilities, runWorkspaceCapabilities } from '../capabilities'
 import { currentRequest } from '../request-context'
+import { emailDispatcherLayer } from './auth-emails'
 import { requireRequestSession } from './auth'
 import { requireWorkspacePermission } from './authorize'
 import { webInvitationBinding } from './invitation-binding'
@@ -70,19 +70,6 @@ const AcceptInvitationInput = Schema.Struct({
 const decodeSend = Schema.decodeUnknownSync(SendInvitationInput)
 const decodeCancel = Schema.decodeUnknownSync(CancelInvitationInput)
 const decodeAccept = Schema.decodeUnknownSync(AcceptInvitationInput)
-
-/**
- * Provider-light by the same selector the API worker used to use: with no
- * `EMAIL` binding configured this is the logging dispatcher, so the invite flow
- * works end to end locally and in tests without an email provider (CLAUDE.md
- * rule 3).
- */
-function emailDispatcherLayer() {
-  return selectEmailDispatcherLayer({
-    EMAIL: cloudflareEnv.EMAIL,
-    EMAIL_FROM_ADDRESS: cloudflareEnv.CLOUDFLARE_EMAIL_FROM
-  })
-}
 
 /**
  * Absolute origin of the in-flight request, so the emailed link is clickable.

--- a/apps/web/src/lib/server/workspace-audit.ts
+++ b/apps/web/src/lib/server/workspace-audit.ts
@@ -5,7 +5,7 @@ import {
 } from '@b2b-saas-starter/capabilities/src/governance/audit-event-log.ts'
 import { WorkspaceContext } from '@b2b-saas-starter/capabilities/src/workspace-context.ts'
 import { WorkspaceMembership } from '@b2b-saas-starter/capabilities/src/governance/workspace-membership.ts'
-import { type WorkspaceRole } from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
+import { type WorkspaceViewer } from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
 import { Effect } from 'effect'
 
 import { runWorkspaceCapabilities } from '../capabilities'
@@ -45,7 +45,7 @@ export type LoadWorkspaceAuditEventsInput = {
  * and the hard gate above already decided who reaches this payload.
  */
 export type WorkspaceAuditPayload = {
-  readonly viewer: { readonly role: WorkspaceRole } | null
+  readonly viewer: WorkspaceViewer | null
   readonly events: readonly AuditEvent[]
   /** Opaque keyset cursor for the next older page, or null on the last one. */
   readonly nextCursor: string | null

--- a/apps/web/src/lib/server/workspace-dashboard.ts
+++ b/apps/web/src/lib/server/workspace-dashboard.ts
@@ -10,7 +10,7 @@ import {
   type WorkspaceDashboardProjection
 } from '@b2b-saas-starter/capabilities/src/workspace-projections.ts'
 import { type CapabilityUnavailable } from '@b2b-saas-starter/capabilities/src/errors.ts'
-import { type WorkspaceRole } from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
+import { type WorkspaceViewer } from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
 import { Effect, type Scope } from 'effect'
 
 import { runWorkspaceCapabilities } from '../capabilities'
@@ -24,7 +24,7 @@ import { requireWorkspacePermission, whenPermitted } from './authorize'
  * the app rather than in `@b2b-saas-starter/capabilities`.
  */
 export type WorkspaceDashboardPayload = WorkspaceDashboardProjection & {
-  readonly viewer: { readonly role: WorkspaceRole } | null
+  readonly viewer: WorkspaceViewer | null
   readonly webhooks: readonly WebhookEndpoint[] | null
 }
 

--- a/apps/web/src/lib/server/workspace-settings.ts
+++ b/apps/web/src/lib/server/workspace-settings.ts
@@ -8,7 +8,7 @@ import {
   WorkspaceInvitations,
   type Invitation
 } from '@b2b-saas-starter/capabilities/src/governance/workspace-invitations.ts'
-import { type WorkspaceRole } from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
+import { type WorkspaceViewer } from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
 import { Effect, type Scope } from 'effect'
 
 import { runWorkspaceCapabilities } from '../capabilities'
@@ -29,7 +29,7 @@ import { requireWorkspacePermission, whenPermitted } from './authorize'
  * shown a form that would only fail on submit.
  */
 export type WorkspaceSettingsPayload = {
-  readonly viewer: { readonly role: WorkspaceRole } | null
+  readonly viewer: WorkspaceViewer | null
   /** The workspace itself; every member may read its own name. */
   readonly workspaceName: string
   readonly unreadCount: number

--- a/apps/web/src/routes/forgot-password.tsx
+++ b/apps/web/src/routes/forgot-password.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useForm } from '@tanstack/react-form'
 import { MailQuestionIcon } from 'lucide-react'
+import { AuthSubmitButton } from '@/components/auth/auth-submit-button'
+import { emailValidator } from '@/components/auth/auth-validators'
 import { FormTextField } from '@/components/form-text-field'
 import { PublicLayout } from '@/components/public-layout'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { authClient } from '@/lib/auth-client'
 import { useHydrated } from '@/lib/client-only-value'
@@ -96,16 +97,7 @@ export function ForgotPasswordPage({
                 }}
                 className="grid gap-4"
               >
-                <form.Field
-                  name="email"
-                  validators={{
-                    onChange: ({ value }) => {
-                      if (value.length === 0) return 'Email is required'
-                      if (!value.includes('@')) return 'Enter a valid email'
-                      return
-                    }
-                  }}
-                >
+                <form.Field name="email" validators={{ onChange: emailValidator }}>
                   {(field) => (
                     <FormTextField
                       name={field.name}
@@ -122,19 +114,12 @@ export function ForgotPasswordPage({
                   )}
                 </form.Field>
 
-                <form.Subscribe
-                  selector={(state): readonly [boolean, boolean] => [
-                    state.canSubmit,
-                    state.isSubmitting
-                  ]}
-                >
-                  {([canSubmit, isSubmitting]) => (
-                    <Button type="submit" disabled={!canSubmit}>
-                      <MailQuestionIcon className="size-4" />
-                      {isSubmitting ? 'Sending…' : 'Send reset link'}
-                    </Button>
-                  )}
-                </form.Subscribe>
+                <AuthSubmitButton
+                  form={form}
+                  icon={<MailQuestionIcon className="size-4" />}
+                  label="Send reset link"
+                  submittingLabel="Sending…"
+                />
 
                 {submitError ? (
                   <p className="text-xs text-destructive" role="alert">

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -3,9 +3,10 @@ import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { useForm } from '@tanstack/react-form'
 import { Schema } from 'effect'
 import { KeyRoundIcon } from 'lucide-react'
+import { AuthSubmitButton } from '@/components/auth/auth-submit-button'
+import { passwordValidator } from '@/components/auth/auth-validators'
 import { FormTextField } from '@/components/form-text-field'
 import { PublicLayout } from '@/components/public-layout'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { authClient } from '@/lib/auth-client'
 import { useHydrated } from '@/lib/client-only-value'
@@ -150,15 +151,7 @@ export function ResetPasswordPage({
               }}
               className="grid gap-4"
             >
-              <form.Field
-                name="password"
-                validators={{
-                  onChange: ({ value }) =>
-                    value.length < 8
-                      ? 'Password must be at least 8 characters'
-                      : undefined
-                }}
-              >
+              <form.Field name="password" validators={{ onChange: passwordValidator }}>
                 {(field) => (
                   <FormTextField
                     name={field.name}
@@ -196,19 +189,12 @@ export function ResetPasswordPage({
                 )}
               </form.Field>
 
-              <form.Subscribe
-                selector={(state): readonly [boolean, boolean] => [
-                  state.canSubmit,
-                  state.isSubmitting
-                ]}
-              >
-                {([canSubmit, isSubmitting]) => (
-                  <Button type="submit" disabled={!canSubmit}>
-                    <KeyRoundIcon className="size-4" />
-                    {isSubmitting ? 'Resetting…' : 'Reset password'}
-                  </Button>
-                )}
-              </form.Subscribe>
+              <AuthSubmitButton
+                form={form}
+                icon={<KeyRoundIcon className="size-4" />}
+                label="Reset password"
+                submittingLabel="Resetting…"
+              />
 
               {submitError ? (
                 <p className="text-xs text-destructive" role="alert">

--- a/apps/web/src/routes/sign-in.tsx
+++ b/apps/web/src/routes/sign-in.tsx
@@ -3,9 +3,10 @@ import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { useForm } from '@tanstack/react-form'
 import { Schema } from 'effect'
 import { KeyRoundIcon } from 'lucide-react'
+import { AuthSubmitButton } from '@/components/auth/auth-submit-button'
+import { emailValidator, passwordValidator } from '@/components/auth/auth-validators'
 import { FormTextField } from '@/components/form-text-field'
 import { PublicLayout } from '@/components/public-layout'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { authClient } from '@/lib/auth-client'
 import { useHydrated } from '@/lib/client-only-value'
@@ -117,16 +118,7 @@ export function SignInPage({
               }}
               className="grid gap-4"
             >
-              <form.Field
-                name="email"
-                validators={{
-                  onChange: ({ value }) => {
-                    if (value.length === 0) return 'Email is required'
-                    if (!value.includes('@')) return 'Enter a valid email'
-                    return
-                  }
-                }}
-              >
+              <form.Field name="email" validators={{ onChange: emailValidator }}>
                 {(field) => (
                   <FormTextField
                     name={field.name}
@@ -143,15 +135,7 @@ export function SignInPage({
                 )}
               </form.Field>
 
-              <form.Field
-                name="password"
-                validators={{
-                  onChange: ({ value }) =>
-                    value.length < 8
-                      ? 'Password must be at least 8 characters'
-                      : undefined
-                }}
-              >
+              <form.Field name="password" validators={{ onChange: passwordValidator }}>
                 {(field) => (
                   <FormTextField
                     name={field.name}
@@ -167,19 +151,12 @@ export function SignInPage({
                 )}
               </form.Field>
 
-              <form.Subscribe
-                selector={(state): readonly [boolean, boolean] => [
-                  state.canSubmit,
-                  state.isSubmitting
-                ]}
-              >
-                {([canSubmit, isSubmitting]) => (
-                  <Button type="submit" disabled={!canSubmit}>
-                    <KeyRoundIcon className="size-4" />
-                    {isSubmitting ? 'Signing in…' : 'Continue'}
-                  </Button>
-                )}
-              </form.Subscribe>
+              <AuthSubmitButton
+                form={form}
+                icon={<KeyRoundIcon className="size-4" />}
+                label="Continue"
+                submittingLabel="Signing in…"
+              />
 
               <p className="text-right">
                 <Link

--- a/apps/web/src/routes/sign-up.tsx
+++ b/apps/web/src/routes/sign-up.tsx
@@ -3,9 +3,10 @@ import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { useForm } from '@tanstack/react-form'
 import { Schema } from 'effect'
 import { UserPlusIcon } from 'lucide-react'
+import { AuthSubmitButton } from '@/components/auth/auth-submit-button'
+import { emailValidator, passwordValidator } from '@/components/auth/auth-validators'
 import { FormTextField } from '@/components/form-text-field'
 import { PublicLayout } from '@/components/public-layout'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { authClient } from '@/lib/auth-client'
 import { useHydrated } from '@/lib/client-only-value'
@@ -148,16 +149,7 @@ export function SignUpPage({
                 )}
               </form.Field>
 
-              <form.Field
-                name="email"
-                validators={{
-                  onChange: ({ value }) => {
-                    if (value.length === 0) return 'Email is required'
-                    if (!value.includes('@')) return 'Enter a valid email'
-                    return
-                  }
-                }}
-              >
+              <form.Field name="email" validators={{ onChange: emailValidator }}>
                 {(field) => (
                   <FormTextField
                     name={field.name}
@@ -174,15 +166,7 @@ export function SignUpPage({
                 )}
               </form.Field>
 
-              <form.Field
-                name="password"
-                validators={{
-                  onChange: ({ value }) =>
-                    value.length < 8
-                      ? 'Password must be at least 8 characters'
-                      : undefined
-                }}
-              >
+              <form.Field name="password" validators={{ onChange: passwordValidator }}>
                 {(field) => (
                   <FormTextField
                     name={field.name}
@@ -198,19 +182,12 @@ export function SignUpPage({
                 )}
               </form.Field>
 
-              <form.Subscribe
-                selector={(state): readonly [boolean, boolean] => [
-                  state.canSubmit,
-                  state.isSubmitting
-                ]}
-              >
-                {([canSubmit, isSubmitting]) => (
-                  <Button type="submit" disabled={!canSubmit}>
-                    <UserPlusIcon className="size-4" />
-                    {isSubmitting ? 'Creating account…' : 'Create account'}
-                  </Button>
-                )}
-              </form.Subscribe>
+              <AuthSubmitButton
+                form={form}
+                icon={<UserPlusIcon className="size-4" />}
+                label="Create account"
+                submittingLabel="Creating account…"
+              />
 
               {submitError ? (
                 <p className="text-xs text-destructive" role="alert">

--- a/deslop-report.md
+++ b/deslop-report.md
@@ -1,0 +1,80 @@
+# Deslop Report — 2026-08-23
+
+Scope: all tracked `*.ts` / `*.tsx` in `b2b-saas-starter-deslop` (248 files). Tools: oxlint, tsc.
+Status: analysis only — no changes applied yet.
+
+## Summary
+
+| Category   | Findings | ≥0.7 confidence   | High severity |
+| ---------- | -------- | ----------------- | ------------- |
+| dedup      | 8        | 6                 | 1             |
+| types      | 2        | 1                 | 0             |
+| unused     | 12       | 5                 | 1             |
+| weak-types | 0        | —                 | —             |
+| defensive  | 2        | 0                 | 0             |
+| legacy     | 3        | 1 (informational) | 0             |
+| slop       | 2        | 1                 | 0             |
+
+## Deduplication
+
+| Conf | Sev  | Location                                                                                          | Issue                                                                                                                     |
+| ---- | ---- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 0.97 | high | `apps/api/src/handlers.ts:349-402`                                                                | `revoke` and `delete` api-token handlers byte-identical except event name — extract shared handler                        |
+| 0.93 | med  | `apps/web/src/lib/server/auth-emails.ts:29-35` + `invitations.ts:80-85`                           | identical `emailDispatcherLayer()` in two modules — consolidate                                                           |
+| 0.86 | med  | `packages/capabilities/src/governance/workspace-membership.ts:181-226` (+ invitations, lifecycle) | binding-failure classify/`callBinding` copy-pasted 3× across governance Live adapters — parameterized factory             |
+| 0.83 | med  | auth routes (`sign-in.tsx:120-199`, sign-up, forgot/reset-password)                               | email/password validators + submit-button block copy-pasted across 4 auth routes — shared validators + `AuthSubmitButton` |
+| 0.82 | med  | `apps/web/src/lib/server/auth-audit.ts:482-590`                                                   | repeated write-and-report and read-untrusted-body blocks within file — extract local helpers                              |
+| 0.78 | low  | `apps/background/src/index.ts:174-178`                                                            | `bytesToHex` re-implemented; exists in `packages/capabilities/src/internal/crypto.ts`                                     |
+| 0.72 | low  | `apps/background/src/index.ts:262-276,385-425`                                                    | dead-letter handler repeats webhook preamble — extract decode/terminal-row helpers                                        |
+| 0.70 | low  | governance seed layers ×3                                                                         | fabricated Member literal written 3× — `fabricateSeedMember()` helper                                                     |
+
+## Type consolidation
+
+| Conf | Sev | Location                                                | Issue                                                                                                  |
+| ---- | --- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 0.85 | med | `apps/web/src/lib/permissions.ts:20` + 3 server modules | `{ readonly role: WorkspaceRole } \| null` re-declared inline 4× — export named type from capabilities |
+| 0.70 | low | 4 governance `.contract.ts` files                       | `ContractExpect` duplicated with drifted matcher surfaces — shared base + per-contract pick            |
+
+## Unused code
+
+| Conf | Sev  | Location                                                             | Issue                                                                                                 |
+| ---- | ---- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 0.85 | high | `apps/web/src/components/code-block.tsx`                             | Dead file — `CodeBlock` never imported anywhere. May be intentional starter showcase surface; confirm |
+| 0.90 | med  | `apps/api/src/rate-limit.ts:68`                                      | unused re-export `clientKey`                                                                          |
+| 0.85 | med  | `apps/web/src/components/chart-defaults.ts:11-32`                    | `COMPACT_CHART_MARGIN`, `COMPACT_AXIS_TICK`, `COMPACT_TOOLTIP_STYLE` unused                           |
+| 0.80 | low  | `apps/api/src/rate-limit.ts:24`, `apps/web/src/lib/rate-limit.ts:25` | unused exported type alias `RateLimitInput` (both)                                                    |
+| 0.70 | low  | `apps/web/src/components/data-table.tsx:57`                          | `DataTableFeatures` only used internally — un-export                                                  |
+
+Needs review (<0.7): un-exported-but-maybe-intentional error types — `MissingD1Binding`, `AuthLive` (auth-runtime.ts), `CapabilityUnavailableError`/`ForbiddenError` re-export (capabilities.ts), `FORBIDDEN_ERROR_NAME` (capability-error.ts), `AuthAuditBodyUnreadable`/`AuthAuditWriteFailed` (auth-audit.ts), `UnauthorizedError` (server/auth.ts); `adminScopeRole` alias (authz/roles.ts, 0.4).
+
+## Weak types
+
+No findings. Only `as any` lives in generated `routeTree.gen.ts`; all `unknown` usage is properly narrowed at boundaries.
+
+## Defensive programming
+
+Both findings below threshold — needs review:
+
+- `packages/capabilities/src/developer-platform/webhook-publisher.ts:122` — identity `catch: (cause) => cause` widens without domain context (0.55)
+- `apps/web/src/routes/api.auth.$.ts:47-48` — best-effort session read `.catch(() => null)` at trust boundary (0.4)
+
+## Legacy
+
+Nothing clearly dead. Informational:
+
+- `apps/web/vite.config.ts:59-66` — workers-shim env guard effectively always-on via package scripts but reachable via bare vite (intentional escape hatch?) (0.55)
+- webhook-publisher queue schema "legacy in-flight shape" test — historical once old messages drain (0.6)
+- `cloudflare-workers-shim.ts` inert-in-prod — **intentional** (test bundle isolation), do not remove (0.9)
+
+## AI slop
+
+Comment quality is unusually high; no stubs, narrating comments, or commented-out code found.
+
+- `apps/web/src/routes/_app.workspaces_.index.tsx`-adjacent → actually `packages/capabilities/src/governance/workspace-lifecycle.ts:172-178` — if/else push loop should be a one-line map (0.8)
+- `apps/api/src/handlers.ts:377-397` — delete-as-revoke duplicate (overlaps dedup finding #1) (0.6)
+
+## Verified false positives (excluded)
+
+- `cloudflare-workers-shim*.ts` "unused files" — resolved by string alias in vite.config
+- Per-app rate-limit config wrappers — deliberate thin config over shared package
+- Seed-vs-Live capability layer duality — documented architecture

--- a/packages/capabilities/src/crypto.ts
+++ b/packages/capabilities/src/crypto.ts
@@ -1,0 +1,7 @@
+/**
+ * Public surface of the package's single Web Crypto boundary
+ * (`internal/crypto.ts`). Consumers outside this package — the background
+ * worker's webhook signature — import from here rather than reaching into
+ * `internal/`.
+ */
+export { bytesToHex } from './internal/crypto.ts'

--- a/packages/capabilities/src/governance/audit-event-log.contract.ts
+++ b/packages/capabilities/src/governance/audit-event-log.contract.ts
@@ -1,4 +1,5 @@
 import { Effect, Encoding } from 'effect'
+import { type ContractExpectMatchers } from './contract-expect.ts'
 import { type CapabilityUnavailable } from '../errors.ts'
 import {
   type AuditEventLog,
@@ -30,11 +31,9 @@ export type AuditEventLogContractCase = {
 }
 
 /** The slice of vitest's `expect` these cases use — see the lifecycle contract. */
-export type ContractExpect = <A>(actual: A) => {
-  readonly toBe: (expected: A) => void
-  readonly toEqual: (expected: A) => void
-  readonly toHaveLength: (expected: number) => void
-}
+export type ContractExpect = <A>(
+  actual: A
+) => Pick<ContractExpectMatchers<A>, 'toBe' | 'toEqual' | 'toHaveLength'>
 
 /**
  * The dataset every adapter installs before running the cases, all attributed

--- a/packages/capabilities/src/governance/contract-expect.ts
+++ b/packages/capabilities/src/governance/contract-expect.ts
@@ -1,0 +1,11 @@
+/**
+ * The full matcher surface the governance contracts draw from. Each contract
+ * file narrows this down on purpose with a `Pick`, so its cases can only
+ * reach for matchers the contract actually promises across adapters.
+ */
+export type ContractExpectMatchers<A> = {
+  readonly toBe: (expected: A) => void
+  readonly toEqual: (expected: A) => void
+  readonly toHaveLength: (expected: number) => void
+  readonly toContain: (expected: A) => void
+}

--- a/packages/capabilities/src/governance/plugin-binding-failure.ts
+++ b/packages/capabilities/src/governance/plugin-binding-failure.ts
@@ -1,4 +1,6 @@
-import { Option, Schema } from 'effect'
+import { Effect, Option, Schema } from 'effect'
+
+import { CapabilityUnavailable } from '../errors.ts'
 
 /**
  * The only shape this starter reads off a rejected Better Auth plugin call.
@@ -44,4 +46,49 @@ export function readPluginBindingFailure(cause: unknown): PluginBindingFailure {
     refusedByWorkspace: statusCode >= 400 && statusCode < 500,
     reason: reasonOf(cause)
   }
+}
+
+/**
+ * The shared shape of the governance Live adapters' plugin calls, built once
+ * per capability: the "no binding wired" error and a `callBinding` wrapper
+ * that classifies rejections through `readPluginBindingFailure`. A 4xx means
+ * the workspace declined the change on its merits — the caller's `Rejected`
+ * error — while anything else is the store failing (`CapabilityUnavailable`).
+ */
+export function makeBindingCaller<Binding, RejectedError>(options: {
+  readonly capability: string
+  readonly noBindingReason: string
+  readonly Rejected: new (args: { reason: string }) => RejectedError
+}) {
+  const noBinding = new CapabilityUnavailable({
+    capability: options.capability,
+    reason: options.noBindingReason
+  })
+
+  function classifyBindingFailure(
+    cause: unknown
+  ): CapabilityUnavailable | RejectedError {
+    const failure = readPluginBindingFailure(cause)
+    if (failure.refusedByWorkspace) {
+      return new options.Rejected({ reason: failure.reason })
+    }
+    return new CapabilityUnavailable({
+      capability: options.capability,
+      reason: failure.reason
+    })
+  }
+
+  /** Fails with `noBinding` when unset, else runs the call through the classifier. */
+  function callBinding(
+    binding: Binding | undefined,
+    call: (bound: Binding) => Promise<void>
+  ) {
+    if (!binding) return Effect.fail(noBinding)
+    return Effect.tryPromise({
+      try: () => call(binding),
+      catch: classifyBindingFailure
+    })
+  }
+
+  return { noBinding, callBinding }
 }

--- a/packages/capabilities/src/governance/workspace-identity.ts
+++ b/packages/capabilities/src/governance/workspace-identity.ts
@@ -30,6 +30,12 @@ export type WorkspaceRole = typeof WorkspaceRole.Type
 export const SystemRole = Schema.Literals(SYSTEM_ROLES)
 export type SystemRole = typeof SystemRole.Type
 
+/**
+ * The resolved viewer shape loaders hand to permission checks and UI: only
+ * the workspace role, or nothing when no viewer is signed in.
+ */
+export type WorkspaceViewer = { readonly role: WorkspaceRole }
+
 export const Workspace = Schema.Struct({
   id: Schema.String,
   slug: Schema.String,
@@ -46,6 +52,26 @@ export const Member = Schema.Struct({
   systemRole: SystemRole
 })
 export type Member = typeof Member.Type
+
+/**
+ * Fabricates the identity fields the seed fixtures have no `user` table to
+ * join, the way `SeedApiTokenRegistry.create` fabricates a token. The email is
+ * derived unless one is known — an accepted invitation carries its real
+ * address.
+ */
+export function fabricateSeedMember(
+  userId: string,
+  role: WorkspaceRole,
+  email?: string
+): Member {
+  return {
+    id: userId,
+    name: userId,
+    email: email ?? `${userId}@seed.local`,
+    role,
+    systemRole: 'user'
+  }
+}
 
 type MemberRow = {
   readonly member: typeof workspaceMembers.$inferSelect

--- a/packages/capabilities/src/governance/workspace-invitations.contract.ts
+++ b/packages/capabilities/src/governance/workspace-invitations.contract.ts
@@ -1,4 +1,5 @@
 import { Effect, Option } from 'effect'
+import { type ContractExpectMatchers } from './contract-expect.ts'
 import { type CapabilityUnavailable, type MembershipChangeRejected } from '../errors.ts'
 import { failureTag } from '../internal/failure-tag.ts'
 import { type WorkspaceContext } from '../workspace-context.ts'
@@ -74,7 +75,7 @@ export type InvitationContractCase = {
 }
 
 /** The slice of vitest's `expect` these cases use — narrow on purpose. */
-export type ContractExpect = <A>(actual: A) => { readonly toBe: (expected: A) => void }
+export type ContractExpect = <A>(actual: A) => Pick<ContractExpectMatchers<A>, 'toBe'>
 
 export function workspaceInvitationsContractCases(
   ids: InvitationContractIds,

--- a/packages/capabilities/src/governance/workspace-invitations.ts
+++ b/packages/capabilities/src/governance/workspace-invitations.ts
@@ -7,13 +7,17 @@ import {
 import { Context, DateTime, Effect, Layer, Option, Ref, Schema } from 'effect'
 import { and, eq } from 'drizzle-orm'
 
-import { CapabilityUnavailable, MembershipChangeRejected } from '../errors.ts'
+import { type CapabilityUnavailable, MembershipChangeRejected } from '../errors.ts'
 import { newCapabilityId } from '../internal/ids.ts'
 import { orUnavailable } from '../internal/unavailable.ts'
 import { WorkspaceContext } from '../workspace-context.ts'
 import { AuditEventLog } from './audit-event-log.ts'
-import { readPluginBindingFailure } from './plugin-binding-failure.ts'
-import { WorkspaceRole, type Member, type Workspace } from './workspace-identity.ts'
+import { makeBindingCaller } from './plugin-binding-failure.ts'
+import {
+  WorkspaceRole,
+  type Workspace,
+  fabricateSeedMember
+} from './workspace-identity.ts'
 import { type SeedRoster } from './workspace-membership.ts'
 
 export const InvitationStatus = Schema.Literals(invitationStatuses)
@@ -154,30 +158,14 @@ export type WorkspaceInvitationBinding = {
   readonly accept: (input: { readonly invitationId: string }) => Promise<void>
 }
 
-const noBinding = new CapabilityUnavailable({
+const { callBinding } = makeBindingCaller<
+  WorkspaceInvitationBinding,
+  MembershipChangeRejected
+>({
   capability: 'workspace-invitations',
-  reason: 'no_invitation_binding'
+  noBindingReason: 'no_invitation_binding',
+  Rejected: MembershipChangeRejected
 })
-
-/**
- * A 4xx from the plugin means the workspace refused the invitation — an address
- * that is already a member, an address already invited, a role it will not
- * accept. Anything else is the store failing. Same classification as
- * `workspace-membership.ts`, and getting it backwards tells a caller to retry a
- * request that can never succeed.
- */
-function classifyBindingFailure(
-  cause: unknown
-): CapabilityUnavailable | MembershipChangeRejected {
-  const failure = readPluginBindingFailure(cause)
-  if (failure.refusedByWorkspace) {
-    return new MembershipChangeRejected({ reason: failure.reason })
-  }
-  return new CapabilityUnavailable({
-    capability: 'workspace-invitations',
-    reason: failure.reason
-  })
-}
 
 /** How long a fixture invitation stays pending — the plugin's own 48 hours. */
 const SEED_INVITATION_TTL_MS = 48 * 60 * 60 * 1000
@@ -321,14 +309,9 @@ export function SeedWorkspaceInvitations(options: {
 
             yield* settle(store, input.invitationId, 'accepted')
             // No `user` table to join, so the fixture fabricates the identity
-            // fields the way `SeedWorkspaceMembership.addMember` does.
-            const joined: Member = {
-              id: input.userId,
-              name: input.userId,
-              email: input.email,
-              role: pending.role,
-              systemRole: 'user'
-            }
+            // fields the way `SeedWorkspaceMembership.addMember` does — but the
+            // invitation's real address is known, so it rides along.
+            const joined = fabricateSeedMember(input.userId, pending.role, input.email)
             yield* Ref.update(options.roster, (current) => [...current, joined])
             return {
               workspaceSlug: options.workspace.slug,
@@ -364,16 +347,6 @@ export function LiveWorkspaceInvitations(
       const audit = yield* AuditEventLog
 
       const unavailable = orUnavailable('workspace-invitations')
-
-      const callBinding = Effect.fnUntraced(function* (
-        call: (bound: WorkspaceInvitationBinding) => Promise<void>
-      ) {
-        if (!binding) return yield* Effect.fail(noBinding)
-        return yield* Effect.tryPromise({
-          try: () => call(binding),
-          catch: classifyBindingFailure
-        })
-      })
 
       /**
        * Reads the invitation back through the same table `list` reads, rather
@@ -466,7 +439,7 @@ export function LiveWorkspaceInvitations(
         create: (input) =>
           Effect.gen(function* () {
             const ctx = yield* WorkspaceContext
-            yield* callBinding((bound) =>
+            yield* callBinding(binding, (bound) =>
               bound.create({
                 workspaceId: ctx.workspace.id,
                 email: input.email,
@@ -494,7 +467,7 @@ export function LiveWorkspaceInvitations(
               ctx.workspace.id,
               input.invitationId
             )
-            yield* callBinding((bound) =>
+            yield* callBinding(binding, (bound) =>
               bound.cancel({ invitationId: input.invitationId })
             )
             yield* audit.record({
@@ -524,7 +497,7 @@ export function LiveWorkspaceInvitations(
 
             // The plugin settles the invitation and creates the member row in
             // one call; this capability never writes either itself.
-            yield* callBinding((bound) =>
+            yield* callBinding(binding, (bound) =>
               bound.accept({ invitationId: input.invitationId })
             )
             yield* audit.record({

--- a/packages/capabilities/src/governance/workspace-lifecycle.contract.ts
+++ b/packages/capabilities/src/governance/workspace-lifecycle.contract.ts
@@ -1,4 +1,5 @@
 import { Effect } from 'effect'
+import { type ContractExpectMatchers } from './contract-expect.ts'
 import { type CapabilityUnavailable, type WorkspaceChangeRejected } from '../errors.ts'
 import { failureTag } from '../internal/failure-tag.ts'
 import { type WorkspaceContext } from '../workspace-context.ts'
@@ -33,10 +34,9 @@ export type LifecycleContractCase = {
 }
 
 /** The slice of vitest's `expect` these cases use — see the membership contract. */
-export type ContractExpect = <A>(actual: A) => {
-  readonly toBe: (expected: A) => void
-  readonly toContain: (expected: A) => void
-}
+export type ContractExpect = <A>(
+  actual: A
+) => Pick<ContractExpectMatchers<A>, 'toBe' | 'toContain'>
 
 export function workspaceLifecycleContractCases(
   ids: LifecycleContractIds,

--- a/packages/capabilities/src/governance/workspace-lifecycle.ts
+++ b/packages/capabilities/src/governance/workspace-lifecycle.ts
@@ -2,14 +2,14 @@ import { Database } from '@b2b-saas-starter/db/src/service.ts'
 import { workspaces } from '@b2b-saas-starter/db/src/schema.ts'
 import { Context, Effect, Layer, Ref, Schema } from 'effect'
 import { eq } from 'drizzle-orm'
-import { CapabilityUnavailable, WorkspaceChangeRejected } from '../errors.ts'
+import { type CapabilityUnavailable, WorkspaceChangeRejected } from '../errors.ts'
 import { newCapabilityId } from '../internal/ids.ts'
 import { orUnavailable } from '../internal/unavailable.ts'
 import { WorkspaceContext } from '../workspace-context.ts'
 import { AuditEventLog } from './audit-event-log.ts'
-import { readPluginBindingFailure } from './plugin-binding-failure.ts'
+import { makeBindingCaller } from './plugin-binding-failure.ts'
 import { type SeedRoster } from './workspace-membership.ts'
-import { type Member, Workspace } from './workspace-identity.ts'
+import { Workspace, fabricateSeedMember } from './workspace-identity.ts'
 
 export const CreatedWorkspace = Schema.Struct({
   ...Workspace.fields,
@@ -84,34 +84,14 @@ export type WorkspaceLifecycleBinding = {
   readonly remove: (input: { readonly workspaceId: string }) => Promise<void>
 }
 
-const noBinding = new CapabilityUnavailable({
+const { callBinding } = makeBindingCaller<
+  WorkspaceLifecycleBinding,
+  WorkspaceChangeRejected
+>({
   capability: 'workspace-lifecycle',
-  reason: 'no_lifecycle_binding'
+  noBindingReason: 'no_lifecycle_binding',
+  Rejected: WorkspaceChangeRejected
 })
-
-function classifyBindingFailure(
-  cause: unknown
-): CapabilityUnavailable | WorkspaceChangeRejected {
-  const failure = readPluginBindingFailure(cause)
-  if (failure.refusedByWorkspace) {
-    return new WorkspaceChangeRejected({ reason: failure.reason })
-  }
-  return new CapabilityUnavailable({
-    capability: 'workspace-lifecycle',
-    reason: failure.reason
-  })
-}
-
-/** Fabricates the identity fields the fixture has no `user` table to join. */
-function seedOwnerMember(userId: string): Member {
-  return {
-    id: userId,
-    name: userId,
-    email: `${userId}@seed.local`,
-    role: 'owner',
-    systemRole: 'user'
-  }
-}
 
 /**
  * In-memory lifecycle, never Better Auth. Created workspaces land in a local
@@ -158,7 +138,9 @@ export function SeedWorkspaceLifecycle(options: {
             if (options.roster) {
               yield* Ref.update(options.roster, (members) => [
                 ...members,
-                seedOwnerMember(input.userId)
+                // Fabricates the identity fields the fixture has no `user`
+                // table to join; the creator enters as owner.
+                fabricateSeedMember(input.userId, 'owner')
               ])
             }
             return workspace
@@ -201,16 +183,6 @@ export function LiveWorkspaceLifecycle(
 
       const unavailable = orUnavailable('workspace-lifecycle')
 
-      const callBinding = Effect.fnUntraced(function* (
-        call: (bound: WorkspaceLifecycleBinding) => Promise<void>
-      ) {
-        if (!binding) return yield* Effect.fail(noBinding)
-        return yield* Effect.tryPromise({
-          try: () => call(binding),
-          catch: classifyBindingFailure
-        })
-      })
-
       /** Reads the workspace back rather than trusting the binding's response. */
       const readBySlug = Effect.fnUntraced(function* (slug: string) {
         const rows = yield* unavailable(
@@ -233,7 +205,7 @@ export function LiveWorkspaceLifecycle(
       return {
         create: (input) =>
           Effect.gen(function* () {
-            yield* callBinding((bound) => bound.create(input))
+            yield* callBinding(binding, (bound) => bound.create(input))
             const workspace = yield* readBySlug(input.slug)
             // Not atomic with the write above, and it cannot be — the same
             // accepted ADR 0051 trade the other plugin-backed capabilities
@@ -251,7 +223,7 @@ export function LiveWorkspaceLifecycle(
         rename: (input) =>
           Effect.gen(function* () {
             const ctx = yield* WorkspaceContext
-            yield* callBinding((bound) =>
+            yield* callBinding(binding, (bound) =>
               bound.rename({ workspaceId: ctx.workspace.id, name: input.name })
             )
             // The plugin's response shape is not this package's contract; the
@@ -291,7 +263,9 @@ export function LiveWorkspaceLifecycle(
           // cascaded children, and the audit event must still name what was
           // removed.
           const removed = ctx.workspace
-          yield* callBinding((bound) => bound.remove({ workspaceId: ctx.workspace.id }))
+          yield* callBinding(binding, (bound) =>
+            bound.remove({ workspaceId: ctx.workspace.id })
+          )
           // A system event on purpose: `audit_events.workspace_id` cascades from
           // `workspaces.id`, so attributing this row to the deleted workspace
           // would delete it alongside the thing it describes.

--- a/packages/capabilities/src/governance/workspace-membership.contract.ts
+++ b/packages/capabilities/src/governance/workspace-membership.contract.ts
@@ -1,4 +1,5 @@
 import { Effect } from 'effect'
+import { type ContractExpectMatchers } from './contract-expect.ts'
 import { type CapabilityUnavailable, type MembershipChangeRejected } from '../errors.ts'
 import { failureTag } from '../internal/failure-tag.ts'
 import { type WorkspaceContext } from '../workspace-context.ts'
@@ -42,7 +43,7 @@ export type MembershipContractCase = {
  * the matcher surface is usually asserting something only one adapter can
  * promise.
  */
-export type ContractExpect = <A>(actual: A) => { readonly toBe: (expected: A) => void }
+export type ContractExpect = <A>(actual: A) => Pick<ContractExpectMatchers<A>, 'toBe'>
 
 export function workspaceMembershipContractCases(
   ids: MembershipContractIds,

--- a/packages/capabilities/src/governance/workspace-membership.ts
+++ b/packages/capabilities/src/governance/workspace-membership.ts
@@ -2,12 +2,13 @@ import { Database } from '@b2b-saas-starter/db/src/service.ts'
 import { user, workspaceMembers, workspaces } from '@b2b-saas-starter/db/src/schema.ts'
 import { Context, Effect, Layer, Ref, Schema } from 'effect'
 import { and, eq } from 'drizzle-orm'
-import { CapabilityUnavailable, MembershipChangeRejected } from '../errors.ts'
+import { type CapabilityUnavailable, MembershipChangeRejected } from '../errors.ts'
 import { orUnavailable } from '../internal/unavailable.ts'
 import { WorkspaceContext } from '../workspace-context.ts'
 import { AuditEventLog } from './audit-event-log.ts'
-import { readPluginBindingFailure } from './plugin-binding-failure.ts'
+import { makeBindingCaller } from './plugin-binding-failure.ts'
 import {
+  fabricateSeedMember,
   findWorkspaceMember,
   Member,
   toMember,
@@ -132,13 +133,7 @@ export function SeedWorkspaceMembership(
       Effect.gen(function* () {
         // No `user` table to join, so the fixture fabricates the identity
         // fields the way `SeedApiTokenRegistry.create` fabricates a token.
-        const added: Member = {
-          id: input.userId,
-          name: input.userId,
-          email: `${input.userId}@seed.local`,
-          role: input.role,
-          systemRole: 'user'
-        }
+        const added = fabricateSeedMember(input.userId, input.role)
         yield* Ref.update(roster, (current) => [...current, added])
         return added
       }),
@@ -178,7 +173,7 @@ export function SeedWorkspaceMembership(
  *
  * Promise-returning on purpose: an Effect-shaped port would have to name the
  * plugin's error type, which is exactly the leak this avoids. Rejections are
- * classified by `classifyBindingFailure` below.
+ * classified by `makeBindingCaller`'s `callBinding`.
  *
  * Resolving to `void`, not to the plugin's response: the capability re-reads the
  * member from D1 after every call, because the plugin's own response shape is
@@ -201,30 +196,14 @@ export type WorkspaceMemberBinding = {
   }) => Promise<void>
 }
 
-const noBinding = new CapabilityUnavailable({
+const { callBinding } = makeBindingCaller<
+  WorkspaceMemberBinding,
+  MembershipChangeRejected
+>({
   capability: 'workspace-membership',
-  reason: 'no_member_binding'
+  noBindingReason: 'no_member_binding',
+  Rejected: MembershipChangeRejected
 })
-
-/**
- * A refusal from the plugin means the workspace declined the change — an
- * unknown user, a role it will not accept. Anything else (a dropped connection,
- * a thrown TypeError) is the store failing, which is what
- * `CapabilityUnavailable` means. `readPluginBindingFailure` owns that reading;
- * `workspace-invitations.ts` classifies its own binding through the same call.
- */
-function classifyBindingFailure(
-  cause: unknown
-): CapabilityUnavailable | MembershipChangeRejected {
-  const failure = readPluginBindingFailure(cause)
-  if (failure.refusedByWorkspace) {
-    return new MembershipChangeRejected({ reason: failure.reason })
-  }
-  return new CapabilityUnavailable({
-    capability: 'workspace-membership',
-    reason: failure.reason
-  })
-}
 
 export function LiveWorkspaceMembership(
   binding?: WorkspaceMemberBinding
@@ -280,16 +259,6 @@ export function LiveWorkspaceMembership(
         return member
       })
 
-      const callBinding = Effect.fnUntraced(function* (
-        call: (bound: WorkspaceMemberBinding) => Promise<void>
-      ) {
-        if (!binding) return yield* Effect.fail(noBinding)
-        return yield* Effect.tryPromise({
-          try: () => call(binding),
-          catch: classifyBindingFailure
-        })
-      })
-
       return {
         listMembers: Effect.gen(function* () {
           const ctx = yield* WorkspaceContext
@@ -326,7 +295,7 @@ export function LiveWorkspaceMembership(
         addMember: (input) =>
           Effect.gen(function* () {
             const ctx = yield* WorkspaceContext
-            yield* callBinding((bound) =>
+            yield* callBinding(binding, (bound) =>
               bound.addMember({
                 workspaceId: ctx.workspace.id,
                 userId: input.userId,
@@ -352,7 +321,7 @@ export function LiveWorkspaceMembership(
           Effect.gen(function* () {
             const ctx = yield* WorkspaceContext
             const memberId = yield* resolveMemberId(ctx.workspace.id, input.userId)
-            yield* callBinding((bound) =>
+            yield* callBinding(binding, (bound) =>
               bound.removeMember({ workspaceId: ctx.workspace.id, memberId })
             )
             yield* audit.record({
@@ -367,7 +336,7 @@ export function LiveWorkspaceMembership(
           Effect.gen(function* () {
             const ctx = yield* WorkspaceContext
             const memberId = yield* resolveMemberId(ctx.workspace.id, input.userId)
-            yield* callBinding((bound) =>
+            yield* callBinding(binding, (bound) =>
               bound.changeRole({
                 workspaceId: ctx.workspace.id,
                 memberId,


### PR DESCRIPTION
## Summary
Applies the **deduplication** and **type-consolidation** findings from a full-codebase deslop sweep (analysis report in `deslop-report.md`). Behavior unchanged.

### Deduplication (8 fixes)
- `apps/api`: one shared implementation for the byte-identical api-token `revoke`/`delete` handlers; both routes kept
- `packages/capabilities` (governance): new `makeBindingCaller` factory replaces 3× copy-pasted binding-failure glue in membership/invitations/lifecycle adapters; `fabricateSeedMember()` replaces 3× duplicated seed Member literals
- `apps/web/server`: single shared `emailDispatcherLayer`; extracted `readAndReportBody`/`writeAndReport` helpers in `auth-audit.ts`
- `apps/web/auth routes`: shared `emailValidator`/`passwordValidator` + new `AuthSubmitButton` component across sign-in/sign-up/forgot/reset
- `apps/background`: reuse exported `bytesToHex`; extracted `decodeEnvelope`/`annotateMessageFields`/`terminalAttemptRow` shared by webhook and dead-letter processing

### Type consolidation (2 fixes)
- `WorkspaceViewer` exported from capabilities and reused in permissions + workspace dashboard/audit/settings modules
- Shared `ContractExpectMatchers` base; each governance contract file derives its intentionally-narrowed alias via `Pick`

## Verification
- `bun run build` ✅ · `bun run test` ✅ (25/25 suites) · typecheck ✅ · oxlint ✅

Full findings inventory (incl. deferred/quarantined items) in `deslop-report.md`.