### PR TITLE
feat(web): webhook management UI (register, deliveries, disable, rotate)

### DIFF
--- a/apps/api/src/handlers.ts
+++ b/apps/api/src/handlers.ts
@@ -419,16 +419,17 @@ export function webhookGroup(env: ApiEnv) {
             params.slug,
             Effect.gen(function* () {
               const webhooks = yield* WebhookEndpoints
-              const endpoint = yield* webhooks.create({
+              const createdEndpoint = yield* webhooks.create({
                 url: payload.url,
                 events: payload.events,
                 description: payload.description
               })
               yield* publishWebhookEvent({
                 eventType: 'webhook_endpoint.created',
-                payload: endpoint
+                // The projection, never the signing secret.
+                payload: createdEndpoint.endpoint
               })
-              return endpoint
+              return createdEndpoint.endpoint
             })
           )
           yield* annotateWide({ webhookEndpointId: created.id })

--- a/apps/background/src/index.test.ts
+++ b/apps/background/src/index.test.ts
@@ -111,6 +111,7 @@ function stubEndpoints(
     create: () => Effect.die('unused in delivery tests'),
     disable: () => Effect.die('unused in delivery tests'),
     rotateSecret: () => Effect.die('unused in delivery tests'),
+    listDeliveries: () => Effect.die('unused in delivery tests'),
     getDispatchTarget: (endpointId, workspaceId) =>
       Effect.succeed(resolveTarget(dispatchTarget, endpointId, workspaceId)),
     recordDeliveryAttempt: (input) =>

--- a/apps/web/src/components/webhook-form.tsx
+++ b/apps/web/src/components/webhook-form.tsx
@@ -1,0 +1,198 @@
+import {
+  WEBHOOK_EVENT_TYPES,
+  type CreatedWebhookEndpoint,
+  type WebhookEventType
+} from '@b2b-saas-starter/capabilities/src/developer-platform/webhook-endpoints.ts'
+import { useState } from 'react'
+import { useForm } from '@tanstack/react-form'
+import { Cause, Effect, Exit, Option } from 'effect'
+
+import { FormTextField } from '@/components/form-text-field'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { causeMessage } from '@/lib/cause-message'
+import { createWebhookEndpointServerFn } from '@/lib/server/webhooks'
+
+const CREATE_WEBHOOK_FAILED = 'Failed to create webhook endpoint'
+
+type WebhookValues = {
+  url: string
+  events: readonly WebhookEventType[]
+}
+
+const DEFAULT_VALUES: WebhookValues = {
+  url: '',
+  events: ['api_token.created']
+}
+
+function validateUrl(value: string): string | undefined {
+  if (value.trim().length === 0) return 'Endpoint URL is required'
+  return
+}
+
+/**
+ * The one server call this form makes, as a port. Injected rather than imported
+ * at the call site so a test drives the form with a real function of this shape
+ * instead of replacing the module it lives in. The default is the production
+ * server function, so every caller but a test passes nothing.
+ */
+export type CreateWebhookEndpoint = (input: {
+  readonly data: {
+    readonly workspaceSlug: string
+    readonly url: string
+    readonly events: readonly string[]
+  }
+}) => Promise<CreatedWebhookEndpoint>
+
+export function WebhookForm({
+  workspaceSlug,
+  onCreated,
+  createEndpoint = createWebhookEndpointServerFn
+}: {
+  readonly workspaceSlug: string
+  readonly onCreated?: (created: CreatedWebhookEndpoint) => void
+  readonly createEndpoint?: CreateWebhookEndpoint
+}) {
+  const [created, setCreated] = useState<CreatedWebhookEndpoint | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const form = useForm({
+    defaultValues: DEFAULT_VALUES,
+    onSubmit: async ({ value }) => {
+      setSubmitError(null)
+      // The server function rejects when the capability or the SSRF guard
+      // fails. `Effect.tryPromise` moves that rejection into the error channel
+      // as a display message, so the failure path is a value not a try/catch.
+      const exit = await Effect.runPromiseExit(
+        Effect.tryPromise({
+          try: () =>
+            createEndpoint({
+              data: {
+                workspaceSlug,
+                url: value.url,
+                events: value.events
+              }
+            }),
+          catch: (cause) => causeMessage(cause, CREATE_WEBHOOK_FAILED)
+        })
+      )
+
+      if (Exit.isFailure(exit)) {
+        setSubmitError(
+          Option.getOrElse(
+            Cause.findErrorOption(exit.cause),
+            () => CREATE_WEBHOOK_FAILED
+          )
+        )
+        return
+      }
+      setCreated(exit.value)
+      onCreated?.(exit.value)
+      form.reset()
+    }
+  })
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        void form.handleSubmit()
+      }}
+      className="grid gap-4"
+    >
+      <form.Field
+        name="url"
+        validators={{ onChange: ({ value }) => validateUrl(value) }}
+      >
+        {(field) => (
+          <FormTextField
+            name={field.name}
+            label="Endpoint URL"
+            value={field.state.value}
+            errors={field.state.meta.errors}
+            onBlur={field.handleBlur}
+            onChange={field.handleChange}
+            placeholder="https://example.com/hooks/b2b-starter"
+          />
+        )}
+      </form.Field>
+
+      <form.Field
+        name="events"
+        validators={{
+          onChange: ({ value }) =>
+            value.length === 0 ? 'Pick at least one event' : undefined
+        }}
+      >
+        {(field) => {
+          const hasError = field.state.meta.errors.length > 0
+          const errorId = `${field.name}-error`
+          return (
+            <fieldset
+              className="grid gap-2"
+              aria-invalid={hasError}
+              aria-describedby={hasError ? errorId : undefined}
+            >
+              <legend className="text-sm font-medium leading-none">Events</legend>
+              <div className="flex flex-wrap gap-3">
+                {WEBHOOK_EVENT_TYPES.map((eventType) => {
+                  const checked = field.state.value.includes(eventType)
+                  return (
+                    <Label key={eventType} className="text-sm">
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={(next) => {
+                          const isChecked = next
+                          field.handleChange(
+                            isChecked
+                              ? [...new Set([...field.state.value, eventType])]
+                              : field.state.value.filter((item) => item !== eventType)
+                          )
+                        }}
+                      />
+
+                      <span>{eventType}</span>
+                    </Label>
+                  )
+                })}
+              </div>
+              {hasError ? (
+                <p id={errorId} className="text-xs text-destructive">
+                  {field.state.meta.errors.join(', ')}
+                </p>
+              ) : null}
+            </fieldset>
+          )
+        }}
+      </form.Field>
+
+      <form.Subscribe
+        selector={(state): readonly [boolean, boolean] => [
+          state.canSubmit,
+          state.isSubmitting
+        ]}
+      >
+        {([canSubmit, isSubmitting]) => (
+          <Button type="submit" disabled={!canSubmit} className="justify-self-start">
+            {isSubmitting ? 'Creating…' : 'Create endpoint'}
+          </Button>
+        )}
+      </form.Subscribe>
+
+      {created ? (
+        <div className="grid gap-1 rounded-md border border-border bg-muted/40 p-3 text-xs">
+          <p className="font-medium">
+            Endpoint created. Copy the signing secret now, it will not be shown again.
+          </p>
+          <code className="break-all">{created.signingSecret}</code>
+        </div>
+      ) : null}
+      {submitError ? (
+        <p className="text-xs text-destructive" role="alert">
+          {submitError}
+        </p>
+      ) : null}
+    </form>
+  )
+}

