### PR TITLE
fix(web): apply impeccable design audit fixes across app pages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,7 +1,7 @@
 ---
 version: alpha
 name: B2B SaaS Starter
-description: Quiet, system-typeface, neutral-on-blue chrome built on shadcn/ui. Production-grade defaults, not branded marketing.
+description: Quiet, system-typeface, neutral-on-mauve chrome built on shadcn/ui. Production-grade defaults, not branded marketing.
 colors:
   background: '#eff1f5'
   foreground: '#4c4f69'
@@ -159,36 +159,36 @@ components:
 
 ## Overview
 
-The B2B SaaS Starter is a production-leaning chrome — quiet, legible, system-typeface — built on shadcn/ui + Tailwind v4 with a single accent blue. It is a workspace UI for serious operators, not a marketing surface. The public Showcase Site shares the same shadcn token contract and primitives but commits harder to the brand: the `.marketing` scope (applied by `PublicLayout`) overrides the token values with a deep petrol teal + amber "signal" palette, and marketing `h1`/`h2` render in Archivo Variable drawn wide. One system, two registers.
+The B2B SaaS Starter is a production-leaning chrome — quiet, legible, system-typeface — built on shadcn/ui + Tailwind v4 with a single saturated mauve accent. It is a workspace UI for serious operators, not a marketing surface. The public Showcase Site shares the same shadcn token contract and primitives but commits harder to the brand: the `.marketing` scope (applied by `PublicLayout`) overrides the token values with a deep petrol teal + amber "signal" palette, and marketing `h1`/`h2` render in Archivo Variable drawn wide. One system, two registers.
 
 **Emotional goals.** Calm, considered, inspectable. The interface should feel like a tool a team will use every day — closer to Linear or Vercel's dashboard than to a launch-day landing page. No exuberance, no novelty, no overlap with consumer-product aesthetics.
 
-**Primary reference.** Stripe Dashboard, Linear, Vercel — sharp 0-radius surfaces, neutral grays, a single saturated blue for action affordance, and Geist throughout. Density is generous-but-not-airy.
+**Primary reference.** Stripe Dashboard, Linear, Vercel — sharp 0-radius surfaces, Catppuccin neutrals, a single saturated mauve for action affordance, and Geist throughout. Density is generous-but-not-airy.
 
 **Anti-references.** Gradient hero pages, glassmorphism, neumorphism, glowing accents, illustration-heavy marketing surfaces. Any "consumer-y" warmth signals the brand wrong.
 
-**Theme.** Neutral grays + a single saturated blue accent. Light by default, dark fully supported. Both themes share the same accent so the brand reads identically regardless of `prefers-color-scheme`. Authoritative token values live in OKLch in `apps/web/src/index.css` for perceptual uniformity; the sRGB hex tokens in this file are the portable equivalent for agents and exports.
+**Theme.** Catppuccin neutrals + a single saturated mauve accent. Light by default, dark fully supported. Both themes share the same accent so the brand reads identically regardless of `prefers-color-scheme`. Authoritative token values live in OKLch in `apps/web/src/index.css` for perceptual uniformity; the sRGB hex tokens in this file are the portable equivalent for agents and exports.
 
 ## Colors
 
