### PR TITLE
fix(auth): enforce email, organization, and 2FA hardening from review

### DIFF
--- a/apps/web/src/components/auth/auth-validators.ts
+++ b/apps/web/src/components/auth/auth-validators.ts
@@ -13,7 +13,11 @@ export function emailValidator({ value }: { value: string }): string | undefined
   return
 }
 
-/** The password validator: at least 8 characters. */
+/**
+ * The password validator: mirrors the server's `minPasswordLength` (12) in
+ * `packages/auth` so a too-short password fails in the form instead of as a
+ * round-trip server error.
+ */
 export function passwordValidator({ value }: { value: string }): string | undefined {
-  return value.length < 8 ? 'Password must be at least 8 characters' : undefined
+  return value.length < 12 ? 'Password must be at least 12 characters' : undefined
 }

--- a/apps/web/src/components/two-factor-panel.test.tsx
+++ b/apps/web/src/components/two-factor-panel.test.tsx
@@ -4,12 +4,14 @@ import { type VerifyTotpCode } from './auth/auth-client-ports'
 import {
   TwoFactorPanel,
   type DisableTwoFactor,
-  type EnableTwoFactor
+  type EnableTwoFactor,
+  type GenerateBackupCodes
 } from './two-factor-panel'
 
 const enableTwoFactor = vi.fn<EnableTwoFactor>()
 const verifyTotp = vi.fn<VerifyTotpCode>()
 const disableTwoFactor = vi.fn<DisableTwoFactor>()
+const generateBackupCodes = vi.fn<GenerateBackupCodes>()
 
 const TOTP_URI =
   'otpauth://totp/B2B%20SaaS%20Starter:demo%40starter.local?secret=JBSWY3DPEHPK3PXP&issuer=B2B%2BSaaS%20Starter'
