### PR TITLE
perf(web): apply vercel react best-practices review fixes

### DIFF
--- a/apps/web/src/components/auth/turnstile-widget.tsx
+++ b/apps/web/src/components/auth/turnstile-widget.tsx
@@ -14,6 +14,8 @@ function loadTurnstileScript(): Promise<TurnstileApi> {
   scriptPromise = new Promise((resolve, reject) => {
     function settle() {
       if (window.turnstile === undefined) {
+        // Allow a later mount to retry: the failed promise is not cached.
+        scriptPromise = undefined
         // oxlint-disable-next-line effect/noNewError -- browser-platform failure signal; there is no Effect context here to lift into
         reject(new Error('Turnstile loaded without its API'))
         return
@@ -22,18 +24,30 @@ function loadTurnstileScript(): Promise<TurnstileApi> {
     }
     const existing = document.getElementById(SCRIPT_ID)
     if (existing !== null) {
-      existing.addEventListener('load', settle)
+      // `{ once: true }`: the listener must not outlive this loader — and an
+      // already-loaded tag never fires `load` again, so resolve immediately.
+      if (window.turnstile !== undefined) {
+        resolve(window.turnstile)
+        return
+      }
+      existing.addEventListener('load', settle, { once: true })
       return
     }
     const script = document.createElement('script')
     script.id = SCRIPT_ID
     script.src = SCRIPT_SRC
     script.async = true
-    script.addEventListener('load', settle)
-    script.addEventListener('error', () => {
-      // oxlint-disable-next-line effect/noNewError -- browser-platform failure signal; there is no Effect context here to lift into
-      reject(new Error('Failed to load the Turnstile script'))
-    })
+    script.addEventListener('load', settle, { once: true })
+    script.addEventListener(
+      'error',
+      () => {
+        // Allow a later mount to retry.
+        scriptPromise = undefined
+        // oxlint-disable-next-line effect/noNewError -- browser-platform failure signal; there is no Effect context here to lift into
+        reject(new Error('Failed to load the Turnstile script'))
+      },
+      { once: true }
+    )
     // bun-types' `append` only models string children; the DOM method takes nodes.
     // oxlint-disable-next-line unicorn/prefer-dom-node-append -- see above; the type conflict is bun-types vs DOM lib, not style
     document.head.appendChild(script)

--- a/apps/web/src/components/code-block.tsx
+++ b/apps/web/src/components/code-block.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 
@@ -14,6 +14,16 @@ export function CodeBlock({
   readonly className?: string
 }) {
   const [copied, setCopied] = useState(false)
+  const resetTimerRef = useRef<number | undefined>(undefined)
+
+  // Unmounting within the 2-second feedback window must not schedule a
+  // post-unmount state update.
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== undefined)
+        {window.clearTimeout(resetTimerRef.current)}
+    }
+  }, [])
 
   function copy() {
     // Clipboard access can reject (permissions/insecure context); the code is
@@ -22,7 +32,8 @@ export function CodeBlock({
       .writeText(code)
       .then(() => {
         setCopied(true)
-        return window.setTimeout(() => setCopied(false), 2000)
+        resetTimerRef.current = window.setTimeout(() => setCopied(false), 2000)
+        return resetTimerRef.current
       })
       .catch(() => null)
   }

--- a/apps/web/src/components/command-palette-dialog.tsx
+++ b/apps/web/src/components/command-palette-dialog.tsx
@@ -1,0 +1,74 @@
+import { useNavigate, useParams } from '@tanstack/react-router'
+import { publicLinks } from '@/lib/content'
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+
+/**
+ * The command palette's dialog, split from `command-palette.tsx` so cmdk and
+ * its dependencies stay out of the entry chunk: this module is loaded only
+ * when the palette opens (or is preloaded on search-button hover/focus).
+ */
+export default function CommandPaletteDialog({
+  open,
+  onOpenChange
+}: {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+}) {
+  const navigate = useNavigate()
+  // Target the current workspace when inside one; outside a workspace the
+  // command falls back to the workspace list — never a hardcoded workspace.
+  const params = useParams({ strict: false })
+  const workspaceSlug = params.workspaceSlug
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput placeholder="Search docs, pages, and actions…" />
+      <CommandList>
+        <CommandEmpty>No result found.</CommandEmpty>
+        <CommandGroup heading="Public pages">
+          {publicLinks.map((link) => (
+            <CommandItem
+              key={link.to}
+              onSelect={() => {
+                onOpenChange(false)
+                void navigate({ to: link.to })
+              }}
+            >
+              {link.label}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+        <CommandGroup heading="Workspace">
+          <CommandItem
+            onSelect={() => {
+              onOpenChange(false)
+              void (workspaceSlug
+                ? navigate({
+                    to: '/workspaces/$workspaceSlug',
+                    params: { workspaceSlug }
+                  })
+                : navigate({ to: '/workspaces' }))
+            }}
+          >
+            {workspaceSlug ? 'Open workspace overview' : 'Open workspaces'}
+          </CommandItem>
+          <CommandItem
+            onSelect={() => {
+              onOpenChange(false)
+              void navigate({ to: '/admin' })
+            }}
+          >
+            Open admin dashboard
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/apps/web/src/components/command-palette-loader.ts
+++ b/apps/web/src/components/command-palette-loader.ts
@@ -1,0 +1,15 @@
+import { lazy } from 'react'
+
+// The dialog lives behind a dynamic import so cmdk stays out of the entry
+// chunk — anonymous landing/blog traffic never opens the palette. Preloaded
+// on search-button hover/focus (and on the ⌘K chord) for perceived speed.
+async function loadCommandPaletteDialog() {
+  return import('@/components/command-palette-dialog')
+}
+
+export const CommandPaletteDialog = lazy(loadCommandPaletteDialog)
+
+export function preloadCommandPalette(): void {
+  // The module registry caches the import, so this is the same chunk promise.
+  void loadCommandPaletteDialog()
+}

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,31 +1,21 @@
-import { type ReactNode, useEffect, useState } from 'react'
-import { useNavigate, useParams } from '@tanstack/react-router'
+import { Suspense, type ReactNode, useEffect, useState } from 'react'
 import { SearchIcon } from 'lucide-react'
-import { publicLinks } from '@/lib/content'
 import { Button } from '@/components/ui/button'
 import {
-  CommandDialog,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList
-} from '@/components/ui/command'
+  CommandPaletteDialog,
+  preloadCommandPalette
+} from '@/components/command-palette-loader'
 import { CommandPaletteContext } from '@/lib/command-palette-context'
 import { useClientValue } from '@/lib/client-only-value'
 
 export function CommandPaletteProvider({ children }: { readonly children: ReactNode }) {
   const [open, setOpen] = useState(false)
-  const navigate = useNavigate()
-  // Target the current workspace when inside one; outside a workspace the
-  // command falls back to the workspace list — never a hardcoded workspace.
-  const params = useParams({ strict: false })
-  const workspaceSlug = params.workspaceSlug
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
         event.preventDefault()
+        preloadCommandPalette()
         setOpen((current) => !current)
       }
     }
@@ -36,48 +26,11 @@ export function CommandPaletteProvider({ children }: { readonly children: ReactN
   return (
     <CommandPaletteContext value={{ open, setOpen }}>
       {children}
-      <CommandDialog open={open} onOpenChange={setOpen}>
-        <CommandInput placeholder="Search docs, pages, and actions…" />
-        <CommandList>
-          <CommandEmpty>No result found.</CommandEmpty>
-          <CommandGroup heading="Public pages">
-            {publicLinks.map((link) => (
-              <CommandItem
-                key={link.to}
-                onSelect={() => {
-                  setOpen(false)
-                  void navigate({ to: link.to })
-                }}
-              >
-                {link.label}
-              </CommandItem>
-            ))}
-          </CommandGroup>
-          <CommandGroup heading="Workspace">
-            <CommandItem
-              onSelect={() => {
-                setOpen(false)
-                void (workspaceSlug
-                  ? navigate({
-                      to: '/workspaces/$workspaceSlug',
-                      params: { workspaceSlug }
-                    })
-                  : navigate({ to: '/workspaces' }))
-              }}
-            >
-              {workspaceSlug ? 'Open workspace overview' : 'Open workspaces'}
-            </CommandItem>
-            <CommandItem
-              onSelect={() => {
-                setOpen(false)
-                void navigate({ to: '/admin' })
-              }}
-            >
-              Open admin dashboard
-            </CommandItem>
-          </CommandGroup>
-        </CommandList>
-      </CommandDialog>
+      {open ? (
+        <Suspense fallback={null}>
+          <CommandPaletteDialog open={open} onOpenChange={setOpen} />
+        </Suspense>
+      ) : null}
     </CommandPaletteContext>
   )
 }
@@ -98,6 +51,8 @@ export function SearchButton() {
         <Button
           variant="outline"
           onClick={() => value?.setOpen(true)}
+          onMouseEnter={preloadCommandPalette}
+          onFocus={preloadCommandPalette}
           aria-label="Search"
           className="hidden h-9 w-56 gap-2 rounded-md px-3 text-sm text-muted-foreground md:flex"
         >

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -102,10 +102,14 @@ export function DataTable<TData extends RowData>({
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
 
+  // `useTable` keys its internal state on input identities. Consumers pass
+  // module-scope constants or stable loader arrays, so the props are handed
+  // straight through — copying (`[...data]`) would re-allocate (and
+  // re-notify) every render.
   const table = useTable({
     features: dataTableFeatures,
-    data: [...data],
-    columns: [...columns],
+    data,
+    columns,
     state: { sorting, globalFilter },
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,

--- a/apps/web/src/components/mdx-components.ts
+++ b/apps/web/src/components/mdx-components.ts
@@ -1,7 +1,12 @@
 import { lazy } from 'react'
 
 import { MdxLink } from '@/components/mdx-link'
-import { MdxMermaid } from '@/components/mdx-mermaid'
+
+// Mermaid's wrapper is lazy like its chart siblings, so nothing eager can
+// sneak the (heavy) module graph into the docs/blog chunks.
+const MdxMermaid = lazy(() =>
+  import('@/components/mdx-mermaid').then((m) => ({ default: m.MdxMermaid }))
+)
 
 const MdxLineChart = lazy(() =>
   import('@/components/mdx-chart').then((m) => ({ default: m.MdxLineChart }))

--- a/apps/web/src/components/sessions-panel.test.tsx
+++ b/apps/web/src/components/sessions-panel.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   SessionsPanel,
@@ -6,6 +7,13 @@ import {
   type RevokeOtherSessions,
   type RevokeSession
 } from './sessions-panel'
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  })
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
 
 const listSessions = vi.fn<ListSessions>()
 const revokeSession = vi.fn<RevokeSession>()
@@ -49,7 +57,7 @@ describe('SessionsPanel', () => {
         })
       ]
     })
-    render(
+    renderWithQueryClient(
       <SessionsPanel
         currentSessionToken="tok_current"
         listSessions={listSessions}
@@ -76,7 +84,7 @@ describe('SessionsPanel', () => {
         ]
       })
       .mockResolvedValueOnce({ data: [session({ token: 'tok_current' })] })
-    render(
+    renderWithQueryClient(
       <SessionsPanel
         currentSessionToken="tok_current"
         listSessions={listSessions}
@@ -101,7 +109,7 @@ describe('SessionsPanel', () => {
         session({ token: 'tok_b' })
       ]
     })
-    render(
+    renderWithQueryClient(
       <SessionsPanel
         currentSessionToken="tok_current"
         listSessions={listSessions}
@@ -123,7 +131,7 @@ describe('SessionsPanel', () => {
     revokeOtherSessions.mockResolvedValue({
       error: { message: 'Could not revoke sessions' }
     })
-    render(
+    renderWithQueryClient(
       <SessionsPanel
         currentSessionToken="tok_current"
         listSessions={listSessions}

--- a/apps/web/src/components/sessions-panel.tsx
+++ b/apps/web/src/components/sessions-panel.tsx
@@ -1,12 +1,14 @@
 import { LaptopIcon } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { authClient } from '@/lib/auth-client'
+import { useHydrated } from '@/lib/client-only-value'
 import { Button } from '@/components/ui/button'
 
 /**
  * One row of the panel's own view model: a Better Auth session plus the
- * expiry label, which is formatted at load time (inside the post-mount
- * effect) so server rendering never formats dates.
+ * expiry label, which is formatted inside the query function (client-side
+ * only) so server rendering never formats dates.
  */
 export type SessionRowView = {
   readonly token: string
@@ -88,6 +90,15 @@ function toViewModels(sessions: readonly SessionRecord[]): SessionRowView[] {
  * and cannot be revoked from here — signing out of it is the shell's
  * sign-out button.
  */
+/**
+ * The sessions query is shared cache, not component state: TanStack Query
+ * deduplicates concurrent reads and keeps the list across mounts, so the
+ * panel renders from cache on revisits instead of re-fetching after every
+ * hydration. `enabled` waits for hydration — the Better Auth client endpoint
+ * is browser-only (relative fetch), so the server render must not fetch.
+ */
+const SESSIONS_QUERY_KEY: readonly unknown[] = ['account', 'sessions']
+
 export function SessionsPanel({
   currentSessionToken,
   listSessions = listSessionsWithAuthClient,
@@ -99,30 +110,26 @@ export function SessionsPanel({
   readonly revokeSession?: RevokeSession
   readonly revokeOtherSessions?: RevokeOtherSessions
 }) {
-  const [rows, setRows] = useState<readonly SessionRowView[] | null>(null)
-  const [loadError, setLoadError] = useState<string | null>(null)
-  const [actionError, setActionError] = useState<string | null>(null)
-  // Bumped by every successful action: refetch without manual memoization.
-  const [reloadKey, setReloadKey] = useState(0)
-
-  useEffect(() => {
-    let cancelled = false
-    async function load() {
-      setLoadError(null)
+  const hydrated = useHydrated()
+  const {
+    data: rows,
+    error: queryError,
+    refetch
+  } = useQuery({
+    queryKey: SESSIONS_QUERY_KEY,
+    queryFn: async (): Promise<readonly SessionRowView[]> => {
       const result = await listSessions()
-      if (cancelled) return
       if (result.error) {
-        setLoadError(result.error.message ?? 'Could not load sessions')
-        return
+        // oxlint-disable-next-line effect/noThrowStatement, effect/noNewError -- TanStack Query surfaces failure states by rejecting the query function; there is no Effect channel here
+        throw new Error(result.error.message ?? 'Could not load sessions')
       }
-      setRows(toViewModels(result.data ?? []))
-    }
-    void load()
-    return () => {
-      cancelled = true
-    }
-    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `reloadKey` is the refetch trigger: every successful action bumps it to re-run this fetch
-  }, [listSessions, reloadKey])
+      return toViewModels(result.data ?? [])
+    },
+    enabled: hydrated,
+    retry: false
+  })
+  const loadError = queryError?.message ?? null
+  const [actionError, setActionError] = useState<string | null>(null)
 
   async function act(
     action: () => Promise<{
@@ -135,7 +142,7 @@ export function SessionsPanel({
       setActionError(result.error.message ?? 'The change could not be made')
       return
     }
-    setReloadKey((key) => key + 1)
+    void refetch()
   }
 
   const othersExist = rows?.some((row) => row.token !== currentSessionToken)

--- a/apps/web/src/lib/server/auth.test.ts
+++ b/apps/web/src/lib/server/auth.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { toRouteSession } from './auth'
+
+/**
+ * The projection is what every gated route serializes into its client
+ * payload (`beforeLoad` context), so this test is the guard that keeps it
+ * narrow: session tokens, IP addresses, user agents and expiry timestamps
+ * must never ride the SSR payload again.
+ */
+describe('toRouteSession', () => {
+  it('carries only the projected user fields', () => {
+    // SAFETY: the literal is the full `Session` shape the gate reads; every
+    // field beyond the projection exists precisely so this test can prove
+    // they are dropped.
+    const routeSession = toRouteSession({
+      session: {
+        id: 'ses_1',
+        token: 'tok_secret',
+        createdAt: new Date('2026-08-01T00:00:00Z'),
+        updatedAt: new Date('2026-08-01T00:00:00Z'),
+        userId: 'usr_1',
+        expiresAt: new Date('2026-09-01T00:00:00Z'),
+        ipAddress: '203.0.113.7',
+        userAgent: 'Mozilla/5.0'
+      },
+      user: {
+        id: 'usr_1',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+        name: 'Demo',
+        banned: false,
+        email: 'demo@starter.local',
+        emailVerified: true,
+        role: 'admin',
+        twoFactorEnabled: false
+      }
+    } satisfies Parameters<typeof toRouteSession>[0])
+
+    expect(routeSession.user).toEqual({
+      id: 'usr_1',
+      email: 'demo@starter.local',
+      emailVerified: true,
+      role: 'admin',
+      twoFactorEnabled: false
+    })
+    expect(Object.keys(routeSession)).toEqual(['user'])
+    expect(JSON.stringify(routeSession)).not.toContain('tok_secret')
+    expect(JSON.stringify(routeSession)).not.toContain('203.0.113.7')
+    expect(JSON.stringify(routeSession)).not.toContain('Mozilla')
+  })
+})

--- a/apps/web/src/lib/server/auth.ts
+++ b/apps/web/src/lib/server/auth.ts
@@ -1,10 +1,10 @@
 import { Auth, type Session } from '@b2b-saas-starter/auth'
 import { notFound, redirect } from '@tanstack/react-router'
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
-import { getRequest } from '@tanstack/react-start/server'
 import { Effect } from 'effect'
 import { authRuntime } from '../auth-runtime'
 import { withWebRequestScope } from '../observability'
+import { currentRequest } from '../request-context'
 
 /**
  * The session read every gate below is built on. `authRuntime` carries the
@@ -13,13 +13,28 @@ import { withWebRequestScope } from '../observability'
  * the gate's outcome into that request's one wide event. Without it the gate
  * that runs first on every gated route would be invisible.
  */
+// One session read per request: the registry is keyed by the request object
+// (an isolate interleaves concurrent requests, so a module-level "current"
+// would race — same pattern as request-context.ts). A route whose `beforeLoad`
+// gate and a server function both read the session must not pay two DB
+// round-trips for one document request.
+const sessionCache = new WeakMap<Request, Promise<Session | null>>()
+
 const readSession = createServerOnlyFn((): Promise<Session | null> => {
-  const request = getRequest()
-  return authRuntime.runPromise(
+  const request = currentRequest()
+  const cached = request === undefined ? undefined : sessionCache.get(request)
+  if (cached !== undefined) return cached
+  const pending = authRuntime.runPromise(
     withWebRequestScope(
       { event: 'auth.session' },
       Effect.gen(function* () {
         const auth = yield* Auth.Tag
+        // No ambient request (unit tests, scripts) means no cookie jar to
+        // read — that is an unauthenticated caller, not a crash.
+        if (request === undefined) {
+          yield* Effect.annotateLogsScoped({ authenticated: false })
+          return null
+        }
         const session = yield* auth.api.getSession({ headers: request.headers })
         // Whether the gate found a session is the useful fact. Never the token,
         // never the email.
@@ -28,22 +43,62 @@ const readSession = createServerOnlyFn((): Promise<Session | null> => {
       })
     )
   )
+  if (request !== undefined) sessionCache.set(request, pending)
+  return pending
 })
 
 const getSessionServerFn = createServerFn({ method: 'GET' }).handler(readSession)
 
 /**
- * Route gate for `beforeLoad`. Redirects unauthenticated visitors to
- * `/sign-in` and returns the session so loaders can pass the actor to
- * `runWorkspaceCapabilities`.
+ * The session projection route context carries. `beforeLoad` results are
+ * serialized into the client payload of every gated route, so this is
+ * deliberately narrow: the user fields the UI and loaders read, and nothing
+ * else — no session token, no IP address, no user agent, no expiry. The
+ * current session token for `/account`'s sessions panel comes from
+ * `authClient.useSession()` instead (client-side, never in the SSR payload).
  */
-export async function requireSession(redirectTo: string): Promise<Session> {
+export type RouteSession = {
+  readonly user: {
+    readonly id: string
+    readonly email: string
+    readonly emailVerified: boolean
+    readonly role: string
+    readonly twoFactorEnabled: boolean
+  }
+}
+
+/**
+ * Strips a Better Auth session down to `RouteSession`. Exported so the
+ * projection's shape is asserted by test rather than trusted.
+ */
+export function toRouteSession(session: Session): RouteSession {
+  return {
+    user: {
+      id: session.user.id,
+      email: session.user.email,
+      // The plugin schema marks these optional; the gate only ever reads
+      // them as scalars, so normalize to definite values here.
+      // The plugin schema marks some of these optional; normalize to
+      // definite values here.
+      emailVerified: session.user.emailVerified,
+      role: session.user.role ?? '',
+      twoFactorEnabled: session.user.twoFactorEnabled ?? false
+    }
+  }
+}
+
+/**
+ * Route gate for `beforeLoad`. Redirects unauthenticated visitors to
+ * `/sign-in` and returns the projected session so loaders can pass the actor
+ * to `runWorkspaceCapabilities`.
+ */
+export async function requireSession(redirectTo: string): Promise<RouteSession> {
   const session = await getSessionServerFn()
   if (!session) {
     // oxlint-disable-next-line effect/noThrowStatement -- `throw redirect()` is TanStack Router's navigation control-flow API
     throw redirect({ to: '/sign-in', search: { redirect: redirectTo } })
   }
-  return session
+  return toRouteSession(session)
 }
 
 /**
@@ -52,7 +107,7 @@ export async function requireSession(redirectTo: string): Promise<Session> {
  * packages/auth). Non-admins get a 404 rather than a 403 so the route's
  * existence is not disclosed.
  */
-export async function requireAdmin(redirectTo: string): Promise<Session> {
+export async function requireAdmin(redirectTo: string): Promise<RouteSession> {
   const session = await requireSession(redirectTo)
   if (session.user.role !== 'admin') {
     // oxlint-disable-next-line effect/noThrowStatement -- `throw notFound()` is TanStack Router's 404 control-flow API

--- a/apps/web/src/routes/account.tsx
+++ b/apps/web/src/routes/account.tsx
@@ -3,6 +3,7 @@ import { TwoFactorPanel } from '@/components/two-factor-panel'
 import { SessionsPanel } from '@/components/sessions-panel'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { WorkspaceShell } from '@/components/workspace-shell'
+import { authClient } from '@/lib/auth-client'
 import { requireSession } from '@/lib/server/auth'
 
 // Account settings live outside the /workspaces subtree on purpose: they are
@@ -19,6 +20,9 @@ export const Route = createFileRoute('/account')({
 
 function AccountRoute() {
   const { session } = Route.useRouteContext()
+  // The current session token never rides the SSR payload (see `RouteSession`
+  // in lib/server/auth.ts) — the panel reads it from the client session hook.
+  const currentSession = authClient.useSession()
   return (
     <WorkspaceShell
       title="Account"
@@ -48,7 +52,9 @@ function AccountRoute() {
             </p>
           </CardHeader>
           <CardContent>
-            <SessionsPanel currentSessionToken={session.session.token} />
+            <SessionsPanel
+              currentSessionToken={currentSession.data?.session.token ?? ''}
+            />
           </CardContent>
         </Card>
       </div>

--- a/apps/web/src/routes/workspaces.$workspaceSlug.index.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.index.tsx
@@ -1,10 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { lazy, Suspense } from 'react'
 import {
   LiveNotifications,
   type ListNotifications
 } from '@/components/live-notifications'
 import { RoutePending } from '@/components/route-pending'
-import { WebhookSuccessChart } from '@/components/charts/webhook-success-chart'
 import { WorkspaceShell } from '@/components/workspace-shell'
 import { viewerCan } from '@/lib/permissions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -15,6 +15,17 @@ import {
 
 // The auth gate lives on the /workspaces layout route (workspaces.tsx);
 // `context.session` arrives from there.
+// Lazy: recharts (and its d3 dependencies) is the heaviest module on this
+// route, and the chart is below-fold secondary content — it must not sit in
+// the dashboard's first chunk. `defaultPreload: 'intent'` warms the chunk on
+// navigation intent.
+async function loadWebhookSuccessChart() {
+  const chart = await import('@/components/charts/webhook-success-chart')
+  return { default: chart.WebhookSuccessChart }
+}
+
+const WebhookSuccessChart = lazy(loadWebhookSuccessChart)
+
 export const Route = createFileRoute('/workspaces/$workspaceSlug/')({
   // The `workspaceDashboard` projection — shared with the REST `overview`
   // endpoint so app and Capability Interface views cannot drift — plus the
@@ -72,7 +83,9 @@ export function WorkspaceDashboardPage({
                 <CardTitle as="h2">Webhook delivery</CardTitle>
               </CardHeader>
               <CardContent>
-                <WebhookSuccessChart webhooks={webhooks} />
+                <Suspense fallback={null}>
+                  <WebhookSuccessChart webhooks={webhooks} />
+                </Suspense>
               </CardContent>
             </Card>
           )}


### PR DESCRIPTION
## Summary
Fixes all nine findings from the vercel-react-best-practices codebase review of `apps/web`.

**High**
- `server-serialization`: route-context sessions are now a narrow projection (`RouteSession`, user fields only). The full Better Auth session (token, IP, user agent, expiry) no longer serializes into every gated route's client payload. `/account` reads the current session token via `authClient.useSession()` instead. Enforced by a new `toRouteSession` unit test asserting sensitive fields are dropped.

**Medium**
- `bundle-dynamic-imports`: `WebhookSuccessChart` (recharts + d3, ~100 kB gz) is lazy-loaded out of the dashboard's first chunk.
- `bundle-conditional`: the command palette dialog moved behind a dynamic import (`command-palette-dialog.tsx` + `command-palette-loader.ts`), preloaded on search-button hover/focus and on the ⌘K chord — cmdk is out of the entry chunk for anonymous traffic.
- `async-api-routes`: SessionsPanel fetching moved from a post-hydration effect onto TanStack Query (dedup, cached revisits, hydration-gated).

**Low**
- `rerender-memo`: `DataTable` passes `data`/`columns` through to `useTable` instead of re-allocating copies each render.
- `bundle-dynamic-imports`: `MdxMermaid` registered lazily like its chart siblings.
- `client-event-listeners`: Turnstile script loader uses `{ once: true }` listeners, resets its cached promise on failure (retryable), and resolves immediately when the API already exists.
- `client-event-listeners`: CodeBlock clears its copy-feedback timer on unmount.
- `server-cache-react`: `readSession` is memoized per request via a WeakMap keyed by the request object.

## Verification
- `bun run lint` / `typecheck` / `test` (205 web tests incl. new projection test) / `build` all green; build output confirms `command-palette-dialog` is emitted as its own chunk.