### PR TITLE
feat(auth): gate requireEmailVerification on ENVIRONMENT=production

### DIFF
--- a/apps/web/src/lib/auth-runtime.ts
+++ b/apps/web/src/lib/auth-runtime.ts
@@ -1,5 +1,6 @@
 import { createDb } from '@b2b-saas-starter/db/src/client.ts'
 import { Auth, AuthConfig } from '@b2b-saas-starter/auth'
+import { requireEmailVerification } from '@b2b-saas-starter/env/src/server.ts'
 import { env } from 'cloudflare:workers'
 import { Layer, ManagedRuntime, Schema } from 'effect'
 import { makeAuthEmailSender } from './server/auth-emails'
@@ -47,7 +48,10 @@ const AuthConfigLive = Layer.sync(AuthConfig)(() => ({
   // The lifecycle-email adapter (reset + verification), built on the same
   // provider-light dispatcher selector as the invitation flow: log mode when
   // no `EMAIL` binding is configured, so the flows stay demoable locally.
-  emails: makeAuthEmailSender()
+  emails: makeAuthEmailSender(),
+  // Production requires verified mailboxes; local dev and previews stay open
+  // because lifecycle emails land in the log there (provider-light rule).
+  requireEmailVerification: requireEmailVerification(env.ENVIRONMENT)
 }))
 
 export const AuthLive = Auth.layer.pipe(Layer.provide(AuthConfigLive))

--- a/packages/auth/AGENTS.md
+++ b/packages/auth/AGENTS.md
@@ -20,7 +20,7 @@ Configuration decisions, stated in code:
 - `sendOnSignUp: true` — the verification email rides sign-up; there is no UI reason to demand a second hop.
 - `autoSignInAfterVerification: true` — the link clicker gets a session: proving mailbox control is the honest reward, not an escalation.
 - `revokeSessionsOnPasswordReset: true` — the sessions that preceded a reset are exactly what the reset exists to distrust.
-- `requireEmailVerification` stays **off**: local dev sends to the log, where nobody could read a gating email; the unverified state surfaces as an app banner instead.
+- `requireEmailVerification` is **env-gated**: on only when `ENVIRONMENT=production` (decided by `requireEmailVerification` in `@b2b-saas-starter/env`, carried on `AuthConfig` — this package never reads env). Local dev sends to the log, where nobody could read a gating email; the unverified state surfaces as an app banner instead.
 
 ## Position in the dependency graph
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -43,6 +43,13 @@ export type AuthConfigInterface = {
   readonly baseURL: string
   readonly trustedOrigins: readonly string[]
   readonly emails: AuthEmailSender
+  /**
+   * Better Auth's `requireEmailVerification`, decided by the app from
+   * `ENVIRONMENT` (`requireEmailVerification` in `@b2b-saas-starter/env`):
+   * on only in production. This package never reads env itself — the caller
+   * owns the decision, local dev stays provider-light.
+   */
+  readonly requireEmailVerification: boolean
 }
 
 export class AuthConfig extends Context.Service<AuthConfig, AuthConfigInterface>()(
@@ -68,10 +75,12 @@ export function makeAuthOptions(options: AuthConfigInterface) {
     }),
     emailAndPassword: {
       enabled: true,
-      // `requireEmailVerification` stays off on purpose: local dev sends to
-      // the log, where nobody can read the verification email, and a gate the
-      // local path cannot pass would break the provider-light rule. The
-      // unverified state is surfaced in the app instead (banner + resend).
+      // Gated by the caller through `AuthConfig.requireEmailVerification`:
+      // on in production, off everywhere else. Local dev sends to the log,
+      // where nobody can read the verification email — a gate the local path
+      // cannot pass would break the provider-light rule. The unverified state
+      // is surfaced in the app instead (banner + resend).
+      requireEmailVerification: options.requireEmailVerification,
       // A reset password is an account-takeover response primitive: once it
       // succeeds, the sessions that preceded it are exactly what the reset
       // exists to distrust.

--- a/packages/auth/src/live-auth.test.ts
+++ b/packages/auth/src/live-auth.test.ts
@@ -53,7 +53,9 @@ beforeAll(
               secret: 'test-secret-at-least-32-characters-long',
               baseURL: 'http://localhost:3071',
               trustedOrigins: [],
-              emails: capturingEmailSender
+              emails: capturingEmailSender,
+              // Local-mode stance: the gate stays off in tests, matching dev.
+              requireEmailVerification: false
             }))
           )
         )