@@ -19,6 +21,7 @@ describe('TwoFactorPanel', () => {
     enableTwoFactor.mockReset()
     verifyTotp.mockReset()
     disableTwoFactor.mockReset()
+    generateBackupCodes.mockReset()
     enableTwoFactor.mockResolvedValue({
       data: { totpURI: TOTP_URI }
     })
@@ -170,5 +173,75 @@ describe('TwoFactorPanel', () => {
     expect(alert.textContent).toContain('Invalid password')
     // Still on.
     expect(screen.getByText(/On\. Codes are required at sign-in/)).toBeDefined()
+  })
+
+  it('regenerates backup codes behind a password confirmation', async () => {
+    generateBackupCodes.mockResolvedValue({
+      data: { backupCodes: ['new-1111', 'new-2222'] }
+    })
+    render(
+      <TwoFactorPanel
+        twoFactorEnabled
+        enableTwoFactor={enableTwoFactor}
+        verifyTotp={verifyTotp}
+        disableTwoFactor={disableTwoFactor}
+        generateBackupCodes={generateBackupCodes}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'correct-horse-battery-staple' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate backup codes' }))
+    await waitFor(() =>
+      expect(generateBackupCodes).toHaveBeenCalledWith({
+        password: 'correct-horse-battery-staple'
+      })
+    )
+    const codes = await screen.findByRole('region', { name: 'Backup codes' })
+    expect(codes.textContent).toContain('new-1111')
+    expect(codes.textContent).toContain('new-2222')
+
+    // Done dismisses the one-time reveal; the codes are not shown again.
+    fireEvent.click(screen.getByRole('button', { name: 'I saved my codes' }))
+    expect(screen.queryByRole('region', { name: 'Backup codes' })).toBeNull()
+  })
+
+  it('surfaces a failed backup-code regeneration without clearing the password state flip', async () => {
+    generateBackupCodes.mockResolvedValue({ error: { message: 'Invalid password' } })
+    render(
+      <TwoFactorPanel
+        twoFactorEnabled
+        enableTwoFactor={enableTwoFactor}
+        verifyTotp={verifyTotp}
+        disableTwoFactor={disableTwoFactor}
+        generateBackupCodes={generateBackupCodes}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'wrong-password' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate backup codes' }))
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Invalid password')
+    expect(screen.queryByRole('region', { name: 'Backup codes' })).toBeNull()
+  })
+
+  it('treats an incomplete regeneration response as a failure', async () => {
+    generateBackupCodes.mockResolvedValue({ data: {} })
+    render(
+      <TwoFactorPanel
+        twoFactorEnabled
+        enableTwoFactor={enableTwoFactor}
+        verifyTotp={verifyTotp}
+        disableTwoFactor={disableTwoFactor}
+        generateBackupCodes={generateBackupCodes}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'correct-horse-battery-staple' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate backup codes' }))
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('incomplete')
   })
 })

--- a/apps/web/src/components/two-factor-panel.tsx
+++ b/apps/web/src/components/two-factor-panel.tsx
@@ -37,12 +37,21 @@ export type DisableTwoFactor = (input: { readonly password: string }) => Promise
   readonly error?: { readonly message?: string | undefined } | null
 }>
 
+export type GenerateBackupCodes = (input: { readonly password: string }) => Promise<{
+  readonly data?: { readonly backupCodes?: string[] | undefined } | null | undefined
+  readonly error?: { readonly message?: string | undefined } | null
+}>
+
 function enableWithAuthClient(input: Parameters<EnableTwoFactor>[0]) {
   return authClient.twoFactor.enable(input)
 }
 
 function disableWithAuthClient(input: Parameters<DisableTwoFactor>[0]) {
   return authClient.twoFactor.disable(input)
+}
+
+function generateBackupCodesWithAuthClient(input: Parameters<GenerateBackupCodes>[0]) {
+  return authClient.twoFactor.generateBackupCodes(input)
 }
 
 type PanelState = {
@@ -73,6 +82,8 @@ type PanelAction =
     }
   | { readonly type: 'verified' }
   | { readonly type: 'disabled' }
+  | { readonly type: 'regenerated'; readonly backupCodes: readonly string[] }
+  | { readonly type: 'dismissCodes' }
   | { readonly type: 'failed'; readonly message: string }
   | { readonly type: 'clearStatus' }
 
@@ -112,6 +123,19 @@ function reducer(state: PanelState, action: PanelAction): PanelState {
         statusMessage: 'Two-factor authentication is now off.'
       }
     }
+    case 'regenerated': {
+      // New codes invalidate every previous one; they get the same one-time
+      // reveal as enrollment, until the user dismisses them.
+      return {
+        ...state,
+        password: '',
+        backupCodes: action.backupCodes,
+        statusMessage: null
+      }
+    }
+    case 'dismissCodes': {
+      return { ...state, backupCodes: null }
+    }
     case 'failed': {
       return { ...state, submitError: action.message }
     }
@@ -130,7 +154,8 @@ export function TwoFactorPanel({
   twoFactorEnabled,
   enableTwoFactor = enableWithAuthClient,
   verifyTotp = verifyTotpWithAuthClient,
-  disableTwoFactor = disableWithAuthClient
+  disableTwoFactor = disableWithAuthClient,
+  generateBackupCodes = generateBackupCodesWithAuthClient
 }: {
   // Optional/nullable to match the plugin's declared field shape; anything
   // truthy means "on".
@@ -138,6 +163,7 @@ export function TwoFactorPanel({
   readonly enableTwoFactor?: EnableTwoFactor
   readonly verifyTotp?: VerifyTotpCode
   readonly disableTwoFactor?: DisableTwoFactor
+  readonly generateBackupCodes?: GenerateBackupCodes
 }) {
   const [state, dispatch] = useReducer(reducer, {
     step: 'idle',
@@ -226,6 +252,27 @@ export function TwoFactorPanel({
     )
   }
 
+  function regenerateCodes() {
+    void runAction(
+      async () => {
+        const result = await generateBackupCodes({ password: state.password })
+        const backupCodes =
+          result.data && !result.error ? (result.data.backupCodes ?? null) : null
+        if (!result.error && (backupCodes === null || backupCodes.length === 0)) {
+          return {
+            error: { message: 'Regeneration response was incomplete' }
+          }
+        }
+        return { ...result, backupCodes }
+      },
+      'Could not regenerate backup codes',
+      (result) => {
+        if (!('backupCodes' in result) || result.backupCodes === null) return
+        dispatch({ type: 'regenerated', backupCodes: result.backupCodes })
+      }
+    )
+  }
+
   // The secret lives in the URI's query string; an unparseable URI yields no
   // secret rather than a mangled substring.
   const secretFromUri = parseSecretFromUri(state.totpURI)
@@ -265,6 +312,18 @@ export function TwoFactorPanel({
             Turn off
           </Button>
         </form>
+        {state.backupCodes !== null && state.backupCodes.length > 0 ? (
+          <BackupCodesSection
+            codes={state.backupCodes}
+            onDismiss={() => dispatch({ type: 'dismissCodes' })}
+          />
+        ) : null}
+        <RegenerateBackupCodesForm
+          password={state.password}
+          busy={busy}
+          onPasswordChange={(value) => dispatch({ type: 'password', value })}
+          onSubmit={regenerateCodes}
+        />
         <PanelMessages state={state} />
       </section>
     )
@@ -295,21 +354,10 @@ export function TwoFactorPanel({
           </div>
         </div>
         {state.backupCodes !== null && state.backupCodes.length > 0 ? (
-          <section
-            aria-label="Backup codes"
-            className="grid gap-2 rounded-sm border border-border bg-muted/40 p-4"
-          >
-            <p className="text-sm font-medium">
-              Save these one-time backup codes now. They are shown only once:
-            </p>
-            <ul className="flex flex-wrap gap-x-4 gap-y-1">
-              {state.backupCodes.map((backupCode) => (
-                <li key={backupCode}>
-                  <code className="font-mono text-xs">{backupCode}</code>
-                </li>
-              ))}
-            </ul>
-          </section>
+          <BackupCodesSection
+            codes={state.backupCodes}
+            intro="Save these one-time backup codes now. They are shown only once:"
+          />
         ) : null}
         <form
           onSubmit={(event) => {
@@ -395,5 +443,88 @@ function PanelMessages({ state }: { readonly state: PanelState }) {
         </p>
       ) : null}
     </>
+  )
+}
+
+/**
+ * The one-time backup-code reveal, shared by enrollment and regeneration.
+ * `onDismiss` (the "I saved my codes" button) is only offered where the codes
+ * can come back — regeneration — so the enrollment reveal keeps its hard
+ * once-only shape.
+ */
+function BackupCodesSection({
+  codes,
+  intro,
+  onDismiss
+}: {
+  readonly codes: readonly string[]
+  readonly intro?: string
+  readonly onDismiss?: () => void
+}) {
+  return (
+    <section
+      aria-label="Backup codes"
+      className="grid gap-2 rounded-sm border border-border bg-muted/40 p-4"
+    >
+      <p className="text-sm font-medium">
+        {intro ??
+          'Save these one-time backup codes now. They are shown only once, and every previous code is now invalid:'}
+      </p>
+      <ul className="flex flex-wrap gap-x-4 gap-y-1">
+        {codes.map((backupCode) => (
+          <li key={backupCode}>
+            <code className="font-mono text-xs">{backupCode}</code>
+          </li>
+        ))}
+      </ul>
+      {onDismiss ? (
+        <Button type="button" variant="outline" className="w-fit" onClick={onDismiss}>
+          I saved my codes
+        </Button>
+      ) : null}
+    </section>
+  )
+}
+
+/**
+ * The regeneration form: a fresh password confirmation feeding the same
+ * shared password state as turn-off. Neither action should trust the other's
+ * input; the distinct label keeps the two fields addressable while one value
+ * feeds both.
+ */
+function RegenerateBackupCodesForm({
+  password,
+  busy,
+  onPasswordChange,
+  onSubmit
+}: {
+  readonly password: string
+  readonly busy: boolean
+  readonly onPasswordChange: (value: string) => void
+  readonly onSubmit: () => void
+}) {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        onSubmit()
+      }}
+      className="grid gap-3"
+    >
+      <div className="grid gap-1.5">
+        <Label htmlFor="twofactor-password-regen">Confirm password</Label>
+        <Input
+          id="twofactor-password-regen"
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(event) => onPasswordChange(event.target.value)}
+          required
+        />
+      </div>
+      <Button type="submit" variant="outline" className="w-fit" disabled={busy}>
+        Regenerate backup codes
+      </Button>
+    </form>
   )
 }

--- a/apps/web/src/lib/auth-runtime.ts
+++ b/apps/web/src/lib/auth-runtime.ts
@@ -52,6 +52,12 @@ const AuthConfigLive = Layer.sync(AuthConfig)(() => ({
   // Production requires verified mailboxes; local dev and previews stay open
   // because lifecycle emails land in the log there (provider-light rule).
   requireEmailVerification: requireEmailVerification(env.ENVIRONMENT)
+  // `runBackground` stays unset: TanStack Start's server handlers do not
+  // surface the Worker's `ExecutionContext`, so there is no `ctx.waitUntil`
+  // to hand Better Auth's `advanced.backgroundTasks.handler`. The package's
+  // inline fallback runs instead — correct, just not crash-proof past the
+  // response. A fork whose server entry reaches the execution context should
+  // supply `runBackground: (promise) => ctx.waitUntil(promise)` here.
 }))
 
 export const AuthLive = Auth.layer.pipe(Layer.provide(AuthConfigLive))

--- a/apps/web/src/routes/sign-in.test.tsx
+++ b/apps/web/src/routes/sign-in.test.tsx
@@ -41,7 +41,7 @@ describe('SignInPage', () => {
     fireEvent.change(screen.getByLabelText('Password'), {
       target: { value: 'short' }
     })
-    await screen.findByText('Password must be at least 8 characters')
+    await screen.findByText('Password must be at least 12 characters')
     const submit = screen.getByRole<HTMLButtonElement>('button', { name: 'Continue' })
     expect(submit.disabled).toBe(true)
     expect(signIn).not.toHaveBeenCalled()

--- a/apps/web/src/routes/sign-up.test.tsx
+++ b/apps/web/src/routes/sign-up.test.tsx
@@ -48,7 +48,7 @@ describe('SignUpPage', () => {
     fireEvent.change(screen.getByLabelText('Password'), {
       target: { value: 'short' }
     })
-    await screen.findByText('Password must be at least 8 characters')
+    await screen.findByText('Password must be at least 12 characters')
     const submit = screen.getByRole<HTMLButtonElement>('button', {
       name: 'Create account'
     })

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -48,6 +48,13 @@ export type AuthConfigInterface = {
    * owns the decision, local dev stays provider-light.
    */
   readonly requireEmailVerification: boolean
+  /**
+   * Better Auth's `advanced.backgroundTasks.handler` (verification and reset
+   * emails are sent as detached background promises). On a Worker this should
+   * be `ctx.waitUntil` so a send survives its response; when absent the
+   * fallback runs the promise inline — still correct, just not crash-proof.
+   */
+  readonly runBackground?: ((promise: Promise<unknown>) => void) | undefined
 }
 
 export class AuthConfig extends Context.Service<AuthConfig, AuthConfigInterface>()(
@@ -79,6 +86,14 @@ export function makeAuthOptions(options: AuthConfigInterface) {
       // cannot pass would break the provider-light rule. The unverified state
       // is surfaced in the app instead (banner + resend).
       requireEmailVerification: options.requireEmailVerification,
+      // Stated rather than defaulted: B2B accounts are phishing targets, so
+      // the floor is above Better Auth's 8-character default.
+      minPasswordLength: 12,
+      maxPasswordLength: 256,
+      // Pinned explicitly so a Better Auth default change cannot silently
+      // extend the window in which a leaked reset link is live. Single-use
+      // either way; thirty minutes is ample for an email round trip.
+      resetPasswordTokenExpiresIn: 60 * 30,
       // A reset password is an account-takeover response primitive: once it
       // succeeds, the sessions that preceded it are exactly what the reset
       // exists to distrust.
@@ -102,9 +117,27 @@ export function makeAuthOptions(options: AuthConfigInterface) {
         await options.emails.sendPasswordReset({ email: user.email, url })
       }
     },
+    advanced: {
+      backgroundTasks: {
+        // Verification and reset sends ride this instead of the response
+        // chain: the endpoint must not hang on SMTP, and on Workers only
+        // `waitUntil` keeps the promise alive past the response. The inline
+        // fallback keeps local/test honest without an execution context.
+        handler: (promise: Promise<unknown>) => {
+          if (options.runBackground) {
+            options.runBackground(promise)
+            return
+          }
+          void promise.catch(() => undefined)
+        }
+      }
+    },
     session: {
-      // Defaults for expiresIn (7 days) and updateAge (24 hours) are kept;
-      // `freshAge` is the one knob the starter states: an hour after each
+      // Same values Better Auth defaults to, stated so a default change is a
+      // visible diff rather than a silent session-lifetime shift.
+      expiresIn: 60 * 60 * 24 * 7,
+      updateAge: 60 * 60 * 24,
+      // The knob the starter states beyond the defaults: an hour after each
       // session's last fresh authentication, sensitive account actions
       // (password change, 2FA enable/disable) can demand re-authentication
       // instead of trusting a long-lived cookie alone.
@@ -144,12 +177,30 @@ export function makeAuthOptions(options: AuthConfigInterface) {
         // enroll their own authenticator and lock the real owner out. The
         // account panel already runs enable → QR → first-code as its flow,
         // and a database hook emails the user on every state change.
-        skipVerificationOnEnable: false
+        skipVerificationOnEnable: false,
+        // Both pinned to the values Better Auth defaults to, so a default
+        // change cannot silently lengthen the challenge window or the
+        // trusted-device grace period.
+        twoFactorCookieMaxAge: 600,
+        trustDeviceMaxAge: 60 * 60 * 24 * 30
       }),
       admin({
         adminRoles: ['admin']
       }),
       organization({
+        // One workspace set per plan is billing's business; five is the
+        // starter's sanity cap on free creation.
+        organizationLimit: 5,
+        // Unverified mailboxes do not get to mint workspaces — but only when
+        // verification is actually enforced. Local dev (log-mode email) could
+        // never pass the gate, which would break the provider-light rule.
+        allowUserToCreateOrganization: (user) =>
+          !options.requireEmailVerification || user.emailVerified,
+        // Invitations are stated rather than left on Better Auth's implicit
+        // 48-hour default, and a re-invite cancels the stale link it replaces.
+        invitationExpiresIn: 60 * 60 * 24 * 7,
+        invitationLimit: 50,
+        cancelPendingInvitationsOnReInvite: true,
         // One statement set, one role table, shared with every non-plugin
         // permission check. `requirePermission` reads the same objects, so the
         // plugin's own endpoints and the starter's guard can never disagree.

--- a/packages/auth/src/options.test.ts
+++ b/packages/auth/src/options.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { type AuthConfigInterface, makeAuthOptions } from './index.ts'
 
 // The email-verification gate is decided by the caller (from `ENVIRONMENT`)
@@ -54,4 +54,108 @@ describe('makeAuthOptions', () => {
       freshAge: 60 * 60
     })
   })
+
+  it('pins the password policy above Better Auth defaults', () => {
+    expect(makeAuthOptions(baseConfig).emailAndPassword).toMatchObject({
+      minPasswordLength: 12,
+      maxPasswordLength: 256
+    })
+  })
+
+  it('pins the reset-token window to thirty minutes', () => {
+    // Explicit so a Better Auth default change cannot silently lengthen the
+    // window in which a leaked reset link is live.
+    expect(makeAuthOptions(baseConfig).emailAndPassword).toMatchObject({
+      resetPasswordTokenExpiresIn: 60 * 30
+    })
+  })
+
+  it('states the session lifetime instead of trusting defaults', () => {
+    expect(makeAuthOptions(baseConfig).session).toMatchObject({
+      expiresIn: 60 * 60 * 24 * 7,
+      updateAge: 60 * 60 * 24
+    })
+  })
+
+  describe('background tasks', () => {
+    it('runs detached promises inline without crashing when they reject', () => {
+      const handler = makeAuthOptions(baseConfig).advanced.backgroundTasks.handler
+      // The fallback must attach handlers (so an unhandled rejection cannot
+      // take the isolate down) without awaiting, rethrowing, or throwing on
+      // the synchronous path.
+      expect(() => {
+        handler(Promise.resolve())
+        handler(Promise.reject(new Error('send failed')))
+      }).not.toThrow()
+    })
+
+    it('delegates to runBackground when the app provides one', () => {
+      const runBackground = vi.fn()
+      const handler = makeAuthOptions({ ...baseConfig, runBackground }).advanced
+        .backgroundTasks.handler
+      const promise = Promise.resolve()
+      handler(promise)
+      expect(runBackground).toHaveBeenCalledWith(promise)
+    })
+  })
+
+  describe('two-factor knobs', () => {
+    it('pins the challenge-cookie and trusted-device windows', () => {
+      const options = pluginOptions(makeAuthOptions(baseConfig).plugins, 'two-factor')
+      expect(options.twoFactorCookieMaxAge).toBe(600)
+      expect(options.trustDeviceMaxAge).toBe(60 * 60 * 24 * 30)
+    })
+  })
+
+  describe('organization knobs', () => {
+    it('caps workspaces per user and pins invitation hygiene', () => {
+      const options = pluginOptions(makeAuthOptions(baseConfig).plugins, 'organization')
+      expect(options.organizationLimit).toBe(5)
+      expect(options.invitationExpiresIn).toBe(60 * 60 * 24 * 7)
+      expect(options.invitationLimit).toBe(50)
+      expect(options.cancelPendingInvitationsOnReInvite).toBe(true)
+    })
+
+    it('lets unverified users create workspaces while verification is off', () => {
+      const allowUserToCreateOrganization = allowCreateOrganization(
+        makeAuthOptions(baseConfig)
+      )
+      expect(allowUserToCreateOrganization({ emailVerified: false })).toBe(true)
+    })
+
+    it('gates workspace creation on a verified mailbox when verification is enforced', () => {
+      const allowUserToCreateOrganization = allowCreateOrganization(
+        makeAuthOptions({ ...baseConfig, requireEmailVerification: true })
+      )
+      expect(allowUserToCreateOrganization({ emailVerified: false })).toBe(false)
+      expect(allowUserToCreateOrganization({ emailVerified: true })).toBe(true)
+    })
+  })
 })
+
+/**
+ * Reads a Better Auth plugin's `options` bag, which the plugin's declared
+ * type omits — the same access the skipVerificationOnEnable test above makes.
+ */
+function pluginOptions(
+  plugins: ReturnType<typeof makeAuthOptions>['plugins'],
+  id: string
+): Record<string, unknown> {
+  const plugin = plugins.find((candidate) => 'id' in candidate && candidate.id === id)
+  // SAFETY: every option read through this helper lives on that bag by
+  // construction of `makeAuthOptions`.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion, effect/noAs -- reading an options bag Better Auth's plugin types do not declare
+  return (plugin as { options?: Record<string, unknown> }).options ?? {}
+}
+
+/** The creation gate, read off the organization plugin's bag and typed. */
+function allowCreateOrganization(options: ReturnType<typeof makeAuthOptions>) {
+  const raw = pluginOptions(
+    options.plugins,
+    'organization'
+  ).allowUserToCreateOrganization
+  // SAFETY: `makeAuthOptions` passes the predicate straight through; this is
+  // its own declared shape, just re-asserted for the test's call site.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion, effect/noAs -- re-typing a value stored as unknown by pluginOptions
+  return raw as (user: { emailVerified: boolean }) => boolean
+}


### PR DESCRIPTION
## Summary
Applies the recommendations from the Better Auth best-practices review (email/password, organization, two-factor), each pinned by tests in `packages/auth/src/options.test.ts`.

### Email & password
- `minPasswordLength: 12` / `maxPasswordLength: 256`; the client validator mirrors the floor so short passwords fail in the form
- `resetPasswordTokenExpiresIn: 60 * 30` — explicit so a Better Auth default change can't silently extend a leaked link's window
- Lifecycle-email sends detach through `advanced.backgroundTasks.handler`, backed by a new `runBackground` port on `AuthConfig` (inline fallback where no Worker `waitUntil` exists; `auth-runtime.ts` documents where a fork supplies it)

### Organization
- `organizationLimit: 5`
- `allowUserToCreateOrganization` gated on `emailVerified` **only when verification is enforced** (local dev with log-mode email stays provider-light)
- Invitation hygiene stated explicitly: `invitationExpiresIn` (7 days), `invitationLimit: 50`, `cancelPendingInvitationsOnReInvite: true`

### Two-factor
- Explicit `twoFactorCookieMaxAge: 600` and `trustDeviceMaxAge` (30 days)
- Backup-code regeneration behind password confirmation in the account panel, with the reveal extracted into shared subcomponents; tests cover success, wrong-password failure, and incomplete responses

### Session
- `expiresIn` / `updateAge` stated alongside `freshAge`

## Deliberately unchanged
- Sign-in's manual `twoFactorRedirect` handling preserves `?redirect=` better than a client-plugin callback would
- `sendInvitationEmail` stays app-side per the starter's binding architecture
- `session.activeOrganizationId` must exist — the plugin writes it unconditionally (AGENTS invariant #2)

## Test plan
- [x] `bun run test` — all suites pass (incl. new options pins and panel regeneration tests)
- [x] `bun run lint`
- [x] `bun run build`