### PR TITLE
chore(lint): enable React Compiler and rules-of-hooks lint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -376,6 +376,21 @@
     "react/no-unknown-property": "error",
     // Automatic JSX runtime, so React is never in scope by hand (851 would-be reports).
     "react-in-jsx-scope": "off",
+    // React Compiler rules (eslint-plugin-react-hooks compiler set)
+    "react/error-boundaries": "error",
+    "react/globals": "error",
+    "react/immutability": "error",
+    "react/incompatible-library": "error",
+    "react/preserve-manual-memoization": "error",
+    "react/purity": "error",
+    "react/refs": "error",
+    "react/set-state-in-effect": "error",
+    "react/set-state-in-render": "error",
+    "react/static-components": "error",
+    "react/unsupported-syntax": "error",
+    "react/use-memo": "error",
+    "react/void-use-memo": "error",
+
     "react-hooks/exhaustive-deps": "error",
     "react-hooks/rules-of-hooks": "error",
 


### PR DESCRIPTION
## Summary
- Explicitly enable the React Compiler rule set (from `eslint-plugin-react-hooks`) at `error` level in `.oxlintrc.json`: `error-boundaries`, `globals`, `immutability`, `incompatible-library`, `preserve-manual-memoization`, `purity`, `refs`, `set-state-in-effect`, `set-state-in-render`, `static-components`, `unsupported-syntax`, `use-memo`, `void-use-memo`
- Rules of Hooks (`react-hooks/rules-of-hooks`) and `exhaustive-deps` were already enabled; verified they fire

## Verification
- oxlint 1.79.0, full repo: 0 warnings / 0 errors (301 files, 1172 rules)
- Sanity-checked with a deliberately violating file: `purity` and `rules-of-hooks` report correctly