--- a/apps/web/src/components/webhooks-panel.tsx
+++ b/apps/web/src/components/webhooks-panel.tsx
@@ -1,0 +1,259 @@
+import {
+  type WebhookDelivery,
+  type WebhookEndpoint
+} from '@b2b-saas-starter/capabilities/src/developer-platform/webhook-endpoints.ts'
+import { useState } from 'react'
+import { useRouter } from '@tanstack/react-router'
+import { Cause, Effect, Exit, Option } from 'effect'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { WebhookForm, type CreateWebhookEndpoint } from '@/components/webhook-form'
+import { causeMessage } from '@/lib/cause-message'
+import { viewerCan, type Viewer } from '@/lib/permissions'
+import {
+  disableWebhookEndpointServerFn,
+  rotateWebhookSecretServerFn
+} from '@/lib/server/webhooks'
+
+const DISABLE_FAILED = 'Failed to disable endpoint'
+const ROTATE_FAILED = 'Failed to rotate secret'
+
+/**
+ * Mutating an endpoint, as a port. Injected rather than imported at the call
+ * site so a test drives the panel with real functions of these shapes instead
+ * of replacing the module they live in. The defaults are the production server
+ * functions, so every caller but a test passes nothing.
+ */
+export type DisableWebhookEndpoint = (input: {
+  readonly data: {
+    readonly workspaceSlug: string
+    readonly endpointId: string
+  }
+}) => Promise<boolean>
+
+export type RotateWebhookSecret = (input: {
+  readonly data: {
+    readonly workspaceSlug: string
+    readonly endpointId: string
+  }
+}) => Promise<string | null>
+
+// An explicit locale and timezone keeps SSR and the browser in agreement.
+function formatDate(iso: string | null): string {
+  if (iso === null) return 'never'
+  return new Date(iso).toLocaleString('en-US', { timeZone: 'UTC' })
+}
+
+// A fallback keeps unknown free-text statuses visible rather than crashing
+// the render — the column is free-text by design.
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline'
+function statusVariant(status: string): BadgeVariant {
+  if (status === 'delivered') return 'default'
+  if (status === 'failed') return 'secondary'
+  return 'destructive'
+}
+
+function Deliveries({
+  deliveries
+}: {
+  readonly deliveries: readonly WebhookDelivery[]
+}) {
+  if (deliveries.length === 0) {
+    return <p className="text-xs text-muted-foreground">No delivery attempts yet.</p>
+  }
+  return (
+    <ul className="grid gap-1">
+      {deliveries.map((delivery) => (
+        <li key={delivery.id} className="flex items-center gap-2 text-xs">
+          <Badge variant={statusVariant(delivery.status)}>{delivery.status}</Badge>
+          <span className="font-mono">{delivery.eventType}</span>
+          <span className="text-muted-foreground">
+            attempt {delivery.attempts}
+            {delivery.responseStatus === null
+              ? ''
+              : ` · ${delivery.responseStatus}`} ·{' '}
+            {formatDate(delivery.lastAttemptAt)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/**
+ * The workspace's webhook endpoints: create (secret shown once), list with
+ * recent deliveries, disable, rotate secret. Presentation only — the controls
+ * render when the role authorizes them, and every mutation is re-checked
+ * server-side by `requireWorkspacePermission` in its server fn.
+ */
+export function WebhooksPanel({
+  workspaceSlug,
+  endpoints,
+  viewer,
+  disableEndpoint = disableWebhookEndpointServerFn,
+  rotateSecret = rotateWebhookSecretServerFn,
+  createEndpoint
+}: {
+  readonly workspaceSlug: string
+  readonly endpoints: readonly (WebhookEndpoint & {
+    readonly deliveries: readonly WebhookDelivery[]
+  })[]
+  readonly viewer: Viewer
+  readonly disableEndpoint?: DisableWebhookEndpoint
+  readonly rotateSecret?: RotateWebhookSecret
+  readonly createEndpoint?: CreateWebhookEndpoint
+}) {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [rotatedSecret, setRotatedSecret] = useState<{
+    readonly endpointId: string
+    readonly secret: string
+  } | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const canCreate = viewerCan(viewer, { webhook: ['create'] })
+  const canDisable = viewerCan(viewer, { webhook: ['disable'] })
+  const canRotate = viewerCan(viewer, { webhook: ['rotateSecret'] })
+
+  async function disable(endpointId: string) {
+    setError(null)
+    setBusy(endpointId)
+    const exit = await Effect.runPromiseExit(
+      Effect.tryPromise({
+        try: () => disableEndpoint({ data: { workspaceSlug, endpointId } }),
+        catch: (cause) => causeMessage(cause, DISABLE_FAILED)
+      })
+    )
+    setBusy(null)
+    if (Exit.isFailure(exit)) {
+      setError(
+        Option.getOrElse(Cause.findErrorOption(exit.cause), () => DISABLE_FAILED)
+      )
+      return
+    }
+    // The loader owns the list, so re-run it rather than mirroring the change
+    // into local state.
+    await router.invalidate()
+  }
+
+  async function rotate(endpointId: string) {
+    setError(null)
+    setRotatedSecret(null)
+    setBusy(endpointId)
+    const exit = await Effect.runPromiseExit(
+      Effect.tryPromise({
+        try: () => rotateSecret({ data: { workspaceSlug, endpointId } }),
+        catch: (cause) => causeMessage(cause, ROTATE_FAILED)
+      })
+    )
+    setBusy(null)
+    if (Exit.isFailure(exit)) {
+      setError(Option.getOrElse(Cause.findErrorOption(exit.cause), () => ROTATE_FAILED))
+      return
+    }
+    // `null` means no endpoint matched in this workspace — nothing was
+    // rotated and there is no secret to show.
+    if (exit.value !== null) setRotatedSecret({ endpointId, secret: exit.value })
+    await router.invalidate()
+  }
+
+  return (
+    <div className="grid gap-6">
+      {canCreate ? (
+        <div className="grid gap-2">
+          <h2 className="text-sm font-medium">Register an endpoint</h2>
+          <WebhookForm
+            workspaceSlug={workspaceSlug}
+            onCreated={() => void router.invalidate()}
+            {...(createEndpoint === undefined ? {} : { createEndpoint })}
+          />
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Your role cannot register endpoints.
+        </p>
+      )}
+
+      <div className="grid gap-2">
+        <h2 className="text-sm font-medium">Endpoints</h2>
+        {endpoints.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No endpoints registered.</p>
+        ) : (
+          <ul className="grid gap-3">
+            {endpoints.map((endpoint) => (
+              <li
+                key={endpoint.id}
+                className="grid gap-2 rounded-md border border-border p-3"
+              >
+                <div className="grid gap-0.5">
+                  <p className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                    <code className="break-all">{endpoint.url}</code>
+                    {endpoint.enabled ? (
+                      <Badge variant="outline">enabled</Badge>
+                    ) : (
+                      <Badge variant="secondary">disabled</Badge>
+                    )}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Success rate {endpoint.successRate}%
+                  </p>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {endpoint.events.map((event) => (
+                      <Badge key={event} variant="outline">
+                        {event}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+
+                <Deliveries deliveries={endpoint.deliveries} />
+
+                {(canDisable || canRotate) && endpoint.enabled ? (
+                  <div className="flex flex-wrap gap-2">
+                    {canDisable ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={busy === endpoint.id}
+                        onClick={() => void disable(endpoint.id)}
+                      >
+                        Disable
+                        {busy === endpoint.id ? '…' : ''}
+                      </Button>
+                    ) : null}
+                    {canRotate ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={busy === endpoint.id}
+                        onClick={() => void rotate(endpoint.id)}
+                      >
+                        Rotate secret
+                      </Button>
+                    ) : null}
+                  </div>
+                ) : null}
+
+                {rotatedSecret?.endpointId === endpoint.id ? (
+                  <div className="grid gap-1 p-3 text-xs">
+                    <p className="font-medium">
+                      Secret rotated. Copy it now, it will not be shown again.
+                    </p>
+                    <code className="break-all">{rotatedSecret.secret}</code>
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {error ? (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/workspace-shell.tsx
+++ b/apps/web/src/components/workspace-shell.tsx
@@ -11,7 +11,8 @@ import {
   MenuIcon,
   SettingsIcon,
   ShieldIcon,
-  UsersIcon
+  UsersIcon,
+  WebhookIcon
 } from 'lucide-react'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Badge } from '@/components/ui/badge'
@@ -53,6 +54,7 @@ export function WorkspaceShell({
   workspaceSlug,
   canReadAuditLog = false,
   canReadApiTokens = false,
+  canReadWebhooks = false,
   signOut = signOutWithAuthClient
 }: {
   readonly children: ReactNode
@@ -83,6 +85,11 @@ export function WorkspaceShell({
    * a direct URL meets instead.
    */
   readonly canReadApiTokens?: boolean
+  /**
+   * Whether the viewer may list webhook endpoints — same contract as
+   * `canReadApiTokens`.
+   */
+  readonly canReadWebhooks?: boolean
   readonly signOut?: SignOut
 }) {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
@@ -99,6 +106,7 @@ export function WorkspaceShell({
           workspaceSlug={workspaceSlug}
           canReadAuditLog={canReadAuditLog}
           canReadApiTokens={canReadApiTokens}
+          canReadWebhooks={canReadWebhooks}
         />
       </aside>
       <div className="min-w-0">
@@ -124,6 +132,7 @@ export function WorkspaceShell({
                   workspaceSlug={workspaceSlug}
                   canReadAuditLog={canReadAuditLog}
                   canReadApiTokens={canReadApiTokens}
+                  canReadWebhooks={canReadWebhooks}
                   onNavigate={() => setMobileNavOpen(false)}
                 />
               </div>
@@ -197,11 +206,13 @@ function WorkspaceNav({
   workspaceSlug,
   canReadAuditLog,
   canReadApiTokens,
+  canReadWebhooks,
   onNavigate
 }: {
   readonly workspaceSlug: string | null
   readonly canReadAuditLog: boolean
   readonly canReadApiTokens: boolean
+  readonly canReadWebhooks: boolean
   readonly onNavigate?: (() => void) | undefined
 }) {
   return (
@@ -249,6 +260,15 @@ function WorkspaceNav({
                 onNavigate={onNavigate}
               />
             ) : null}
+            {canReadWebhooks ? (
+              <NavLink
+                to="/workspaces/$workspaceSlug/webhooks"
+                workspaceSlug={workspaceSlug}
+                label="Webhooks"
+                icon={<WebhookIcon className="size-4" />}
+                onNavigate={onNavigate}
+              />
+            ) : null}
             {canReadAuditLog ? (
               <NavLink
                 to="/workspaces/$workspaceSlug/audit"
@@ -286,6 +306,7 @@ function NavLink({
     | '/workspaces/$workspaceSlug/members'
     | '/workspaces/$workspaceSlug/settings'
     | '/workspaces/$workspaceSlug/audit'
+    | '/workspaces/$workspaceSlug/webhooks'
   readonly workspaceSlug: string
   readonly label: string
   readonly icon: ReactNode

--- a/apps/web/src/lib/server/webhooks.test.ts
+++ b/apps/web/src/lib/server/webhooks.test.ts
@@ -1,0 +1,198 @@
+import {
+  SeedWebhookEndpoints,
+  type WebhookEndpoint
+} from '@b2b-saas-starter/capabilities/src/developer-platform/webhook-endpoints.ts'
+import {
+  testWorkspaceContext,
+  type Actor
+} from '@b2b-saas-starter/capabilities/src/workspace-context.ts'
+import {
+  type Workspace,
+  type WorkspaceRole
+} from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
+import { describe, expect, it } from 'vitest'
+import { Effect, Layer } from 'effect'
+
+import {
+  disableWebhookEndpoint,
+  loadWorkspaceWebhooks,
+  rotateWebhookSecret
+} from './webhooks'
+
+/**
+ * The webhook management surface below its session gate. `disableWebhookEndpoint`
+ * and `rotateWebhookSecret` are exported as effects taking only the mutation
+ * input, so what is testable without a request or an auth runtime is exactly
+ * the behaviour: the `webhook:disable` / `webhook:rotateSecret` gates (both
+ * declared-but-unenforced until this page) and the hand-off to the capability.
+ *
+ * Real clock on purpose: plain `it` + `Effect.runPromise`, not
+ * `@effect/vitest`'s TestClock epoch.
+ */
+
+const workspace: Workspace = {
+  id: 'wrk_test',
+  slug: 'test-lab',
+  name: 'Test Lab',
+  planId: 'starter'
+}
+
+function actor(role: WorkspaceRole): Actor {
+  return { userId: `usr_${role}`, role, systemRole: 'user' }
+}
+
+const OWNER = actor('owner')
+
+// Roles: owner/admin hold every `webhook` action via `starterResources`;
+// a plain member holds none.
+const ADMIN = actor('admin')
+const MEMBER = actor('member')
+
+const seedEndpoints: readonly WebhookEndpoint[] = [
+  {
+    id: 'wh_1',
+    url: 'https://example.com/hooks/starter',
+    enabled: true,
+    events: ['api_token.created'],
+    successRate: 100
+  }
+]
+
+/** Turns a typed failure into a value, so a denial is asserted not thrown. */
+function outcome<A, E extends { readonly _tag: string; readonly reason?: string }, R>(
+  effect: Effect.Effect<A, E, R>
+) {
+  return Effect.match(effect, {
+    onSuccess: (value) => ({ tag: 'ok', value }),
+    onFailure: (failure) => ({ tag: failure._tag, reason: failure.reason })
+  })
+}
+
+describe('disableWebhookEndpoint', () => {
+  it('lets an actor with webhook:disable disable', async () => {
+    const layer = Layer.mergeAll(
+      SeedWebhookEndpoints(seedEndpoints),
+      testWorkspaceContext(workspace, ADMIN)
+    )
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        outcome(
+          disableWebhookEndpoint({ endpointId: 'wh_1', actorUserId: ADMIN.userId })
+        ).pipe(Effect.provide(layer))
+      )
+    )
+    expect(result).toEqual({ tag: 'ok', value: true })
+  })
+
+  it('denies a plain member — webhook:disable is withheld from member', async () => {
+    const layer = Layer.mergeAll(
+      SeedWebhookEndpoints(seedEndpoints),
+      testWorkspaceContext(workspace, MEMBER)
+    )
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        outcome(
+          disableWebhookEndpoint({ endpointId: 'wh_1', actorUserId: ADMIN.userId })
+        ).pipe(Effect.provide(layer))
+      )
+    )
+    expect(result).toEqual({
+      tag: 'AuthorizationDenied',
+      reason: 'insufficient_permission'
+    })
+  })
+
+  it('fails closed with no resolved actor', async () => {
+    const layer = Layer.mergeAll(
+      SeedWebhookEndpoints(seedEndpoints),
+      testWorkspaceContext(workspace, null)
+    )
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        outcome(
+          disableWebhookEndpoint({ endpointId: 'wh_1', actorUserId: ADMIN.userId })
+        ).pipe(Effect.provide(layer))
+      )
+    )
+    expect(result).toEqual({ tag: 'AuthorizationDenied', reason: 'no_principal' })
+  })
+})
+
+describe('rotateWebhookSecret', () => {
+  it('returns the new secret to an actor with webhook:rotateSecret', async () => {
+    const layer = Layer.mergeAll(
+      SeedWebhookEndpoints(seedEndpoints),
+      testWorkspaceContext(workspace, OWNER)
+    )
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        outcome(
+          rotateWebhookSecret({ endpointId: 'wh_1', actorUserId: OWNER.userId })
+        ).pipe(Effect.provide(layer))
+      )
+    )
+    expect(result).toEqual({ tag: 'ok', value: 'whsec_seed_rotated' })
+  })
+
+  it('denies a plain member — webhook:rotateSecret is withheld from member', async () => {
+    const layer = Layer.mergeAll(
+      SeedWebhookEndpoints(seedEndpoints),
+      testWorkspaceContext(workspace, MEMBER)
+    )
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        outcome(
+          rotateWebhookSecret({ endpointId: 'wh_1', actorUserId: OWNER.userId })
+        ).pipe(Effect.provide(layer))
+      )
+    )
+    expect(result).toEqual({
+      tag: 'AuthorizationDenied',
+      reason: 'insufficient_permission'
+    })
+  })
+
+  it('resolves no secret for an unknown endpoint — none is minted', async () => {
+    const layer = Layer.mergeAll(
+      SeedWebhookEndpoints(seedEndpoints),
+      testWorkspaceContext(workspace, OWNER)
+    )
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        rotateWebhookSecret({
+          endpointId: 'wh_missing',
+          actorUserId: OWNER.userId
+        }).pipe(Effect.provide(layer))
+      )
+    )
+    expect(result).toBeNull()
+  })
+})
+
+/**
+ * The loader seam, driven against the app's own Seed layer: `DB` is undefined
+ * under Vitest (vite.config.ts), so `runWorkspaceCapabilities` answers from
+ * the in-memory fixture. Both users below are seed members of `starter-lab` —
+ * `usr_demo` owns it, `usr_dev` is a plain member.
+ */
+describe('loadWorkspaceWebhooks', () => {
+  it('lists endpoints with deliveries attached for an owner', async () => {
+    const payload = await loadWorkspaceWebhooks({
+      workspaceSlug: 'starter-lab',
+      userId: 'usr_demo'
+    })
+    expect(payload.viewer).toEqual({ role: 'owner' })
+    expect(payload.unreadCount).toBeTypeOf('number')
+    expect(payload.endpoints.length).toBeGreaterThan(0)
+    // Every endpoint carries its delivery list, even when empty.
+    for (const endpoint of payload.endpoints) {
+      expect(Array.isArray(endpoint.deliveries)).toBe(true)
+    }
+  })
+
+  it('denies a plain member — reading webhooks is itself gated', async () => {
+    await expect(
+      loadWorkspaceWebhooks({ workspaceSlug: 'starter-lab', userId: 'usr_dev' })
+    ).rejects.toMatchObject({ name: 'ForbiddenError' })
+  })
+})

--- a/apps/web/src/lib/server/webhooks.ts
+++ b/apps/web/src/lib/server/webhooks.ts
@@ -1,0 +1,185 @@
+import {
+  type CreatedWebhookEndpoint,
+  WebhookEndpoints,
+  type WebhookDelivery,
+  type WebhookEndpoint
+} from '@b2b-saas-starter/capabilities/src/developer-platform/webhook-endpoints.ts'
+import { type AuthorizationDenied } from '@b2b-saas-starter/authz/src/errors.ts'
+import { type CapabilityUnavailable } from '@b2b-saas-starter/capabilities/src/errors.ts'
+import { NotificationFeed } from '@b2b-saas-starter/capabilities/src/notifications/notification-feed.ts'
+import { WorkspaceContext } from '@b2b-saas-starter/capabilities/src/workspace-context.ts'
+import { type WorkspaceRole } from '@b2b-saas-starter/capabilities/src/governance/workspace-identity.ts'
+import { createServerFn } from '@tanstack/react-start'
+import { Effect, Option, Schema, type Scope } from 'effect'
+
+import { runWorkspaceCapabilities } from '../capabilities'
+import { requireRequestSession } from './auth'
+import { requireWorkspacePermission } from './authorize'
+
+// All input constraints live in the schema — no imperative re-validation.
+const CreateWebhookInput = Schema.Struct({
+  workspaceSlug: Schema.NonEmptyString,
+  url: Schema.NonEmptyString,
+  events: Schema.NonEmptyArray(Schema.NonEmptyString)
+})
+
+const decodeCreateInput = Schema.decodeUnknownSync(CreateWebhookInput)
+
+export const createWebhookEndpointServerFn = createServerFn({ method: 'POST' })
+  .validator((input) => decodeCreateInput(input))
+  .handler(async ({ data }): Promise<CreatedWebhookEndpoint> => {
+    const session = await requireRequestSession()
+    return runWorkspaceCapabilities(
+      data.workspaceSlug,
+      Effect.gen(function* () {
+        // The session gate above proves who is asking; this proves they may.
+        yield* requireWorkspacePermission({ webhook: ['create'] })
+        const webhooks = yield* WebhookEndpoints
+        return yield* webhooks.create({
+          url: data.url,
+          events: data.events,
+          actorUserId: session.user.id
+        })
+      }),
+      { userId: session.user.id }
+    )
+  })
+
+/**
+ * The webhooks payload.
+ *
+ * Like tokens, reading webhooks is itself a permission: `webhook:list` is
+ * withheld from a plain `member`, so the page hard-gates on it — a member
+ * meeting the URL directly gets the denial, not an empty list. Deliveries are
+ * fetched per endpoint so each endpoint card can show its recent attempts.
+ */
+export type WorkspaceWebhooksPayload = {
+  readonly viewer: { readonly role: WorkspaceRole } | null
+  readonly unreadCount: number
+  readonly endpoints: readonly (WebhookEndpoint & {
+    readonly deliveries: readonly WebhookDelivery[]
+  })[]
+}
+
+/**
+ * `webhook:list` is the page's own read permission and a hard gate.
+ */
+const webhooksPayload: Effect.Effect<
+  WorkspaceWebhooksPayload,
+  AuthorizationDenied | CapabilityUnavailable,
+  Scope.Scope | WorkspaceContext | WebhookEndpoints | NotificationFeed
+> = Effect.gen(function* () {
+  yield* requireWorkspacePermission({ webhook: ['list'] })
+  const ctx = yield* WorkspaceContext
+  const feed = yield* NotificationFeed
+  const webhooks = yield* WebhookEndpoints
+  const [unreadCount, endpoints] = yield* Effect.all(
+    [feed.unreadCount, webhooks.list],
+    {
+      concurrency: 'unbounded'
+    }
+  )
+  const withDeliveries = yield* Effect.forEach(
+    endpoints,
+    (endpoint) =>
+      Effect.map(
+        webhooks.listDeliveries({ endpointId: endpoint.id }),
+        (deliveries) => ({ ...endpoint, deliveries })
+      ),
+    { concurrency: 'unbounded' }
+  )
+  return {
+    viewer: ctx.actor ? { role: ctx.actor.role } : null,
+    unreadCount,
+    endpoints: withDeliveries
+  }
+})
+
+/** The webhooks route's loader. */
+export function loadWorkspaceWebhooks(input: {
+  readonly workspaceSlug: string
+  readonly userId: string
+}): Promise<WorkspaceWebhooksPayload> {
+  return runWorkspaceCapabilities(input.workspaceSlug, webhooksPayload, {
+    userId: input.userId
+  })
+}
+
+// All input constraints live in the schema — no imperative re-validation.
+const EndpointMutationSchema = Schema.Struct({
+  workspaceSlug: Schema.NonEmptyString,
+  endpointId: Schema.NonEmptyString
+})
+
+const decodeEndpointMutation = Schema.decodeUnknownSync(EndpointMutationSchema)
+
+/**
+ * The effect below the session gate: proves the actor may disable
+ * (`webhook:disable`, declared → enforced here), then hands the mutation to
+ * the capability. Exported so tests drive it against fixture layers without a
+ * request or an auth runtime. Disabling an unknown id is not an error — the
+ * capability resolves `false` and skips the audit row.
+ */
+export function disableWebhookEndpoint(input: {
+  readonly endpointId: string
+  readonly actorUserId: string
+}): Effect.Effect<
+  boolean,
+  AuthorizationDenied | CapabilityUnavailable,
+  Scope.Scope | WorkspaceContext | WebhookEndpoints
+> {
+  return Effect.gen(function* () {
+    yield* requireWorkspacePermission({ webhook: ['disable'] })
+    const webhooks = yield* WebhookEndpoints
+    return yield* webhooks.disable(input)
+  })
+}
+
+export const disableWebhookEndpointServerFn = createServerFn({ method: 'POST' })
+  .validator((input) => decodeEndpointMutation(input))
+  .handler(async ({ data }): Promise<boolean> => {
+    const session = await requireRequestSession()
+    return runWorkspaceCapabilities(
+      data.workspaceSlug,
+      disableWebhookEndpoint({
+        endpointId: data.endpointId,
+        actorUserId: session.user.id
+      }),
+      { userId: session.user.id }
+    )
+  })
+
+/**
+ * Resolves the new signing secret to show once, or `null` when no endpoint
+ * matched in this workspace (no secret is minted in that case). Exported for
+ * tests, same seam as `disableWebhookEndpoint`.
+ */
+export function rotateWebhookSecret(input: {
+  readonly endpointId: string
+  readonly actorUserId: string
+}): Effect.Effect<
+  string | null,
+  AuthorizationDenied | CapabilityUnavailable,
+  Scope.Scope | WorkspaceContext | WebhookEndpoints
+> {
+  return Effect.gen(function* () {
+    yield* requireWorkspacePermission({ webhook: ['rotateSecret'] })
+    const webhooks = yield* WebhookEndpoints
+    const rotated = yield* webhooks.rotateSecret(input)
+    return Option.isSome(rotated) ? rotated.value.signingSecret : null
+  })
+}
+
+export const rotateWebhookSecretServerFn = createServerFn({ method: 'POST' })
+  .validator((input) => decodeEndpointMutation(input))
+  .handler(async ({ data }): Promise<string | null> => {
+    const session = await requireRequestSession()
+    return runWorkspaceCapabilities(
+      data.workspaceSlug,
+      rotateWebhookSecret({
+        endpointId: data.endpointId,
+        actorUserId: session.user.id
+      }),
+      { userId: session.user.id }
+    )
+  })

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as WorkspacesWorkspaceSlugApiTokensRouteImport } from './routes/w
 import { Route as WorkspacesWorkspaceSlugAuditRouteImport } from './routes/workspaces.$workspaceSlug.audit'
 import { Route as WorkspacesWorkspaceSlugMembersRouteImport } from './routes/workspaces.$workspaceSlug.members'
 import { Route as WorkspacesWorkspaceSlugSettingsRouteImport } from './routes/workspaces.$workspaceSlug.settings'
+import { Route as WorkspacesWorkspaceSlugWebhooksRouteImport } from './routes/workspaces.$workspaceSlug.webhooks'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -177,6 +178,12 @@ const WorkspacesWorkspaceSlugSettingsRoute =
     path: '/$workspaceSlug/settings',
     getParentRoute: () => WorkspacesRoute,
   } as any)
+const WorkspacesWorkspaceSlugWebhooksRoute =
+  WorkspacesWorkspaceSlugWebhooksRouteImport.update({
+    id: '/$workspaceSlug/webhooks',
+    path: '/$workspaceSlug/webhooks',
+    getParentRoute: () => WorkspacesRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -205,6 +212,7 @@ export interface FileRoutesByFullPath {
   '/workspaces/$workspaceSlug/audit': typeof WorkspacesWorkspaceSlugAuditRoute
   '/workspaces/$workspaceSlug/members': typeof WorkspacesWorkspaceSlugMembersRoute
   '/workspaces/$workspaceSlug/settings': typeof WorkspacesWorkspaceSlugSettingsRoute
+  '/workspaces/$workspaceSlug/webhooks': typeof WorkspacesWorkspaceSlugWebhooksRoute
   '/workspaces/$workspaceSlug/': typeof WorkspacesWorkspaceSlugIndexRoute
 }
 export interface FileRoutesByTo {
@@ -232,6 +240,7 @@ export interface FileRoutesByTo {
   '/workspaces/$workspaceSlug/audit': typeof WorkspacesWorkspaceSlugAuditRoute
   '/workspaces/$workspaceSlug/members': typeof WorkspacesWorkspaceSlugMembersRoute
   '/workspaces/$workspaceSlug/settings': typeof WorkspacesWorkspaceSlugSettingsRoute
+  '/workspaces/$workspaceSlug/webhooks': typeof WorkspacesWorkspaceSlugWebhooksRoute
   '/workspaces/$workspaceSlug': typeof WorkspacesWorkspaceSlugIndexRoute
 }
 export interface FileRoutesById {
@@ -262,6 +271,7 @@ export interface FileRoutesById {
   '/workspaces/$workspaceSlug/audit': typeof WorkspacesWorkspaceSlugAuditRoute
   '/workspaces/$workspaceSlug/members': typeof WorkspacesWorkspaceSlugMembersRoute
   '/workspaces/$workspaceSlug/settings': typeof WorkspacesWorkspaceSlugSettingsRoute
+  '/workspaces/$workspaceSlug/webhooks': typeof WorkspacesWorkspaceSlugWebhooksRoute
   '/workspaces/$workspaceSlug/': typeof WorkspacesWorkspaceSlugIndexRoute
 }
 export interface FileRouteTypes {
@@ -293,6 +303,7 @@ export interface FileRouteTypes {
     | '/workspaces/$workspaceSlug/audit'
     | '/workspaces/$workspaceSlug/members'
     | '/workspaces/$workspaceSlug/settings'
+    | '/workspaces/$workspaceSlug/webhooks'
     | '/workspaces/$workspaceSlug/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -320,6 +331,7 @@ export interface FileRouteTypes {
     | '/workspaces/$workspaceSlug/audit'
     | '/workspaces/$workspaceSlug/members'
     | '/workspaces/$workspaceSlug/settings'
+    | '/workspaces/$workspaceSlug/webhooks'
     | '/workspaces/$workspaceSlug'
   id:
     | '__root__'
@@ -349,6 +361,7 @@ export interface FileRouteTypes {
     | '/workspaces/$workspaceSlug/audit'
     | '/workspaces/$workspaceSlug/members'
     | '/workspaces/$workspaceSlug/settings'
+    | '/workspaces/$workspaceSlug/webhooks'
     | '/workspaces/$workspaceSlug/'
   fileRoutesById: FileRoutesById
 }
@@ -565,6 +578,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspacesWorkspaceSlugSettingsRouteImport
       parentRoute: typeof WorkspacesRoute
     }
+    '/workspaces/$workspaceSlug/webhooks': {
+      id: '/workspaces/$workspaceSlug/webhooks'
+      path: '/$workspaceSlug/webhooks'
+      fullPath: '/workspaces/$workspaceSlug/webhooks'
+      preLoaderRoute: typeof WorkspacesWorkspaceSlugWebhooksRouteImport
+      parentRoute: typeof WorkspacesRoute
+    }
   }
 }
 
@@ -586,6 +606,7 @@ interface WorkspacesRouteChildren {
   WorkspacesWorkspaceSlugAuditRoute: typeof WorkspacesWorkspaceSlugAuditRoute
   WorkspacesWorkspaceSlugMembersRoute: typeof WorkspacesWorkspaceSlugMembersRoute
   WorkspacesWorkspaceSlugSettingsRoute: typeof WorkspacesWorkspaceSlugSettingsRoute
+  WorkspacesWorkspaceSlugWebhooksRoute: typeof WorkspacesWorkspaceSlugWebhooksRoute
   WorkspacesWorkspaceSlugIndexRoute: typeof WorkspacesWorkspaceSlugIndexRoute
 }
 
@@ -595,6 +616,7 @@ const WorkspacesRouteChildren: WorkspacesRouteChildren = {
   WorkspacesWorkspaceSlugAuditRoute: WorkspacesWorkspaceSlugAuditRoute,
   WorkspacesWorkspaceSlugMembersRoute: WorkspacesWorkspaceSlugMembersRoute,
   WorkspacesWorkspaceSlugSettingsRoute: WorkspacesWorkspaceSlugSettingsRoute,
+  WorkspacesWorkspaceSlugWebhooksRoute: WorkspacesWorkspaceSlugWebhooksRoute,
   WorkspacesWorkspaceSlugIndexRoute: WorkspacesWorkspaceSlugIndexRoute,
 }
 

--- a/apps/web/src/routes/workspaces.$workspaceSlug.settings.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.settings.tsx
@@ -159,7 +159,18 @@ export function WorkspaceSettingsPage({
               <div className="grid gap-2">
                 <Label>Outbound webhooks</Label>
                 <p className="text-sm text-muted-foreground">
-                  {webhookCount} endpoint is configured for selected workspace events.
+                  {webhookCount} endpoint
+                  {webhookCount === 1 ? ' is' : 's are'} configured for selected
+                  workspace events. Registration, delivery history, and secret rotation
+                  live on the{' '}
+                  <Link
+                    to="/workspaces/$workspaceSlug/webhooks"
+                    params={{ workspaceSlug }}
+                    className="underline underline-offset-2"
+                  >
+                    Webhooks page
+                  </Link>
+                  .
                 </p>
               </div>
             )}

--- a/apps/web/src/routes/workspaces.$workspaceSlug.webhooks.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.webhooks.tsx
@@ -1,0 +1,63 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { RoutePending } from '@/components/route-pending'
+import { WebhooksPanel } from '@/components/webhooks-panel'
+import { WorkspaceShell } from '@/components/workspace-shell'
+import { viewerCan } from '@/lib/permissions'
+import {
+  loadWorkspaceWebhooks,
+  type WorkspaceWebhooksPayload
+} from '@/lib/server/webhooks'
+
+// The auth gate lives on the /workspaces layout route (workspaces.tsx);
+// `context.session` arrives from there. The page's own read permission
+// (`webhook:list`) is a hard gate inside the loader.
+export const Route = createFileRoute('/workspaces/$workspaceSlug/webhooks')({
+  loader: ({ params, context }) =>
+    loadWorkspaceWebhooks({
+      workspaceSlug: params.workspaceSlug,
+      userId: context.session.user.id
+    }),
+  pendingComponent: RoutePending,
+  component: WorkspaceWebhooksRoute
+})
+
+/**
+ * The route's thin wrapper: reads the params and loader data the router
+ * resolved, and hands them to the page. Keeping the two apart is what lets the
+ * page be rendered from a test with plain props — no route tree, no loader.
+ */
+function WorkspaceWebhooksRoute() {
+  const { workspaceSlug } = Route.useParams()
+  const data = Route.useLoaderData()
+  return <WorkspaceWebhooksPage workspaceSlug={workspaceSlug} data={data} />
+}
+
+export function WorkspaceWebhooksPage({
+  workspaceSlug,
+  data
+}: {
+  readonly workspaceSlug: string
+  readonly data: WorkspaceWebhooksPayload
+}) {
+  const { viewer, unreadCount, endpoints } = data
+
+  return (
+    <WorkspaceShell
+      workspaceSlug={workspaceSlug}
+      title="Webhooks"
+      description="Outbound endpoints that receive workspace events."
+      unreadCount={unreadCount}
+      canReadAuditLog={viewerCan(viewer, { auditLog: ['read'] })}
+      canReadApiTokens={viewerCan(viewer, { apiToken: ['list'] })}
+      canReadWebhooks={viewerCan(viewer, { webhook: ['list'] })}
+    >
+      <div className="grid gap-6">
+        <WebhooksPanel
+          workspaceSlug={workspaceSlug}
+          endpoints={endpoints}
+          viewer={viewer}
+        />
+      </div>
+    </WorkspaceShell>
+  )
+}

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.ts
@@ -22,6 +22,34 @@ export const WebhookEndpoint = Schema.Struct({
 export type WebhookEndpoint = typeof WebhookEndpoint.Type
 
 /**
+ * The creation result: the projected endpoint plus the signing secret shown
+ * once to the caller. The secret rides beside — never inside — the endpoint
+ * projection, so adapters that publish the projection as an event payload
+ * (`webhook_endpoint.created`) cannot leak it to the endpoint being registered.
+ */
+export type CreatedWebhookEndpoint = {
+  readonly endpoint: WebhookEndpoint
+  readonly signingSecret: string
+}
+
+/** A recorded delivery attempt, newest first in `listDeliveries`. */
+export const WebhookDelivery = Schema.Struct({
+  id: Schema.String,
+  endpointId: Schema.String,
+  eventType: Schema.String,
+  status: Schema.String,
+  attempts: Schema.Number,
+  lastAttemptAt: Schema.NullOr(Schema.String),
+  nextAttemptAt: Schema.NullOr(Schema.String),
+  responseStatus: Schema.NullOr(Schema.Number)
+})
+export type WebhookDelivery = typeof WebhookDelivery.Type
+
+export type ListWebhookDeliveriesInput = {
+  readonly endpointId: string
+}
+
+/**
  * Delivery status vocabulary (free-text column, keep these values consistent):
  * - `delivered` — 2xx response.
  * - `failed` — retryable failure (5xx, 408, 429, network error, timeout); the
@@ -80,6 +108,24 @@ export type CreateWebhookEndpointInput = {
   readonly actorUserId?: string
 }
 
+/**
+ * The event types this starter currently publishes (see the API worker's
+ * `publishWebhookEvent` call sites). Subscriptions are free-text strings so a
+ * producer can grow without a migration; this list is what the management UI
+ * offers as checkboxes.
+ */
+export type WebhookEventType =
+  | 'api_token.created'
+  | 'api_token.revoked'
+  | 'webhook_endpoint.created'
+
+// oxlint-disable-next-line effect/noAs -- a const assertion, not a type assertion
+export const WEBHOOK_EVENT_TYPES = [
+  'api_token.created',
+  'api_token.revoked',
+  'webhook_endpoint.created'
+] as const satisfies readonly WebhookEventType[]
+
 /** Wire payload for endpoint creation, shared by the REST contract and the API worker. */
 export const CreateWebhookEndpointPayload = Schema.Struct({
   url: Schema.String,
@@ -108,8 +154,21 @@ export type WebhookEndpointsInterface = {
   readonly create: (
     input: CreateWebhookEndpointInput
   ) => Effect.Effect<
-    WebhookEndpoint,
+    CreatedWebhookEndpoint,
     CapabilityUnavailable | InvalidWebhookUrl,
+    WorkspaceContext
+  >
+
+  /**
+   * Recent delivery attempts for one of this workspace's endpoints, newest
+   * first. Workspace scoping comes from `WorkspaceContext`; an endpoint id
+   * from another workspace yields an empty list, never its deliveries.
+   */
+  readonly listDeliveries: (
+    input: ListWebhookDeliveriesInput
+  ) => Effect.Effect<
+    readonly WebhookDelivery[],
+    CapabilityUnavailable,
     WorkspaceContext
   >
 
@@ -175,14 +234,16 @@ export function SeedWebhookEndpoints(
     list: Effect.succeed(seed),
     create: Effect.fnUntraced(function* (input) {
       yield* ensureValidWebhookUrl(input.url)
-      return {
+      const endpoint: WebhookEndpoint = {
         id: yield* newCapabilityId('wh'),
         url: input.url,
         enabled: true,
         events: [...input.events],
         successRate: 100
       }
+      return { endpoint, signingSecret: 'whsec_seed_created' }
     }),
+    listDeliveries: () => Effect.succeed([]),
     disable: (input) =>
       Effect.succeed(seed.some((endpoint) => endpoint.id === input.endpointId)),
     rotateSecret: (input) => {
@@ -348,12 +409,47 @@ export const LiveWebhookEndpoints: Layer.Layer<
             batch(db, [db.insert(webhookEndpoints).values(endpoint), auditCreated])
           )
           return {
-            id: endpoint.id,
-            url: endpoint.url,
-            enabled: endpoint.enabled,
-            events: endpoint.events,
-            successRate: 100
+            endpoint: {
+              id: endpoint.id,
+              url: endpoint.url,
+              enabled: endpoint.enabled,
+              events: endpoint.events,
+              successRate: 100
+            },
+            signingSecret
           }
+        }),
+      listDeliveries: (input) =>
+        Effect.gen(function* () {
+          const ctx = yield* WorkspaceContext
+          // The join scopes to the calling workspace: a foreign endpoint id
+          // matches no row of its own and yields an empty list.
+          return yield* unavailable(
+            db
+              .select({
+                id: webhookDeliveries.id,
+                endpointId: webhookDeliveries.endpointId,
+                eventType: webhookDeliveries.eventType,
+                status: webhookDeliveries.status,
+                attempts: webhookDeliveries.attempts,
+                lastAttemptAt: webhookDeliveries.lastAttemptAt,
+                nextAttemptAt: webhookDeliveries.nextAttemptAt,
+                responseStatus: webhookDeliveries.responseStatus
+              })
+              .from(webhookDeliveries)
+              .innerJoin(
+                webhookEndpoints,
+                eq(webhookEndpoints.id, webhookDeliveries.endpointId)
+              )
+              .where(
+                and(
+                  eq(webhookDeliveries.endpointId, input.endpointId),
+                  eq(webhookEndpoints.workspaceId, ctx.workspace.id)
+                )
+              )
+              .orderBy(sql`${webhookDeliveries.lastAttemptAt} desc`)
+              .limit(20)
+          )
         }),
       disable: (input) =>
         auditedEndpointUpdate(input, 'webhook_endpoint.disabled', () => ({


### PR DESCRIPTION
Closes #127 (wave 2, governance, on the [finish-or-remove map](https://github.com/brandhaug/b2b-saas-starter/issues/98)).

## What ships
- `/workspaces/$workspaceSlug/webhooks`: register endpoint (https-only SSRF-guarded URL + event checkboxes), endpoint list with success rate and recent delivery attempts, disable, rotate secret (shown once).
- Nav entry and settings-page link, both gated on `webhook:list`.

## Permissions: declared → enforced
- Loader hard-gates `webhook:list` (members meet a denial at the URL).
- `webhook:create`, `webhook:disable`, `webhook:rotateSecret` enforced in the server fns via `requireWorkspacePermission`.

## Capability changes
- `WebhookEndpoints.listDeliveries`: workspace-scoped recent deliveries (join on endpoints so a foreign endpoint id yields an empty list).
- `create` now resolves `{ endpoint, signingSecret }` so the UI can show the secret once; the REST contract still returns/publishes only the projection — the secret never rides the `webhook_endpoint.created` event.

## Tests
- Server-module tests drive the exported plain effects against seed layers: permission denials (member), no-principal fail-closed, unknown-endpoint no-secret-minted, loader seam.
- Full `bun run build` / `bun run test` green; oxlint clean.