--- a/packages/auth/src/options.test.ts
+++ b/packages/auth/src/options.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { type AuthConfigInterface, makeAuthOptions } from './index.ts'
+
+// The email-verification gate is decided by the caller (from `ENVIRONMENT`)
+// and carried on `AuthConfig`; these tests pin that `makeAuthOptions` forwards
+// it to Better Auth instead of hardcoding a stance.
+const baseConfig: AuthConfigInterface = {
+  // SAFETY: these tests only read the returned options object — `db` is
+  // forwarded into `drizzleAdapter`'s closure and no property of it is read.
+  // oxlint-disable-next-line effect/noAs, typescript/no-unsafe-type-assertion, anti-slop(require-safety-comment-for-type-assertion) -- an empty sentinel stands in for the promise client, which the adapter alone would touch
+  db: {} as AuthConfigInterface['db'],
+  secret: 'test-secret-at-least-32-characters-long',
+  baseURL: 'http://localhost:3071',
+  trustedOrigins: [],
+  emails: {
+    sendPasswordReset: () => Promise.resolve(),
+    sendEmailVerification: () => Promise.resolve()
+  },
+  requireEmailVerification: false
+}
+
+describe('makeAuthOptions', () => {
+  it('forwards requireEmailVerification from the config', () => {
+    expect(makeAuthOptions(baseConfig).emailAndPassword).toMatchObject({
+      requireEmailVerification: false
+    })
+    expect(
+      makeAuthOptions({ ...baseConfig, requireEmailVerification: true })
+        .emailAndPassword
+    ).toMatchObject({ requireEmailVerification: true })
+  })
+})

--- a/packages/env/src/server.test.ts
+++ b/packages/env/src/server.test.ts
@@ -3,6 +3,7 @@ import {
   auditRequiredEnv,
   optionalModuleEnvKeys,
   readServerEnv,
+  requireEmailVerification,
   serverEnvKeys,
   ServerEnvSchema
 } from './server.ts'
@@ -35,6 +36,19 @@ describe('readServerEnv', () => {
     const env = readServerEnv(workerEnv)
     expect(env.CLOUDFLARE_EMAIL_FROM).toBe('no-reply@example.com')
     expect('DB' in env).toBe(false)
+  })
+})
+
+describe('requireEmailVerification', () => {
+  it('is on in production only', () => {
+    expect(requireEmailVerification('production')).toBe(true)
+  })
+
+  it('stays off for local dev and every non-production environment', () => {
+    expect(requireEmailVerification(undefined)).toBe(false)
+    expect(requireEmailVerification('')).toBe(false)
+    expect(requireEmailVerification('staging')).toBe(false)
+    expect(requireEmailVerification('preview')).toBe(false)
   })
 })
 

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -152,6 +152,16 @@ export type RequiredEnvAudit = {
   readonly problems: readonly RequiredEnvProblem[]
 }
 
+/**
+ * The pure decision for Better Auth's `requireEmailVerification`: on only when
+ * `ENVIRONMENT` is exactly `production`. Local dev sends lifecycle emails to
+ * the log, where nobody could read a gating verification link, so the gate
+ * stays off everywhere else — the provider-light rule (see the auth package).
+ */
+export function requireEmailVerification(environment: string | undefined): boolean {
+  return environment === 'production'
+}
+
 function requiredEnvMode(source: RawEnvSource): RequiredEnvAudit['mode'] {
   if (source.ENVIRONMENT === 'production') return 'production'
   if (hasValue(source.ENVIRONMENT)) return 'deployed'


### PR DESCRIPTION
## Summary
- Better Auth's `requireEmailVerification` was hardcoded off in `packages/auth/src/index.ts`. It is now env-gated: **on only when `ENVIRONMENT=production`**, off everywhere else so local dev stays provider-light (lifecycle emails land in the log, where a gating verification link would be unreadable).
- New pure decision function `requireEmailVerification(environment)` in `packages/env/src/server.ts`, next to the existing `ENVIRONMENT` gating (`auditRequiredEnv`). The auth package still never reads env — the app decides and carries the flag on `AuthConfig.requireEmailVerification`; `makeAuthOptions` forwards it into `emailAndPassword`.
- `apps/web/src/lib/auth-runtime.ts` supplies it from worker `env.ENVIRONMENT`.
- Updated `packages/auth/AGENTS.md` (the 'stays off' statement is now 'env-gated').

## Test evidence (Vitest, TDD red→green)
- `packages/env/src/server.test.ts`: `requireEmailVerification` on for `production`; off for unset/empty/staging/preview. Failed first (function missing), then green.
- `packages/auth/src/options.test.ts` (new): `makeAuthOptions` forwards the config flag to Better Auth's `emailAndPassword`. Failed first (asserted wrong block), then green.
- `packages/auth`: 11 tests pass (incl. live D1 suite). `packages/env`: 14 pass. `apps/web`: 170 pass across 31 files.
- `bun run typecheck`: 25/25 tasks OK. `oxlint`: 0 errors. Formatted with `oxfmt`.