-The palette is rooted in neutral grays with a single saturated blue accent — chosen so chrome stays out of the way and the data on screen reads first.
+The palette is rooted in Catppuccin neutrals with a single saturated mauve accent (#8839EF light / #CBA6F7 dark) — chosen so chrome stays out of the way and the data on screen reads first.
 
 - **Background (`#FCFCFC` / `#1E1E1E`):** Page surface. Near-white in light mode, near-black in dark mode. Avoid hard `#FFF` / `#000`.
 - **Card / Popover (`#FFFFFF` / `#2D2D2D`):** Lifted neutral surface for panels, dialogs, popovers, sidebars. Light mode card sits a hair above background; dark mode lifts visibly.
 - **Foreground (`#424242` / `#E5E5E5`):** Body and heading text. Soft on light, soft on dark — true black/white reserved for accents.
-- **Primary (`#3B82F6`):** The single accent. CTAs, focus rings, active links, selected rows. If everything is blue, nothing is.
-- **Primary-foreground (`#FFFFFF`):** Pure white text on primary fills — passes contrast against the blue at all sizes.
+- **Primary (`#8839EF` / `#CBA6F7`):** The single accent. CTAs, active links, selected rows. If everything is mauve, nothing is.
+- **Primary-foreground:** Light mode uses white on the primary fill; dark mode flips to near-black (`#11111B`) on the lifted lavender — both pass contrast at all sizes.
 - **Secondary (`#F1F5F9` / `#2D2D2D`):** Default button fill. Most buttons land here, not on primary.
 - **Muted (`#F8FAFC` / `#2D2D2D`):** Recessed background for nested panels, code blocks, and "secondary information" zones.
 - **Accent (`#E0F2FE` / `#1E40AF`):** Hover lift on rows and tabs. Light mode goes pale-cyan; dark mode goes saturated-blue. The accent-foreground tracks the inverse.
 - **Border (`#E2E8F0` / `#494949`):** The carved edge that gives the card 0-radius chrome its shape. Always 1px. Never thicker.
 - **Destructive (`#EF4444`):** Delete, revoke, leave-workspace. Confirmations only — never as a chrome color.
-- **Ring (`#3B82F6`):** Focus outline. Same hue as primary so focus and action read as one system.
-- **Chart 1–5:** Scaled-blue chart palette (no rainbow). Defined in `index.css` `--chart-1`…`--chart-5`; reach for these in dashboards before introducing new colors.
+- **Ring (`#7287FD` / `#B4BEFE`):** Focus outline. Same hue family as primary so focus and action read as one system.
+- **Chart 1–5:** Scaled chart palette in the brand hue family (no rainbow). Defined in `index.css` `--chart-1`…`--chart-5`; reach for these in dashboards before introducing new colors.
 
 The sidebar has its own tokens (`--sidebar-*`) so navigation can lift independently from the body in either mode. Treat them as the source of truth for `WorkspaceShell` navigation chrome.
 
-**Marketing scope.** Public routes (wrapped in `.marketing` by `PublicLayout`) redefine the same token names in `apps/web/src/index.css`: primary becomes a deep petrol teal (`oklch(0.42 0.075 215)` light / lifted teal dark), neutrals tint toward the same hue, and two extra tokens exist — `--signal` (burnt amber, for schematic marks and status dots) and `--signal-ink` (its text-safe counterpart, ≥4.5:1 on the page background). `.band-deep` re-overrides the contract for petrol-drenched sections; inside a band, `primary` flips to amber so CTAs pop. Workspace routes never see any of this — the app keeps the neutral/blue chrome above.
+**Marketing scope.** Public routes (wrapped in `.marketing` by `PublicLayout`) redefine the same token names in `apps/web/src/index.css`: primary becomes a deep petrol teal (`oklch(0.42 0.075 215)` light / lifted teal dark), neutrals tint toward the same hue, and two extra tokens exist — `--signal` (burnt amber, for schematic marks and status dots) and `--signal-ink` (its text-safe counterpart, ≥4.5:1 on the page background). `.band-deep` re-overrides the contract for petrol-drenched sections; inside a band, `primary` flips to amber so CTAs pop. Workspace routes never see any of this — the app keeps the neutral/mauve chrome above.
 
 ## Typography
 
@@ -243,12 +243,12 @@ This is intentional: the contrast between sharp panels and softly-rounded contro
 
 Component tokens are defined in the YAML above and are the normative surface for agents. A few usage notes:
 
-- **`button-primary`** is the saturated blue CTA. One per screen region. Reserve for the most important action ("Save", "Create workspace", "Sign in").
+- **`button-primary`** is the saturated mauve CTA. One per screen region. Reserve for the most important action ("Save", "Create workspace", "Sign in").
 - **`button-secondary`** is the default action. The overwhelming majority of buttons are this.
 - **`button-ghost`** carries no fill and no border — use for in-row actions, dismiss, cancel.
 - **`button-destructive`** is for delete, revoke, leave-workspace. Always paired with a confirmation step.
 - **`card`** is the only panel surface. Don't nest cards inside cards; lift via `bg-muted` instead.
-- **`input`** sits at `border` + `bg-card`. Focus ring is the primary blue.
+- **`input`** sits at `border` + `bg-card`. Focus ring is the primary accent.
 - **`badge`** uses 22px height + 4/8px padding. Plan-tier and status pills should land here, not in ad-hoc spans.
 - **Sidebar** uses its own `--sidebar-*` tokens — don't apply body tokens to navigation chrome.
 
@@ -264,7 +264,7 @@ Component tokens are defined in the YAML above and are the normative surface for
 
 **Don't**
 
-- Don't introduce a second accent hue in the workspace. The one blue is the app system; petrol + amber belong to the `.marketing` scope only.
+- Don't introduce a second accent hue in the workspace. The one mauve is the app system; petrol + amber belong to the `.marketing` scope only.
 - Don't swap in system fonts "for performance." Geist + Geist Mono (+ Archivo Variable on public routes) are load-bearing and shipped self-hosted via `@fontsource-variable`.
 - Don't round panels. The sharp/soft contrast between cards and controls is the brand.
 - Don't use `destructive` red for anything but genuinely destructive actions. It is a signal, not a color.

--- a/apps/web/src/components/admin-user-actions.tsx
+++ b/apps/web/src/components/admin-user-actions.tsx
@@ -20,6 +20,14 @@ import {
 import { Spinner } from '@/components/ui/spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import {
   banSystemUserServerFn,
   changeUserWorkspaceRoleServerFn,
   listUserWorkspacesServerFn,
@@ -29,11 +37,84 @@ import {
 import { callServerFn } from '@/lib/server-call'
 
 /**
- * Per-user admin actions under `/admin`'s users table: ban/unban, and a
- * cross-workspace role editor keyed by the selected user. Presentation only —
- * every change is re-gated by the admin role in the server fn and again
- * inside Better Auth's plugin.
+ * Cross-workspace role editor under `/admin`'s users table, keyed by the
+ * selected user. Ban/unban lives in `BanUserAction` on the table rows.
+ * Presentation only — every change is re-gated by the admin role in the
+ * server fn and again inside Better Auth's plugin.
  */
+/**
+ * Row-level ban/unban for `/admin`'s users table: a confirmed destructive
+ * action — the dialog names the user, cancel is the safe default. Every change
+ * is re-gated by the admin role in the server fn and again inside Better
+ * Auth's plugin.
+ */
+export function BanUserAction({ user }: { readonly user: SystemUser }) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const banned = user.banned
+  const verb = banned ? 'Unban' : 'Ban'
+
+  async function confirm() {
+    setError(null)
+    setBusy(true)
+    const outcome = await callServerFn(() => {
+      const write = banned
+        ? unbanSystemUserServerFn({ data: { userId: user.id } })
+        : banSystemUserServerFn({ data: { userId: user.id } })
+      return write.then(() => undefined)
+    }, `${verb} failed`).finally(() => setBusy(false))
+    if (!outcome.ok) {
+      setError(outcome.message)
+      return
+    }
+    setOpen(false)
+    await router.invalidate()
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label={`${verb} ${user.email}`}
+        onClick={() => setOpen(true)}
+      >
+        {verb}
+      </Button>
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogTitle>
+            {verb} {user.email}?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {banned
+              ? 'The user will be able to sign in again.'
+              : 'The user will be signed out and blocked from signing in.'}
+          </AlertDialogDescription>
+          {error ? (
+            <p role="alert" className="text-xs text-destructive">
+              {error}
+            </p>
+          ) : null}
+          <div className="flex justify-end gap-2">
+            <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant={banned ? 'default' : 'destructive'}
+              disabled={busy}
+              onClick={() => void confirm()}
+            >
+              {busy ? <Spinner data-icon="inline-start" /> : null}
+              {verb}
+            </AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
 export function AdminUserActions({ users }: { readonly users: readonly SystemUser[] }) {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
@@ -54,27 +135,6 @@ export function AdminUserActions({ users }: { readonly users: readonly SystemUse
     }
     await router.invalidate()
     return true
-  }
-
-  async function toggleBan(user: SystemUser) {
-    const banned = user.banned
-    const verb = banned ? 'Unban' : 'Ban'
-    // The busy key is scoped to the user so only the acting row shows a
-    // spinner; the visible/accessible label stays stable while pending.
-    await settle(
-      () => {
-        if (banned) {
-          return unbanSystemUserServerFn({ data: { userId: user.id } }).then(
-            () => undefined
-          )
-        }
-        return banSystemUserServerFn({ data: { userId: user.id } }).then(
-          () => undefined
-        )
-      },
-      `${verb}:${user.id}`,
-      verb
-    )
   }
 
   async function loadWorkspaces(userId: string) {
@@ -122,32 +182,7 @@ export function AdminUserActions({ users }: { readonly users: readonly SystemUse
 
   return (
     <div className="grid gap-4">
-      <ul className="grid gap-2">
-        {users.map((user) => (
-          <li
-            key={user.id}
-            className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1"
-          >
-            <span className="min-w-0 text-sm break-all text-muted-foreground">
-              {user.email}
-            </span>
-            <Button
-              variant={user.banned ? 'outline' : 'destructive'}
-              size="sm"
-              disabled={busy !== null}
-              aria-label={`${user.banned ? 'Unban' : 'Ban'} ${user.email}`}
-              onClick={() => void toggleBan(user)}
-            >
-              {user.banned ? 'Unban' : 'Ban'}
-              {busy === `${user.banned ? 'Unban' : 'Ban'}:${user.id}` ? (
-                <Spinner data-icon="inline-end" />
-              ) : null}
-            </Button>
-          </li>
-        ))}
-      </ul>
-
-      <div className="grid gap-2 rounded-md border border-border p-3">
+      <div className="grid gap-2 rounded-none bg-muted p-3">
         <p className="text-xs text-muted-foreground">Workspace roles</p>
         <Select
           value={selectedId}
@@ -165,13 +200,13 @@ export function AdminUserActions({ users }: { readonly users: readonly SystemUse
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {users.map((user) => (
-              <SelectGroup key={user.id}>
-                <SelectItem value={user.id}>
+            <SelectGroup>
+              {users.map((user) => (
+                <SelectItem key={user.id} value={user.id}>
                   {user.name} ({user.email})
                 </SelectItem>
-              </SelectGroup>
-            ))}
+              ))}
+            </SelectGroup>
           </SelectContent>
         </Select>
         <Button

--- a/apps/web/src/components/api-token-form.test.tsx
+++ b/apps/web/src/components/api-token-form.test.tsx
@@ -64,6 +64,8 @@ describe('ApiTokenForm', () => {
     expect(createToken).toHaveBeenCalledWith({
       data: { workspaceSlug: 'starter-lab', name: 'CI token', scopes: ['read'] }
     })
+    await screen.findByRole('alert')
+    fireEvent.click(screen.getByRole('button', { name: 'Show API token' }))
     await screen.findByText('bsk_live_secret_value')
   })
 

--- a/apps/web/src/components/api-token-form.tsx
+++ b/apps/web/src/components/api-token-form.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { FieldError, FieldLabel, FieldLegend, FieldSet } from '@/components/ui/field'
 import { Spinner } from '@/components/ui/spinner'
+import { SecretReveal } from '@/components/secret-reveal'
 import { createApiTokenServerFn } from '@/lib/server/api-tokens'
 import { callServerFn } from '@/lib/server-call'
 
@@ -182,7 +183,11 @@ export function ApiTokenForm({
             Token created. Copy it now, it will not be shown again.
           </AlertTitle>
           <AlertDescription>
-            <code className="break-all">{created.token}</code>
+            <SecretReveal
+              secret={created.token}
+              label="API token"
+              className="flex items-center gap-2"
+            />
           </AlertDescription>
         </Alert>
       ) : null}

--- a/apps/web/src/components/auth/auth-card-form.tsx
+++ b/apps/web/src/components/auth/auth-card-form.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 import { useHydrated } from '@/lib/client-only-value'
 import { PublicLayout } from '@/components/public-layout'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -48,6 +48,10 @@ export function AuthCardForm({
   // Hydration signal for e2e: interacting before React hydrates falls through
   // to a native GET submit, so the smoke test waits for this attribute.
   const hydrated = useHydrated()
+  const errorRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (error) errorRef.current?.focus()
+  }, [error])
   return (
     <PublicLayout>
       {/* `flex-1` fills the space PublicLayout's `min-h-dvh flex-col` leaves
@@ -79,7 +83,7 @@ export function AuthCardForm({
                 {children}
                 {submit}
                 {error ? (
-                  <Alert variant="destructive">
+                  <Alert ref={errorRef} tabIndex={-1} variant="destructive">
                     <AlertDescription>{error}</AlertDescription>
                   </Alert>
                 ) : null}

--- a/apps/web/src/components/charts/webhook-success-chart.tsx
+++ b/apps/web/src/components/charts/webhook-success-chart.tsx
@@ -31,7 +31,14 @@ export function WebhookSuccessChart({
 
   return (
     <div className="h-40 w-full">
-      <ResponsiveContainer width="100%" height="100%">
+      <ul className="sr-only">
+        {data.map((entry) => (
+          <li key={entry.label}>
+            {entry.label}: {entry.successRate}% success rate
+          </li>
+        ))}
+      </ul>
+      <ResponsiveContainer aria-hidden width="100%" height="100%">
         <BarChart data={data} margin={CHART_MARGIN}>
           <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
           <XAxis dataKey="label" tickLine={false} axisLine={false} tick={AXIS_TICK} />
@@ -46,7 +53,7 @@ export function WebhookSuccessChart({
             {data.map((entry) => (
               <Cell
                 key={entry.label}
-                fill={entry.successRate >= 95 ? 'var(--chart-1)' : 'var(--destructive)'}
+                fill={entry.successRate >= 95 ? 'var(--chart-1)' : 'var(--chart-3)'}
               />
             ))}
           </Bar>

--- a/apps/web/src/components/confirm-button.tsx
+++ b/apps/web/src/components/confirm-button.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
@@ -7,7 +7,7 @@ import { Spinner } from '@/components/ui/spinner'
  * An irreversible action's two states: the idle button that arms it, then an
  * armed pair (confirm plus cancel). The armed state can be owned here or
  * lifted — panels that arm one row at a time pass `armed`/`onArm`/`onCancel`
- * keyed to the row.
+ * keyed to the row. Pass `target` to distinguish rows by accessible name.
  */
 export function ConfirmButton({
   label,
@@ -19,6 +19,7 @@ export function ConfirmButton({
   size = 'sm',
   cancelVariant = 'ghost',
   className,
+  target,
   armed,
   onArm,
   onCancel
@@ -32,6 +33,7 @@ export function ConfirmButton({
   readonly size?: React.ComponentProps<typeof Button>['size']
   readonly cancelVariant?: React.ComponentProps<typeof Button>['variant']
   readonly className?: string
+  readonly target?: string
   readonly armed?: boolean
   readonly onArm?: () => void
   readonly onCancel?: () => void
@@ -39,12 +41,31 @@ export function ConfirmButton({
   const [armedHere, setArmedHere] = useState(false)
   const isArmed = armed ?? armedHere
 
+  const confirmRef = useRef<HTMLButtonElement>(null)
+  const onCancelRef = useRef(onCancel)
+
+  useEffect(() => {
+    if (!isArmed) return
+    onCancelRef.current = onCancel
+    confirmRef.current?.focus()
+    function disarm(event: KeyboardEvent) {
+      if (event.key !== 'Escape') return
+      setArmedHere(false)
+      onCancelRef.current?.()
+    }
+    document.addEventListener('keydown', disarm)
+    return () => document.removeEventListener('keydown', disarm)
+  }, [isArmed, onCancel])
+
+  const row = target ? ` ${target}` : ''
+
   if (!isArmed) {
     return (
       <Button
         variant={variant}
         size={size}
         className={className}
+        aria-label={`${label}${row}`}
         onClick={() => {
           setArmedHere(true)
           onArm?.()
@@ -56,10 +77,15 @@ export function ConfirmButton({
   }
   return (
     <>
+      <span className="sr-only" role="alert">
+        Press again to confirm{target ? ` ${target}` : ''}
+      </span>
       <Button
+        ref={confirmRef}
         variant="destructive"
         size={size}
         disabled={busy}
+        aria-label={`${confirmLabel}${row}`}
         onClick={() => {
           setArmedHere(false)
           onCancel?.()
@@ -72,6 +98,7 @@ export function ConfirmButton({
       <Button
         variant={cancelVariant}
         size={size}
+        aria-label={`${cancelLabel}${row}`}
         onClick={() => {
           setArmedHere(false)
           onCancel?.()

--- a/apps/web/src/components/data-table.test.tsx
+++ b/apps/web/src/components/data-table.test.tsx
@@ -64,9 +64,10 @@ describe('DataTable', () => {
     expect(next.disabled).toBe(true)
   })
 
-  it('hides pagination controls when everything fits on one page', () => {
+  it('keeps pagination controls rendered but disabled when everything fits on one page', () => {
     render(<DataTable columns={columns} data={rows} pageSize={10} />)
-    expect(screen.queryByRole('button', { name: 'Next' })).toBeNull()
+    const next = screen.getByRole<HTMLButtonElement>('button', { name: 'Next' })
+    expect(next.disabled).toBe(true)
   })
 
   it('sorts rows when a sortable header is toggled', () => {

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { Option, Schema } from 'effect'
 import {
   columnFilteringFeature,
@@ -32,7 +32,26 @@ import {
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 
-const STICKY_CLASSES = 'sticky left-0 z-10 bg-card'
+const STICKY_CLASSES = 'sticky left-0 z-10 bg-card group-hover:bg-muted/50'
+
+/** Deterministic UTC rendering so SSR and the browser agree; table
+ * convention sets identifiers and timestamps in mono tabular figures. */
+function isDate(cell: ReactNode | Date): cell is Date {
+  return Object.prototype.toString.call(cell) === '[object Date]'
+}
+
+function formatDateCell(value: Date) {
+  return (
+    <span className="font-mono tabular-nums">
+      {value.toLocaleString('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZone: 'UTC'
+      })}{' '}
+      UTC
+    </span>
+  )
+}
 
 // v9 registers features explicitly (prerequisites before their slots). The
 // registered `sortFns` are the ones `sortFn: 'auto'` can resolve for a column.
@@ -188,12 +207,16 @@ export function DataTable<TData extends RowData>({
             </TableRow>
           ) : (
             table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
+              <TableRow key={row.id} className="group">
                 {row.getVisibleCells().map((cell) => {
                   const isSticky = cell.column.columnDef.meta?.sticky === true
+                  const rendered = flexRender(
+                    cell.column.columnDef.cell,
+                    cell.getContext()
+                  )
                   return (
                     <TableCell key={cell.id} className={cn(isSticky && STICKY_CLASSES)}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      {isDate(rendered) ? formatDateCell(rendered) : rendered}
                     </TableCell>
                   )
                 })}
@@ -202,35 +225,33 @@ export function DataTable<TData extends RowData>({
           )}
         </TableBody>
       </Table>
-      {filteredCount > pageSize ? (
-        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
-          <span>
-            Page {table.state.pagination.pageIndex + 1} of {table.getPageCount()}
-            {' · '}
-            {filteredCount} rows
-          </span>
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              Previous
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              Next
-            </Button>
-          </div>
+      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span>
+          Page {table.state.pagination.pageIndex + 1} of {table.getPageCount()}
+          {' · '}
+          {filteredCount} rows
+        </span>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
         </div>
-      ) : null}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/form-text-field.tsx
+++ b/apps/web/src/components/form-text-field.tsx
@@ -14,6 +14,20 @@ type FormTextFieldProps = Omit<
   readonly onChange: (value: string) => void
 }
 
+// oxlint-disable anti-slop/no-runtime-typeof, anti-slop/no-unknown-parameters, starter/no-unknown-error-message
+// TanStack Form validator failures reach this component untyped — a plain
+// string from our validators, or an object carrying a `message`. This is the
+// parse step for that boundary: the shape probes live here once and nowhere else.
+function errorMessageOf(error: unknown): string | undefined {
+  if (typeof error === 'string') return error
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const { message } = error
+    if (typeof message === 'string') return message
+  }
+  return undefined
+}
+// oxlint-enable anti-slop/no-runtime-typeof, anti-slop/no-unknown-parameters, starter/no-unknown-error-message
+
 export function FormTextField({
   name,
   label,
@@ -25,6 +39,9 @@ export function FormTextField({
 }: FormTextFieldProps) {
   const hasError = errors.length > 0
   const errorId = `${name}-error`
+  const errorMessages = errors
+    .map(errorMessageOf)
+    .filter((message): message is string => message !== undefined)
 
   return (
     <Field data-invalid={hasError || undefined}>
@@ -39,7 +56,9 @@ export function FormTextField({
         aria-describedby={hasError ? errorId : undefined}
         {...inputProps}
       />
-      {hasError ? <FieldError id={errorId}>{errors.join(', ')}</FieldError> : null}
+      {hasError && errorMessages.length > 0 ? (
+        <FieldError id={errorId}>{errorMessages.join(', ')}</FieldError>
+      ) : null}
     </Field>
   )
 }

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -49,13 +49,21 @@ function HeroSection({ workspaceSlug }: { readonly workspaceSlug: string }) {
               >
                 <GithubIcon className="size-4" />
                 View on GitHub
+                <span className="sr-only">(opens in new tab)</span>
               </a>
               <code className="font-mono text-xs text-muted-foreground max-sm:mt-2">
                 $ bun install && bun run dev
               </code>
             </div>
           </div>
-          <figure className="rise rise-3 min-w-0 overflow-x-auto border border-border bg-card p-3 sm:p-4">
+          <figure
+            // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- <figure> is the semantic element; role="region" exposes the scrollable area without losing figure semantics.
+            role="region"
+            aria-label="Architecture schematic, scrollable horizontally"
+            // oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- keyboard users need a focus stop to pan the horizontally overflowing schematic.
+            tabIndex={0}
+            className="rise rise-3 min-w-0 overflow-x-auto border border-border bg-card p-3 sm:p-4"
+          >
             <ArchitectureSchematic />
             <figcaption className="sr-only">
               Every label in this diagram is a real path in the repository.

--- a/apps/web/src/components/mdx-link.tsx
+++ b/apps/web/src/components/mdx-link.tsx
@@ -14,9 +14,17 @@ export function MdxLink({ href, children, className }: MdxLinkProps) {
     return <span className={className}>{children}</span>
   }
 
-  const isInternal = href.startsWith('/') || href.startsWith('#')
+  const isAnchor = href.startsWith('#')
 
-  if (isInternal) {
+  if (isAnchor) {
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    )
+  }
+
+  if (href.startsWith('/')) {
     return (
       <Link to={href} className={className}>
         {children}

--- a/apps/web/src/components/members-panel.tsx
+++ b/apps/web/src/components/members-panel.tsx
@@ -102,6 +102,7 @@ export function MembersPanel({
                       variant="ghost"
                       size="sm"
                       disabled={changing === member.id}
+                      aria-label={`Make ${role}: ${member.name}`}
                       onClick={() => void changeRole(member.id, role)}
                     >
                       {changing === member.id ? (

--- a/apps/web/src/components/public-layout.tsx
+++ b/apps/web/src/components/public-layout.tsx
@@ -83,7 +83,7 @@ export function PublicLayout({ children }: { readonly children: ReactNode }) {
           <ThemeToggle />
           <Link
             to="/sign-in"
-            className="inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             Sign in
           </Link>
@@ -96,19 +96,19 @@ export function PublicLayout({ children }: { readonly children: ReactNode }) {
           <div className="flex flex-wrap gap-4">
             <Link
               to="/privacy"
-              className="underline-offset-4 hover:text-foreground hover:underline"
+              className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
             >
               Privacy
             </Link>
             <Link
               to="/terms"
-              className="underline-offset-4 hover:text-foreground hover:underline"
+              className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
             >
               Terms
             </Link>
             <Link
               to="/changelog"
-              className="underline-offset-4 hover:text-foreground hover:underline"
+              className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
             >
               Changelog
             </Link>

--- a/apps/web/src/components/secret-reveal.tsx
+++ b/apps/web/src/components/secret-reveal.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+function maskSecret(secret: string) {
+  if (secret.length <= 8) return `••••••••${secret.slice(-4)}`
+  return `${secret.slice(0, 3)}…${secret.slice(-4)}`
+}
+export function SecretReveal({
+  secret,
+  label,
+  className
+}: {
+  readonly secret: string
+  readonly label: string
+  readonly className?: string
+}) {
+  const [revealed, setRevealed] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => () => clearTimeout(timer.current), [])
+
+  async function copy() {
+    await navigator.clipboard.writeText(secret)
+    setCopied(true)
+    clearTimeout(timer.current)
+    timer.current = setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <span className={className}>
+      <code className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
+        {revealed ? secret : maskSecret(secret)}
+      </code>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-label={revealed ? `Hide ${label}` : `Show ${label}`}
+        aria-pressed={revealed}
+        onClick={() => {
+          setRevealed((r) => !r)
+        }}
+      >
+        {revealed ? 'Hide' : 'Show'}
+      </Button>
+      <Button type="button" variant="ghost" size="sm" onClick={() => void copy()}>
+        Copy
+        <span className="sr-only"> {label}</span>
+      </Button>
+      <output className="sr-only">{copied ? 'Copied' : ''}</output>
+    </span>
+  )
+}

--- a/apps/web/src/components/sessions-panel.test.tsx
+++ b/apps/web/src/components/sessions-panel.test.tsx
@@ -72,7 +72,10 @@ describe('SessionsPanel', () => {
       screen.getByRole('button', { name: 'Sign out everywhere else' })
     ).toBeDefined()
     // The current session has no per-row revoke button.
-    expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeNull()
+    expect(screen.queryByRole('button', { name: 'Revoke Mac session' })).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Revoke Mobile browser session' })
+    ).toBeDefined()
   })
 
   it('revokes a single other session and refreshes the list', async () => {
@@ -93,7 +96,12 @@ describe('SessionsPanel', () => {
       />
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Revoke' }))
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Revoke Mobile browser session'
+      })
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Revoke session' }))
     await waitFor(() =>
       expect(revokeSession).toHaveBeenCalledWith({ token: 'tok_other' })
     )
@@ -120,6 +128,7 @@ describe('SessionsPanel', () => {
     fireEvent.click(
       await screen.findByRole('button', { name: 'Sign out everywhere else' })
     )
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }))
     await waitFor(() => expect(revokeOtherSessions).toHaveBeenCalledTimes(1))
     expect(revokeSession).not.toHaveBeenCalled()
   })
@@ -142,6 +151,7 @@ describe('SessionsPanel', () => {
     fireEvent.click(
       await screen.findByRole('button', { name: 'Sign out everywhere else' })
     )
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }))
     const alert = await screen.findByRole('alert')
     expect(alert.textContent).toContain('Could not revoke sessions')
   })

--- a/apps/web/src/components/sessions-panel.tsx
+++ b/apps/web/src/components/sessions-panel.tsx
@@ -208,7 +208,7 @@ export function SessionsPanel({
           ))}
         </ul>
       ) : null}
-      {rows === null ? null : (
+      {Array.isArray(rows) ? (
         <ul className="grid gap-2">
           {rows.map((row) => {
             const isCurrent = row.token === currentSessionToken
@@ -266,7 +266,7 @@ export function SessionsPanel({
             )
           })}
         </ul>
-      )}
+      ) : null}
     </section>
   )
 }

--- a/apps/web/src/components/sessions-panel.tsx
+++ b/apps/web/src/components/sessions-panel.tsx
@@ -124,6 +124,7 @@ export function SessionsPanel({
   const {
     data: rows,
     error: queryError,
+    isPending,
     refetch
   } = useQuery({
     queryKey: SESSIONS_QUERY_KEY,
@@ -198,7 +199,7 @@ export function SessionsPanel({
         </p>
       ) : null}
 
-      {rows === null && !loadError ? (
+      {hydrated && isPending ? (
         <ul className="grid gap-2" aria-busy="true">
           {[0, 1].map((index) => (
             <li key={index} className="rounded-sm border border-border px-3 py-2">

--- a/apps/web/src/components/sessions-panel.tsx
+++ b/apps/web/src/components/sessions-panel.tsx
@@ -4,6 +4,16 @@ import { useQuery } from '@tanstack/react-query'
 import { authClient } from '@/lib/auth-client'
 import { useHydrated } from '@/lib/client-only-value'
 import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+  AlertDialogTrigger
+} from '@/components/ui/alert-dialog'
+import { Skeleton } from '@/components/ui/skeleton'
 
 /**
  * One row of the panel's own view model: a Better Auth session plus the
@@ -155,13 +165,25 @@ export function SessionsPanel({
           <h3 className="text-sm font-medium">Active sessions</h3>
         </div>
         {othersExist ? (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => void act(() => revokeOtherSessions())}
-          >
-            Sign out everywhere else
-          </Button>
+          <AlertDialog>
+            <AlertDialogTrigger render={<Button variant="outline" size="sm" />}>
+              Sign out everywhere else
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogTitle>Sign out everywhere else?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Every session except this device will be revoked.
+              </AlertDialogDescription>
+              <div className="flex justify-end gap-2">
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => void act(() => revokeOtherSessions())}
+                >
+                  Sign out
+                </AlertDialogAction>
+              </div>
+            </AlertDialogContent>
+          </AlertDialog>
         ) : null}
       </header>
 
@@ -176,38 +198,75 @@ export function SessionsPanel({
         </p>
       ) : null}
 
-      <ul className="grid gap-2">
-        {(rows ?? []).map((row) => {
-          const isCurrent = row.token === currentSessionToken
-          return (
-            <li
-              key={row.token}
-              className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-sm border border-border px-3 py-2"
-            >
-              <div className="min-w-0 flex-1">
-                <p className="text-sm">
-                  {row.deviceLabel}{' '}
-                  {isCurrent ? (
-                    <span className="text-muted-foreground">· This device</span>
-                  ) : null}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {row.ipAddress ? `${row.ipAddress} · ` : ''}Expires {row.expiresLabel}
-                </p>
-              </div>
-              {isCurrent ? null : (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => void act(() => revokeSession({ token: row.token }))}
-                >
-                  Revoke
-                </Button>
-              )}
+      {rows === null && !loadError ? (
+        <ul className="grid gap-2" aria-busy="true">
+          {[0, 1].map((index) => (
+            <li key={index} className="rounded-sm border border-border px-3 py-2">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="mt-1 h-3 w-56" />
             </li>
-          )
-        })}
-      </ul>
+          ))}
+        </ul>
+      ) : null}
+      {rows === null ? null : (
+        <ul className="grid gap-2">
+          {rows.map((row) => {
+            const isCurrent = row.token === currentSessionToken
+            return (
+              <li
+                key={row.token}
+                className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-sm border border-border px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm">
+                    {row.deviceLabel}{' '}
+                    {isCurrent ? (
+                      <span className="text-muted-foreground">· This device</span>
+                    ) : null}
+                  </p>
+                  <p className="text-xs font-mono tabular-nums text-muted-foreground">
+                    {row.ipAddress ? `${row.ipAddress} · ` : ''}Expires{' '}
+                    {row.expiresLabel}
+                  </p>
+                </div>
+                {isCurrent ? null : (
+                  <AlertDialog>
+                    <AlertDialogTrigger
+                      render={
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Revoke ${row.deviceLabel} session`}
+                        />
+                      }
+                    >
+                      Revoke
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogTitle>
+                        Revoke the {row.deviceLabel} session?
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        That device will be signed out.
+                      </AlertDialogDescription>
+                      <div className="flex justify-end gap-2">
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() =>
+                            void act(() => revokeSession({ token: row.token }))
+                          }
+                        >
+                          Revoke session
+                        </AlertDialogAction>
+                      </div>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
     </section>
   )
 }

--- a/apps/web/src/components/table-of-contents.tsx
+++ b/apps/web/src/components/table-of-contents.tsx
@@ -34,7 +34,7 @@ export function TableOfContents({
                 }}
                 aria-current={isActive ? 'location' : undefined}
                 className={cn(
-                  'block border-l-2 py-1 text-xs transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring',
+                  'block border-l-2 py-2 text-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring',
                   heading.level === 3 ? 'pl-5' : 'pl-3',
                   isActive
                     ? 'border-foreground font-medium text-foreground'

--- a/apps/web/src/components/two-factor-panel.tsx
+++ b/apps/web/src/components/two-factor-panel.tsx
@@ -235,10 +235,13 @@ export function TwoFactorPanel({
       <section className="grid gap-4" aria-label="Two-factor authentication">
         <header className="flex items-center gap-2">
           <ShieldCheckIcon className="size-4 text-primary" />
-          <h3 className="text-sm font-medium">Two-factor authentication</h3>
+          <h3 className="text-sm font-medium">Status</h3>
         </header>
-        <p className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span className="inline-block size-2 rounded-full bg-primary" aria-hidden />
+        <p className="text-sm text-muted-foreground">
+          <span
+            className="mr-2 inline-block size-2 rounded-full bg-muted-foreground"
+            aria-hidden
+          />
           On. Codes are required at sign-in.
         </p>
         <form
@@ -284,6 +287,7 @@ export function TwoFactorPanel({
         <div className="flex flex-wrap items-start gap-6">
           <figure aria-label="Two-factor secret QR code">
             <QRCodeSVG value={state.totpURI} size={144} />
+            <figcaption className="sr-only">Two-factor secret QR code</figcaption>
           </figure>
           <div className="grid max-w-xs gap-1">
             <p className="text-sm text-muted-foreground">
@@ -345,10 +349,10 @@ export function TwoFactorPanel({
     <section className="grid gap-4" aria-label="Two-factor authentication">
       <header className="flex items-center gap-2">
         <ShieldCheckIcon className="size-4 text-muted-foreground" />
-        <h3 className="text-sm font-medium">Two-factor authentication</h3>
+        <h3 className="text-sm font-medium">Turn on</h3>
       </header>
-      <p className="flex items-center gap-2 text-sm text-muted-foreground">
-        <span className="inline-block size-2 rounded-full bg-border" aria-hidden />
+      <p className="text-sm text-muted-foreground">
+        <span className="mr-2 inline-block size-2 rounded-full bg-border" aria-hidden />
         Off. Add an authenticator-app code to sign-in.
       </p>
       <form

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog'
+import * as React from 'react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  children,
+  ...props
+}: AlertDialogPrimitive.Popup.Props) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        className={cn(
+          'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-full sm:max-w-sm -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md border border-border p-6 shadow-lg duration-200',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </AlertDialogPrimitive.Popup>
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Props) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('text-foreground text-sm font-medium', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: AlertDialogPrimitive.Description.Props) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-muted-foreground text-xs/relaxed', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-action"
+      render={<Button size="sm" className={className} {...props} />}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      render={<Button size="sm" variant="outline" className={className} {...props} />}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel
+}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'h-5 gap-1 rounded-none border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge',
+  'h-5.5 gap-1 rounded-md border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge',
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-none border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-1 aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
   {
     variants: {
       variant: {
@@ -23,14 +23,14 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          'h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
-        xs: "h-6 gap-1 rounded-none px-2 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-none px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3',
-        icon: 'size-8',
-        'icon-xs': "size-6 rounded-none [&_svg:not([class*='size-'])]:size-3",
-        'icon-sm': 'size-7 rounded-none',
-        'icon-lg': 'size-9'
+          'h-9 gap-1.5 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        xs: "h-7 gap-1 px-2 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1 px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: 'h-10 gap-1.5 px-3 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3',
+        icon: 'size-9',
+        'icon-xs': "size-7 [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10'
       }
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-none border bg-transparent px-2.5 py-1 text-xs transition-colors file:h-6 file:text-xs file:font-medium focus-visible:ring-1 aria-invalid:ring-1 md:text-xs file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-9 rounded-md border bg-transparent px-2.5 py-1 text-sm transition-colors file:h-6 file:text-xs file:font-medium focus-visible:ring-1 aria-invalid:ring-1 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-9 rounded-md border bg-transparent px-3 py-2 text-sm transition-colors focus-visible:ring-1 aria-invalid:ring-1 placeholder:text-muted-foreground w-full min-w-0 outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/apps/web/src/components/webhooks-panel.tsx
+++ b/apps/web/src/components/webhooks-panel.tsx
@@ -19,6 +19,7 @@ import { Separator } from '@/components/ui/separator'
 import { Spinner } from '@/components/ui/spinner'
 import { WebhookForm, type CreateWebhookEndpoint } from '@/components/webhook-form'
 import { ConfirmButton } from '@/components/confirm-button'
+import { SecretReveal } from '@/components/secret-reveal'
 import { webhookDeliveryStatusVariant } from '@/lib/badge-variants'
 import { viewerCan, type Viewer } from '@/lib/permissions'
 import {
@@ -255,7 +256,11 @@ export function WebhooksPanel({
                         Secret rotated. Copy it now, it will not be shown again.
                       </AlertTitle>
                       <AlertDescription>
-                        <code className="break-all">{rotatedSecret.secret}</code>
+                        <SecretReveal
+                          secret={rotatedSecret.secret}
+                          label="Webhook secret"
+                          className="flex items-center gap-2"
+                        />
                       </AlertDescription>
                     </Alert>
                   </>

--- a/apps/web/src/components/workspace-assistant-page.tsx
+++ b/apps/web/src/components/workspace-assistant-page.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Textarea } from '@/components/ui/textarea'
 import { WorkspaceShell } from '@/components/workspace-shell'
 import { viewerCan } from '@/lib/permissions'
 import { Spinner } from '@/components/ui/spinner'
@@ -31,22 +32,19 @@ const PROVIDER_LABELS = {
 } satisfies Record<AssistantPageProvider, string>
 
 type TranscriptEntry = {
-  readonly id: number
+  readonly id: string
   readonly role: 'user' | 'assistant'
   readonly text: string
   /** Set on assistant entries that carry a real provider reply. */
   readonly provider: AssistantPageProvider | null
 }
 
-let nextEntryId = 0
-
 function entry(
   role: TranscriptEntry['role'],
   text: string,
   provider: AssistantPageProvider | null = null
 ): TranscriptEntry {
-  nextEntryId += 1
-  return { id: nextEntryId, role, text, provider }
+  return { id: crypto.randomUUID(), role, text, provider }
 }
 
 function outcomeToEntry(outcome: AskAssistantOutcome): TranscriptEntry {
@@ -86,7 +84,7 @@ function TranscriptBubble({ item }: { readonly item: TranscriptEntry }) {
   const isUser = item.role === 'user'
   return (
     <li className="grid gap-1">
-      <div className="text-muted-foreground text-xs uppercase tracking-wide">
+      <div className="text-muted-foreground text-xs font-medium">
         {isUser ? 'You' : 'Assistant'}
       </div>
       <div
@@ -185,18 +183,13 @@ export function WorkspaceAssistantPage({
                 void submit()
               }}
             >
-              {/* Plain textarea on purpose: the shadcn set has no textarea
-                  primitive, and the audit page sets the same precedent for
-                  one-off inputs. `text-base` keeps the control at 16px on
-                  mobile for readable focus. */}
-              <textarea
+              <Textarea
                 aria-label="Your question"
                 value={question}
                 onChange={(event) => setQuestion(event.target.value)}
                 maxLength={2000}
                 rows={3}
                 placeholder="e.g. Summarize what changed recently"
-                className="rounded-md border border-input bg-transparent px-3 py-2 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:text-sm disabled:opacity-50"
                 disabled={pending}
               />
               <div className="flex justify-end">

--- a/apps/web/src/components/workspace-general-settings.tsx
+++ b/apps/web/src/components/workspace-general-settings.tsx
@@ -187,7 +187,7 @@ function DeleteSection({
   }
 
   return (
-    <div className="grid gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-4">
+    <div className="grid gap-2 rounded-none bg-muted p-4">
       <p className="text-sm font-medium">Delete this workspace</p>
       <p className="text-sm text-muted-foreground">
         Removing <span className="font-medium">{name}</span> removes every member,

--- a/apps/web/src/components/workspace-shell.tsx
+++ b/apps/web/src/components/workspace-shell.tsx
@@ -103,7 +103,7 @@ export function WorkspaceShell({
       >
         Skip to content
       </a>
-      <aside className="hidden border-r border-border p-4 lg:block">
+      <aside className="hidden border-r border-sidebar-border bg-sidebar text-sidebar-foreground p-4 lg:block">
         <WorkspaceNav
           workspaceSlug={workspaceSlug}
           canReadAuditLog={canReadAuditLog}
@@ -122,7 +122,10 @@ export function WorkspaceShell({
                 </Button>
               }
             />
-            <SheetContent side="left" className="flex flex-col gap-0">
+            <SheetContent
+              side="left"
+              className="flex flex-col gap-0 bg-sidebar text-sidebar-foreground border-sidebar-border"
+            >
               <SheetHeader>
                 <SheetTitle className="sr-only">Workspace navigation</SheetTitle>
                 <SheetDescription className="sr-only">
@@ -145,7 +148,11 @@ export function WorkspaceShell({
             <p className="truncate text-sm text-muted-foreground">{description}</p>
           </div>
           {unreadCount === undefined ? null : (
-            <Badge variant="secondary" className="gap-1">
+            <Badge
+              variant="secondary"
+              className="gap-1 font-mono tabular-nums"
+              aria-label={`${unreadCount} unread notifications`}
+            >
               <BellIcon className="size-3" />
               {unreadCount}
             </Badge>
@@ -164,33 +171,42 @@ export function WorkspaceShell({
 function SignOutButton({ signOut }: { readonly signOut: SignOut }) {
   const router = useRouter()
   const [signingOut, setSigningOut] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   // `callServerFn` keeps the Better Auth rejection in the error channel and
   // never rejects itself, so the flag below is cleared on every path — a
   // failed sign-out can be retried instead of leaving the header stuck.
   // The failure is reported rather than escaping as an unhandled rejection.
   async function runSignOut() {
+    setError(null)
     const outcome = await callServerFn(async () => {
       await signOut()
       await router.navigate({ to: '/sign-in' })
     }, SIGN_OUT_FAILED)
     setSigningOut(false)
     if (!outcome.ok) {
-      console.error('Sign-out failed', outcome.message)
+      setError(outcome.message)
     }
   }
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label="Sign out"
-      disabled={signingOut}
-      onClick={() => {
-        setSigningOut(true)
-        void runSignOut()
-      }}
-    >
-      <LogOutIcon className="size-4" />
-    </Button>
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Sign out"
+        disabled={signingOut}
+        onClick={() => {
+          setSigningOut(true)
+          void runSignOut()
+        }}
+      >
+        <LogOutIcon className="size-4" />
+      </Button>
+      {error ? (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/web/src/hooks/use-heading-observer.ts
+++ b/apps/web/src/hooks/use-heading-observer.ts
@@ -6,6 +6,13 @@ type Heading = {
   readonly level: number
 }
 
+function addsHeading(node: Node): boolean {
+  return (
+    node instanceof Element &&
+    (node.matches('h2[id], h3[id]') || node.querySelector('h2[id], h3[id]') !== null)
+  )
+}
+
 export function useHeadingObserver({
   containerRef
 }: {
@@ -61,7 +68,10 @@ export function useHeadingObserver({
     sync(container)
 
     let debounceId = 0
-    const mutationObserver = new MutationObserver(() => {
+    const mutationObserver = new MutationObserver((records) => {
+      if (!records.some((record) => [...record.addedNodes].some(addsHeading))) {
+        return
+      }
       window.clearTimeout(debounceId)
       debounceId = window.setTimeout(() => sync(container), 50)
     })

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -43,7 +43,7 @@
   --font-sans: Geist, ui-sans-serif, sans-serif, system-ui;
   --font-display: 'Archivo Variable', Geist, ui-sans-serif, sans-serif;
   --font-mono: Geist Mono, ui-monospace, monospace;
-  --radius: 0rem;
+  --radius: 0.5rem;
   --shadow-x: 0;
   --shadow-y: 1px;
   --shadow-blur: 3px;
@@ -105,7 +105,7 @@
   --font-sans: Geist, ui-sans-serif, sans-serif, system-ui;
   --font-display: 'Archivo Variable', Geist, ui-sans-serif, sans-serif;
   --font-mono: Geist Mono, ui-monospace, monospace;
-  --radius: 0rem;
+  --radius: 0.5rem;
   --shadow-x: 0;
   --shadow-y: 1px;
   --shadow-blur: 3px;
@@ -249,8 +249,10 @@
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  /* Controls resolve to 6px via rounded-md; panels, cards and code blocks
+     stay square (0rem) per the sharp/soft brand contrast. */
+  --radius-lg: 0rem;
+  --radius-xl: 0rem;
 
   --shadow-2xs: var(--shadow-2xs);
   --shadow-xs: var(--shadow-xs);
@@ -430,13 +432,4 @@
 .prose :where(code):not(:where([class~='not-prose'] *))::before,
 .prose :where(code):not(:where([class~='not-prose'] *))::after {
   content: '';
-}
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
 }

--- a/apps/web/src/lib/badge-variants.ts
+++ b/apps/web/src/lib/badge-variants.ts
@@ -14,6 +14,6 @@ export function invitationStatusVariant(status: Invitation['status']): BadgeVari
 // the render — the column is free-text by design.
 export function webhookDeliveryStatusVariant(status: string): BadgeVariant {
   if (status === 'delivered') return 'default'
-  if (status === 'failed') return 'secondary'
-  return 'destructive'
+  if (status === 'failed') return 'destructive'
+  return 'outline'
 }

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -5,7 +5,7 @@ import {
 import { createFileRoute } from '@tanstack/react-router'
 import { Effect } from 'effect'
 
-import { AdminUserActions } from '@/components/admin-user-actions'
+import { AdminUserActions, BanUserAction } from '@/components/admin-user-actions'
 import { DataTable, type DataTableColumnDef } from '@/components/data-table'
 import { WorkspaceShell } from '@/components/workspace-shell'
 import { Badge } from '@/components/ui/badge'
@@ -40,6 +40,12 @@ const userColumns: DataTableColumnDef<SystemUser>[] = [
     accessorKey: 'banned',
     header: 'Status',
     cell: ({ row }) => renderStatus(row.original.banned)
+  },
+  {
+    id: 'actions',
+    header: '',
+    enableSorting: false,
+    cell: ({ row }) => <BanUserAction user={row.original} />
   }
 ]
 

--- a/apps/web/src/routes/blog.$slug.tsx
+++ b/apps/web/src/routes/blog.$slug.tsx
@@ -89,7 +89,7 @@ function BlogPostPage() {
               <div className="flex items-center gap-3 text-sm text-muted-foreground">
                 <span>{frontmatter.author}</span>
                 <span>&middot;</span>
-                <time>
+                <time dateTime={frontmatter.date}>
                   {new Date(frontmatter.date).toLocaleDateString('en-US', {
                     year: 'numeric',
                     month: 'long',

--- a/apps/web/src/routes/blog.index.tsx
+++ b/apps/web/src/routes/blog.index.tsx
@@ -49,7 +49,10 @@ function BlogIndexPage() {
               <p className="mt-1 text-xs text-muted-foreground">
                 {post.frontmatter.description}
               </p>
-              <time className="mt-auto pt-2 text-xs text-muted-foreground">
+              <time
+                dateTime={post.frontmatter.date}
+                className="mt-auto pt-2 text-xs text-muted-foreground"
+              >
                 {new Date(post.frontmatter.date).toLocaleDateString('en-US', {
                   year: 'numeric',
                   month: 'long',

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -4,7 +4,23 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { changelog } from '@/lib/content'
 
 export const Route = createFileRoute('/changelog')({
-  component: ChangelogPage
+  component: ChangelogPage,
+  head: () => ({
+    meta: [
+      { title: 'Changelog | B2B SaaS Starter' },
+      {
+        name: 'description',
+        content:
+          'Release history for the B2B SaaS Starter: new capabilities, fixes, and breaking changes by version.'
+      },
+      { property: 'og:title', content: 'Changelog | B2B SaaS Starter' },
+      {
+        property: 'og:description',
+        content:
+          'Release history for the B2B SaaS Starter: new capabilities, fixes, and breaking changes by version.'
+      }
+    ]
+  })
 })
 
 function ChangelogPage() {
@@ -17,7 +33,7 @@ function ChangelogPage() {
             <Card key={entry.version}>
               <CardHeader>
                 <p className="text-sm text-muted-foreground">
-                  {entry.version} · {entry.date}
+                  {entry.version} · <time dateTime={entry.date}>{entry.date}</time>
                 </p>
                 <CardTitle as="h2">{entry.title}</CardTitle>
               </CardHeader>

--- a/apps/web/src/routes/docs.$category.$slug.tsx
+++ b/apps/web/src/routes/docs.$category.$slug.tsx
@@ -138,7 +138,7 @@ function DocArticlePage() {
             /* Colors come from the `.marketing .prose` token map in index.css;
                `prose-neutral` would hardcode a gray palette that clashes with
                Catppuccin and can fail AA in dark mode. */
-            className="prose max-w-none"
+            className="prose max-w-3xl"
           >
             <Component components={mdxComponents} />
           </article>
@@ -151,7 +151,7 @@ function DocArticlePage() {
               <Link
                 to="/docs/$category/$slug"
                 params={{ category, slug: prevSlug }}
-                className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                className="inline-flex items-center gap-1 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 <ArrowLeftIcon className="size-3" />
                 {prevTitle}
@@ -163,7 +163,7 @@ function DocArticlePage() {
               <Link
                 to="/docs/$category/$slug"
                 params={{ category, slug: nextSlug }}
-                className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                className="py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 {nextTitle} &rarr;
               </Link>

--- a/apps/web/src/routes/docs.index.tsx
+++ b/apps/web/src/routes/docs.index.tsx
@@ -55,7 +55,7 @@ function DocsIndex() {
                     <Link
                       to="/docs/$category/$slug"
                       params={{ category: slug, slug: article.slug }}
-                      className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      className="block py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
                     >
                       {article.frontmatter.title}
                     </Link>

--- a/apps/web/src/routes/docs.tsx
+++ b/apps/web/src/routes/docs.tsx
@@ -23,7 +23,7 @@ function DocsLayout() {
                   {/* Group label, not a heading: the page's first heading is the
                       article <h1> in <main>, and an <h2>/<h3> here would skip
                       levels in the document outline. */}
-                  <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-foreground">
+                  <p className="mb-1 text-xs font-semibold text-foreground">
                     {DOC_CATEGORIES[slug]}
                   </p>
                   <ul className="flex flex-col gap-0.5">
@@ -38,8 +38,8 @@ function DocsLayout() {
                             aria-current={isActive ? 'page' : undefined}
                             className={
                               isActive
-                                ? 'block rounded-md bg-muted px-2 py-1 text-sm font-medium text-foreground'
-                                : 'block rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground'
+                                ? 'block rounded-md bg-muted px-2 py-2 text-sm font-medium text-foreground'
+                                : 'block rounded-md px-2 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground'
                             }
                           >
                             {article.frontmatter.title}

--- a/apps/web/src/routes/faq.tsx
+++ b/apps/web/src/routes/faq.tsx
@@ -9,7 +9,23 @@ import {
 import { faqItems } from '@/lib/content'
 
 export const Route = createFileRoute('/faq')({
-  component: FaqPage
+  component: FaqPage,
+  head: () => ({
+    meta: [
+      { title: 'FAQ | B2B SaaS Starter' },
+      {
+        name: 'description',
+        content:
+          'Answers about billing, licensing, and adopting the B2B SaaS Starter for your product.'
+      },
+      { property: 'og:title', content: 'FAQ | B2B SaaS Starter' },
+      {
+        property: 'og:description',
+        content:
+          'Answers about billing, licensing, and adopting the B2B SaaS Starter for your product.'
+      }
+    ]
+  })
 })
 
 function FaqPage() {

--- a/apps/web/src/routes/forgot-password.tsx
+++ b/apps/web/src/routes/forgot-password.tsx
@@ -96,7 +96,9 @@ export function ForgotPasswordPage({
       }
     >
       {sent ? (
-        <p className="text-sm text-muted-foreground">{SENT_MESSAGE}</p>
+        <p role="alert" className="text-sm text-muted-foreground">
+          {SENT_MESSAGE}
+        </p>
       ) : (
         <form.Field name="email" validators={{ onChange: emailValidator }}>
           {(field) => (

--- a/apps/web/src/routes/pricing.tsx
+++ b/apps/web/src/routes/pricing.tsx
@@ -4,7 +4,23 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 export const Route = createFileRoute('/pricing')({
-  component: PricingPage
+  component: PricingPage,
+  head: () => ({
+    meta: [
+      { title: 'Pricing | B2B SaaS Starter' },
+      {
+        name: 'description',
+        content:
+          'Plans for teams adopting the B2B SaaS Starter, from local development to enterprise patterns.'
+      },
+      { property: 'og:title', content: 'Pricing | B2B SaaS Starter' },
+      {
+        property: 'og:description',
+        content:
+          'Plans for teams adopting the B2B SaaS Starter, from local development to enterprise patterns.'
+      }
+    ]
+  })
 })
 
 type Plan = {
@@ -62,9 +78,9 @@ function PricingPage() {
                 <p className="text-sm text-muted-foreground">{plan.description}</p>
                 <Link
                   to="/sign-up"
-                  className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-none border border-border bg-background px-3 text-xs font-medium transition-colors hover:bg-muted hover:text-foreground"
+                  className="inline-flex h-11 max-md:w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-none border border-border bg-background px-3 text-xs font-medium transition-colors hover:bg-muted hover:text-foreground"
                 >
-                  {plan.name === 'Enterprise' ? 'Contact sales' : 'Get started'}
+                  Get started
                 </Link>
                 <p className="text-xs text-muted-foreground">
                   Checkout completes on your workspace's Billing page. Stripe checkout

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -2,7 +2,23 @@ import { createFileRoute } from '@tanstack/react-router'
 import { PublicLayout } from '@/components/public-layout'
 
 export const Route = createFileRoute('/privacy')({
-  component: PrivacyPage
+  component: PrivacyPage,
+  head: () => ({
+    meta: [
+      { title: 'Privacy | B2B SaaS Starter' },
+      {
+        name: 'description',
+        content:
+          'How the reference app categorizes workspace, member, session, and audit data.'
+      },
+      { property: 'og:title', content: 'Privacy | B2B SaaS Starter' },
+      {
+        property: 'og:description',
+        content:
+          'How the reference app categorizes workspace, member, session, and audit data.'
+      }
+    ]
+  })
 })
 
 function PrivacyPage() {
@@ -10,7 +26,7 @@ function PrivacyPage() {
     <PublicLayout>
       <main id="main-content" className="mx-auto w-full max-w-3xl px-4 py-12 sm:px-6">
         <h1 className="text-3xl font-semibold">Privacy</h1>
-        <div className="prose mt-6 max-w-none dark:prose-invert">
+        <div className="prose mt-6 max-w-none">
           <p>
             This starter-focused page describes the reference app's data categories:
             users, sessions, workspaces, members, API tokens, audit events,

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -74,10 +74,6 @@ export function ResetPasswordPage({
     defaultValues: { password: '', confirm: '' } satisfies ResetPasswordValues,
     onSubmit: async ({ value }) => {
       setSubmitError(null)
-      if (value.password !== value.confirm) {
-        setSubmitError('Passwords do not match')
-        return
-      }
       const result = await resetPassword({
         newPassword: value.password,
         token: token ?? ''
@@ -152,8 +148,13 @@ export function ResetPasswordPage({
       <form.Field
         name="confirm"
         validators={{
-          onChange: ({ value }) =>
-            value.length === 0 ? 'Confirm your password' : undefined
+          onChange: ({ value, fieldApi }) => {
+            if (value.length === 0) return 'Confirm your password'
+            if (value !== fieldApi.form.getFieldValue('password')) {
+              return 'Passwords do not match'
+            }
+            return null
+          }
         }}
       >
         {(field) => (

--- a/apps/web/src/routes/sign-in.tsx
+++ b/apps/web/src/routes/sign-in.tsx
@@ -132,35 +132,39 @@ export function SignInPage({
               Forgot your password?
             </Link>
           </p>
-          <p className="text-xs text-muted-foreground">
-            Seeded a local database? Sign in with{' '}
-            <code className="rounded-sm bg-muted px-1 py-0.5">
-              {DEMO_CREDENTIALS.email}
-            </code>{' '}
-            /{' '}
-            <code className="rounded-sm bg-muted px-1 py-0.5">
-              {DEMO_CREDENTIALS.password}
-            </code>
-            .
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Or as a plain member, to see the role-gated view:{' '}
-            <code className="rounded-sm bg-muted px-1 py-0.5">
-              {DEMO_MEMBER_CREDENTIALS.email}
-            </code>{' '}
-            /{' '}
-            <code className="rounded-sm bg-muted px-1 py-0.5">
-              {DEMO_MEMBER_CREDENTIALS.password}
-            </code>
-            .
-          </p>
-          <Link
-            to="/workspaces/$workspaceSlug"
-            params={{ workspaceSlug: DEMO_WORKSPACE_SLUG }}
-            className="text-center text-sm text-primary underline underline-offset-4"
-          >
-            Open seeded workspace instead
-          </Link>
+          {import.meta.env.DEV ? (
+            <>
+              <p className="text-xs text-muted-foreground">
+                Seeded a local database? Sign in with{' '}
+                <code className="rounded-sm bg-muted px-1 py-0.5">
+                  {DEMO_CREDENTIALS.email}
+                </code>{' '}
+                /{' '}
+                <code className="rounded-sm bg-muted px-1 py-0.5">
+                  {DEMO_CREDENTIALS.password}
+                </code>
+                .
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Or as a plain member, to see the role-gated view:{' '}
+                <code className="rounded-sm bg-muted px-1 py-0.5">
+                  {DEMO_MEMBER_CREDENTIALS.email}
+                </code>{' '}
+                /{' '}
+                <code className="rounded-sm bg-muted px-1 py-0.5">
+                  {DEMO_MEMBER_CREDENTIALS.password}
+                </code>
+                .
+              </p>
+              <Link
+                to="/workspaces/$workspaceSlug"
+                params={{ workspaceSlug: DEMO_WORKSPACE_SLUG }}
+                className="text-center text-sm text-primary underline underline-offset-4"
+              >
+                Open seeded workspace instead
+              </Link>
+            </>
+          ) : null}
           <p className="text-center text-sm text-muted-foreground">
             No account yet?{' '}
             <Link

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -2,7 +2,23 @@ import { createFileRoute } from '@tanstack/react-router'
 import { PublicLayout } from '@/components/public-layout'
 
 export const Route = createFileRoute('/terms')({
-  component: TermsPage
+  component: TermsPage,
+  head: () => ({
+    meta: [
+      { title: 'Terms | B2B SaaS Starter' },
+      {
+        name: 'description',
+        content:
+          'Implementation-copy terms covering acceptable use, accounts, billing, and API access for the starter.'
+      },
+      { property: 'og:title', content: 'Terms | B2B SaaS Starter' },
+      {
+        property: 'og:description',
+        content:
+          'Implementation-copy terms covering acceptable use, accounts, billing, and API access for the starter.'
+      }
+    ]
+  })
 })
 
 function TermsPage() {
@@ -10,7 +26,7 @@ function TermsPage() {
     <PublicLayout>
       <main id="main-content" className="mx-auto w-full max-w-3xl px-4 py-12 sm:px-6">
         <h1 className="text-3xl font-semibold">Terms</h1>
-        <div className="prose mt-6 max-w-none dark:prose-invert">
+        <div className="prose mt-6 max-w-none">
           <p>
             These starter terms are implementation copy, not final legal terms. They
             show where teams describe acceptable use, accounts, billing, workspace data,

--- a/apps/web/src/routes/two-factor.tsx
+++ b/apps/web/src/routes/two-factor.tsx
@@ -72,10 +72,13 @@ export function TwoFactorChallengePage({
             inputMode="numeric"
             autoComplete="one-time-code"
             placeholder="123456"
+            maxLength={6}
+            // oxlint-disable-next-line jsx-a11y/no-autofocus -- the challenge page has exactly one field, so focusing it cannot surprise anyone mid-task
+            autoFocus
             value={field.state.value}
             errors={field.state.meta.errors}
             onBlur={field.handleBlur}
-            onChange={field.handleChange}
+            onChange={(value) => field.handleChange(value.replaceAll(/\D/g, ''))}
             required
           />
         )}

--- a/apps/web/src/routes/workspaces.$workspaceSlug.index.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.index.tsx
@@ -66,7 +66,7 @@ export function WorkspaceDashboardPage({
       unreadCount={unreadCount}
       canReadAuditLog={viewerCan(viewer, { auditLog: ['read'] })}
     >
-      <div className="grid gap-6 lg:grid-cols-[1fr_22rem]">
+      <div className="grid gap-6">
         <div className="grid gap-6">
           <LiveNotifications
             workspaceSlug={workspace.slug}

--- a/apps/web/src/routes/workspaces.$workspaceSlug.settings.test.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.settings.test.tsx
@@ -53,9 +53,11 @@ async function renderPage(data: WorkspaceSettingsPayload = settingsSummary) {
 describe('WorkspaceSettingsPage', () => {
   it('renders the operational counts from the loader projection', async () => {
     await renderPage()
-    screen.getByText(/3 active workspace-scoped tokens/)
+    screen.getByText('3')
+    screen.getByText(/active workspace-scoped tokens/)
     screen.getByRole('link', { name: 'API tokens page' })
-    screen.getByText(/1 endpoint is configured/)
+    screen.getByText('1')
+    screen.getByText(/endpoint is configured/)
     // Unread-notification badge in the shell header.
     screen.getByText('2')
   })

--- a/apps/web/src/routes/workspaces.$workspaceSlug.settings.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.settings.tsx
@@ -123,8 +123,8 @@ export function WorkspaceSettingsPage({
               <div className="grid gap-2">
                 <Label>API tokens</Label>
                 <p className="text-sm text-muted-foreground">
-                  {apiTokenCount} active workspace-scoped tokens. Creation and
-                  revocation live on the{' '}
+                  <span className="font-mono tabular-nums">{apiTokenCount}</span> active
+                  workspace-scoped tokens. Creation and revocation live on the{' '}
                   <Link
                     to="/workspaces/$workspaceSlug/api-tokens"
                     params={{ workspaceSlug }}
@@ -159,7 +159,8 @@ export function WorkspaceSettingsPage({
               <div className="grid gap-2">
                 <Label>Outbound webhooks</Label>
                 <p className="text-sm text-muted-foreground">
-                  {webhookCount} endpoint
+                  <span className="font-mono tabular-nums">{webhookCount}</span>{' '}
+                  endpoint
                   {webhookCount === 1 ? ' is' : 's are'} configured for selected
                   workspace events. Registration, delivery history, and secret rotation
                   live on the{' '}

--- a/apps/web/src/routes/workspaces.index.tsx
+++ b/apps/web/src/routes/workspaces.index.tsx
@@ -2,7 +2,7 @@ import { listWorkspacesForUser } from '@b2b-saas-starter/capabilities/workspace-
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { CreateWorkspaceForm } from '@/components/create-workspace-form'
 import { EmailVerificationBanner } from '@/components/email-verification-banner'
-import { PublicLayout } from '@/components/public-layout'
+import { WorkspaceShell } from '@/components/workspace-shell'
 import { RoutePending } from '@/components/route-pending'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { runCapabilities } from '@/lib/capabilities'
@@ -22,12 +22,12 @@ function WorkspacesPage() {
   const navigate = useNavigate()
 
   return (
-    <PublicLayout>
-      <main id="main-content" className="mx-auto w-full max-w-4xl px-4 py-12 sm:px-6">
-        <h1 className="text-3xl font-semibold">Workspaces</h1>
-        <p className="mt-3 text-muted-foreground">
-          Every workspace your account is a member of.
-        </p>
+    <WorkspaceShell
+      workspaceSlug={null}
+      title="Workspaces"
+      description="Every workspace your account is a member of."
+    >
+      <div className="mx-auto w-full max-w-4xl">
         {/* The unverified state surfaces here rather than gating anything:
               verification is encouraged, not enforced (provider-light rule). */}
         {session.user.emailVerified ? null : (
@@ -74,7 +74,12 @@ function WorkspacesPage() {
                   </CardHeader>
                   <CardContent>
                     <p className="text-sm text-muted-foreground">
-                      {memberCount} members, {notificationCount} notifications
+                      <span className="font-mono tabular-nums">{memberCount}</span>{' '}
+                      members,{' '}
+                      <span className="font-mono tabular-nums">
+                        {notificationCount}
+                      </span>{' '}
+                      notifications
                     </p>
                   </CardContent>
                 </Card>
@@ -82,7 +87,7 @@ function WorkspacesPage() {
             ))}
           </div>
         )}
-      </main>
-    </PublicLayout>
+      </div>
+    </WorkspaceShell>
   )
 }


### PR DESCRIPTION
## Summary

Ran a full `$impeccable audit` across every web app page group (marketing, docs/blog, auth, workspace core, workspace features, admin/account) via parallel audits, then applied the recommended fixes. 50 files changed.

### Accessibility
- Field-level password-mismatch error; focus moves to error alerts on failed auth submits; OTP digit-only with `maxLength` + autofocus; sent/reset confirmations announced via `role="alert"`
- Member-scoped aria-labels on role-change buttons; unread-count badge and webhook chart data exposed to screen readers; sign-out failure surfaces inline instead of `console.error`
- Ban / per-session revoke / sign-out-everywhere now require confirmation dialogs; sessions render an aria-busy skeleton while loading
- Keyboard-pannable hero schematic, labelled QR figure, unique `head()` meta on pricing/faq/privacy/terms/changelog

### Design system
- Button/Input raised to `h-9 text-sm rounded-md`; Badge at 22px per contract; radius chain fixed so controls get 6px while panels stay sharp
- Duplicate `@layer base` merged; DESIGN.md prose reconciled with the implemented mauve/lavender palette; sidebar uses its own `--sidebar-*` tokens
- Workspaces index moved off the marketing layout onto `WorkspaceShell`; chart degraded band switched from destructive red to chart tokens

### Components
- New `SecretReveal` (masked + copyable secrets) used by API-token creation and webhook rotation
- `ConfirmButton` gains focus management, Escape-to-cancel, armed-state announcement, and target context in accessible names
- Badge variants: `failed` → destructive, unknown → outline; uppercase labels removed; mono/tabular figures for counts and table timestamps

### Docs & marketing
- Docs prose capped at `max-w-3xl`; touch targets raised across docs nav, TOC, pagers, footers; `<time dateTime>` added; hash links render native anchors; demo credentials gated behind `import.meta.env.DEV`

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` green (minimal test updates where behavior legitimately changed: settings count spans, data-table pagination disabled state, sessions confirm flows, token reveal)