### PR TITLE
fix(capabilities): apply Effect usage audit fixes

### DIFF
--- a/apps/web/src/lib/observability.test.ts
+++ b/apps/web/src/lib/observability.test.ts
@@ -1,7 +1,11 @@
 import { Effect, Schema } from 'effect'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { runWebRequestScope, withWebRequestScope } from './observability'
+import {
+  memoizePerRequest,
+  runWebRequestScope,
+  withWebRequestScope
+} from './observability'
 
 /**
  * The ambient request is the one input these functions read from outside their
@@ -147,6 +151,108 @@ describe('runWebRequestScope', () => {
     // No standalone marker: the nested run joined instead of opening a second
     // event of its own.
     expect(record.annotations['scope']).toBeUndefined()
+  })
+})
+
+describe('memoizePerRequest', () => {
+  it('dedupes calls per key within one request scope, not across keys', async () => {
+    const request = new Request('http://localhost/workspaces/acme')
+    ambient.request = request
+    let reads = 0
+    async function make() {
+      reads += 1
+      return `value-${reads}`
+    }
+
+    await runWebRequestScope(
+      { request, handlerType: 'router' },
+      async () => {
+        // Two callers in the same request — the beforeLoad gate and a server
+        // function — must share one read.
+        expect(await memoizePerRequest('auth.session', make, lookupRequest)).toBe(
+          'value-1'
+        )
+        expect(await memoizePerRequest('auth.session', make, lookupRequest)).toBe(
+          'value-1'
+        )
+        // A different key is its own slot.
+        expect(await memoizePerRequest('other.key', make, lookupRequest)).toBe(
+          'value-2'
+        )
+        return new Response(null, { status: 204 })
+      },
+      lookupRequest
+    )
+
+    expect(reads).toBe(2)
+  })
+
+  it('shares one slot when Start re-wraps the request mid-flight', async () => {
+    const registered = new Request('http://localhost/workspaces/acme')
+    ambient.request = new Request('http://localhost/workspaces/acme')
+    let reads = 0
+
+    await runWebRequestScope(
+      { request: registered, handlerType: 'router' },
+      async () => {
+        await memoizePerRequest(
+          'auth.session',
+          async () => {
+            reads += 1
+          },
+          lookupRequest
+        )
+        await memoizePerRequest(
+          'auth.session',
+          async () => {
+            reads += 1
+          },
+          lookupRequest
+        )
+        return new Response(null, { status: 204 })
+      },
+      lookupRequest
+    )
+
+    expect(reads).toBe(1)
+  })
+
+  it('falls back to calling make on every call outside a request scope', async () => {
+    let reads = 0
+    async function make() {
+      reads += 1
+      return reads
+    }
+
+    expect(await memoizePerRequest('k', make, lookupRequest)).toBe(1)
+    expect(await memoizePerRequest('k', make, lookupRequest)).toBe(2)
+  })
+
+  it('does not leak memoized values into a later request', async () => {
+    const first = new Request('http://localhost/first')
+    const second = new Request('http://localhost/second')
+    let reads = 0
+    async function make() {
+      reads += 1
+      return `read-${reads}`
+    }
+    async function run(request: Request): Promise<Response> {
+      return runWebRequestScope(
+        { request, handlerType: 'router' },
+        async () => {
+          await memoizePerRequest('k', make, lookupRequest)
+          return new Response(null, { status: 204 })
+        },
+        lookupRequest
+      )
+    }
+
+    ambient.request = first
+    await run(first)
+    ambient.request = second
+    await run(second)
+
+    expect(reads).toBe(2)
   })
 })
 

--- a/apps/web/src/lib/observability.ts
+++ b/apps/web/src/lib/observability.ts
@@ -44,6 +44,12 @@ type RequestTelemetry = {
   readonly baseKeys: ReadonlySet<string>
   /** Nested work, appended in completion order, flushed onto the wide event. */
   readonly nested: Array<Record<string, unknown>>
+  /**
+   * Per-request memoization slots (`memoizePerRequest`). Lives on the telemetry
+   * object — not a separate WeakMap — so it dies with the request *and* is
+   * shared across the `Request` instances Start may substitute mid-flight.
+   */
+  readonly memo: Map<string, Promise<unknown>>
 }
 
 // Keyed by the request object so entries die with the request; a Worker isolate
@@ -103,6 +109,41 @@ type WebRequestMetadata = {
 }
 
 /**
+ * One promise per (request, key): the request-scoped memoization every gate
+ * or loader that reads the same expensive thing more than once joins.
+ *
+ * Outside a request scope — unit tests, scripts, client-side navigations —
+ * there is nothing to dedupe against, so `make` runs on every call. Within a
+ * request, slots live on the request's telemetry object, so they die with the
+ * request (no cross-request leakage on an interleaved isolate) and are shared
+ * across the `Request` instances Start may substitute mid-flight, exactly like
+ * the telemetry join above.
+ *
+ * This is the sanctioned home for request-scoped memoization in this app; new
+ * call sites join it instead of adding another module-level WeakMap.
+ */
+export function memoizePerRequest<A>(
+  key: string,
+  make: () => Promise<A>,
+  lookupRequest: CurrentRequest = currentRequest
+): Promise<A> {
+  const request = lookupRequest()
+  const telemetry = request === undefined ? undefined : registry.get(request)
+  if (!telemetry) return make()
+  const existing = telemetry.memo.get(key)
+  if (existing) {
+    // SAFETY: slots are keyed by the caller's `key`, so every promise stored
+    // under one key came from that caller's own `make` — the value type is a
+    // property of the key, checked at this single boundary.
+    // oxlint-disable-next-line effect/noAs, typescript/no-unsafe-type-assertion -- see above
+    return existing as Promise<A>
+  }
+  const pending = make()
+  telemetry.memo.set(key, pending)
+  return pending
+}
+
+/**
  * Wraps one web request in the single wide-event scope every nested run joins.
  * Called only from the global request middleware.
  *
@@ -146,7 +187,13 @@ function registerAndRun(
     // request's identity (service, traceId, pathname) for free.
     const services = yield* Effect.context<never>()
     const baseKeys = new Set(Object.keys(yield* References.CurrentLogAnnotations))
-    const telemetry: RequestTelemetry = { span, services, baseKeys, nested: [] }
+    const telemetry: RequestTelemetry = {
+      span,
+      services,
+      baseKeys,
+      nested: [],
+      memo: new Map()
+    }
     registry.set(request, telemetry)
     // The middleware and the loaders may see different `Request` instances
     // (Start re-wraps the request as it flows through the handler chain), so

--- a/apps/web/src/lib/server/auth.ts
+++ b/apps/web/src/lib/server/auth.ts
@@ -3,7 +3,7 @@ import { notFound, redirect } from '@tanstack/react-router'
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
 import { Effect } from 'effect'
 import { authRuntime } from '../auth-runtime'
-import { withWebRequestScope } from '../observability'
+import { memoizePerRequest, withWebRequestScope } from '../observability'
 import { currentRequest } from '../request-context'
 
 /**
@@ -13,39 +13,35 @@ import { currentRequest } from '../request-context'
  * the gate's outcome into that request's one wide event. Without it the gate
  * that runs first on every gated route would be invisible.
  */
-// One session read per request: the registry is keyed by the request object
-// (an isolate interleaves concurrent requests, so a module-level "current"
-// would race — same pattern as request-context.ts). A route whose `beforeLoad`
-// gate and a server function both read the session must not pay two DB
-// round-trips for one document request.
-const sessionCache = new WeakMap<Request, Promise<Session | null>>()
-
-const readSession = createServerOnlyFn((): Promise<Session | null> => {
-  const request = currentRequest()
-  const cached = request === undefined ? undefined : sessionCache.get(request)
-  if (cached !== undefined) return cached
-  const pending = authRuntime.runPromise(
-    withWebRequestScope(
-      { event: 'auth.session' },
-      Effect.gen(function* () {
-        const auth = yield* Auth.Tag
-        // No ambient request (unit tests, scripts) means no cookie jar to
-        // read — that is an unauthenticated caller, not a crash.
-        if (request === undefined) {
-          yield* Effect.annotateLogsScoped({ authenticated: false })
-          return null
-        }
-        const session = yield* auth.api.getSession({ headers: request.headers })
-        // Whether the gate found a session is the useful fact. Never the token,
-        // never the email.
-        yield* Effect.annotateLogsScoped({ authenticated: session !== null })
-        return session
-      })
+// One session read per request through `memoizePerRequest`: a route whose
+// `beforeLoad` gate and a server function both read the session must not pay
+// two DB round-trips for one document request. Slots live on the request's
+// telemetry, so they survive Start re-wrapping the `Request` mid-flight —
+// which the old module-local WeakMap did not.
+const readSession = createServerOnlyFn((): Promise<Session | null> =>
+  memoizePerRequest('auth.session', () =>
+    authRuntime.runPromise(
+      withWebRequestScope(
+        { event: 'auth.session' },
+        Effect.gen(function* () {
+          const auth = yield* Auth.Tag
+          const request = currentRequest()
+          // No ambient request (unit tests, scripts) means no cookie jar to
+          // read — that is an unauthenticated caller, not a crash.
+          if (request === undefined) {
+            yield* Effect.annotateLogsScoped({ authenticated: false })
+            return null
+          }
+          const session = yield* auth.api.getSession({ headers: request.headers })
+          // Whether the gate found a session is the useful fact. Never the token,
+          // never the email.
+          yield* Effect.annotateLogsScoped({ authenticated: session !== null })
+          return session
+        })
+      )
     )
   )
-  if (request !== undefined) sessionCache.set(request, pending)
-  return pending
-})
+)
 
 const getSessionServerFn = createServerFn({ method: 'GET' }).handler(readSession)
 

--- a/packages/capabilities/src/billing/billing.test.ts
+++ b/packages/capabilities/src/billing/billing.test.ts
@@ -87,12 +87,9 @@ describe('seed billing contract', () => {
       )
       expect(Result.isFailure(result)).toBe(true)
       if (Result.isFailure(result)) {
+        // The typed error carries `reason` directly — no narrowing needed.
         expect(result.failure._tag).toBe('CapabilityUnavailable')
-        // SAFETY: the tag assertion above proves the cast; the reason field
-        // is what this test is about.
-        // oxlint-disable-next-line effect/noAs -- test-only narrowing proven by the tag assertion directly above
-        const error = result.failure as { readonly reason?: string }
-        expect(error.reason).toBe('provider_not_configured')
+        expect(result.failure.reason).toBe('provider_not_configured')
       }
     }).pipe(Effect.provide(billingFixture({ stripeConfigured: false }).layer))
   )

--- a/packages/capabilities/src/billing/billing.ts
+++ b/packages/capabilities/src/billing/billing.ts
@@ -303,10 +303,59 @@ function stripeCheckoutBody(input: {
   return params.toString()
 }
 
+/** Deadline for one outbound provider call (Stripe or siteverify). */
+const PROVIDER_TIMEOUT = '10 seconds'
+
+/**
+ * The Workers global `fetch` wrapped at the platform-adapter boundary: an HTTP
+ * client dependency would add weight, not safety, to one form-encoded POST,
+ * but the call still gets `Effect.tryPromise`'s `AbortSignal` so interruption
+ * and deadlines reach the socket, and transport failures are classified as
+ * typed `CapabilityUnavailable` instead of defects.
+ */
+function stripePost(url: string, headers: Record<string, string>, body: string) {
+  return Effect.tryPromise({
+    try: (signal) =>
+      // oxlint-disable-next-line effect/noGlobals -- see docstring above
+      fetch(url, { method: 'POST', headers, body, signal }),
+    catch: () =>
+      new CapabilityUnavailable({
+        capability: 'billing',
+        reason: 'stripe request failed'
+      })
+  }).pipe(
+    Effect.timeout(PROVIDER_TIMEOUT),
+    // The deadline is the same "provider unreachable" failure the transport
+    // path reports — never leak `TimeoutError` into the interface channel.
+    Effect.catchTag('TimeoutError', () =>
+      Effect.fail(
+        new CapabilityUnavailable({
+          capability: 'billing',
+          reason: 'stripe request timed out'
+        })
+      )
+    )
+  )
+}
+
+function stripeJson(response: Response) {
+  return Effect.tryPromise({
+    try: () => response.json(),
+    catch: () =>
+      new CapabilityUnavailable({
+        capability: 'billing',
+        reason: `stripe responded ${response.status} with an unparseable body`
+      })
+  })
+}
+
 /**
  * One form-encoded Stripe API call, via the Workers global `fetch` — the REST
  * API needs no SDK, and keeping the dependency out keeps the worker bundle
- * small and the failure surface explicit. Exported for tests.
+ * small and the failure surface explicit. The call carries an `AbortSignal`
+ * from `Effect.tryPromise` so interruption and the 10s deadline reach the
+ * socket, and transport failures surface as typed `CapabilityUnavailable`
+ * instead of defects. Exported for tests.
  */
 export const createStripeCheckoutSession = Effect.fnUntraced(function* (input: {
   readonly secretKey: string
@@ -316,18 +365,15 @@ export const createStripeCheckoutSession = Effect.fnUntraced(function* (input: {
   readonly successUrl: string
   readonly cancelUrl: string
 }) {
-  const response = yield* Effect.promise(() =>
-    // oxlint-disable-next-line effect/noGlobals -- the Workers global fetch is the platform adapter here; an HTTP client dependency would add weight, not safety, to one form-encoded POST
-    fetch('https://api.stripe.com/v1/checkout/sessions', {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${input.secretKey}`,
-        'content-type': 'application/x-www-form-urlencoded'
-      },
-      body: stripeCheckoutBody(input)
-    })
+  const response = yield* stripePost(
+    'https://api.stripe.com/v1/checkout/sessions',
+    {
+      authorization: `Bearer ${input.secretKey}`,
+      'content-type': 'application/x-www-form-urlencoded'
+    },
+    stripeCheckoutBody(input)
   )
-  const json: unknown = yield* Effect.promise(() => response.json())
+  const json = yield* stripeJson(response)
   const decoded = decodeStripeCheckoutResponse(json)
   let message = `stripe responded ${response.status}`
   if (Result.isSuccess(decoded) && decoded.success.error?.message !== undefined) {

--- a/packages/capabilities/src/developer-platform/api-token-registry.ts
+++ b/packages/capabilities/src/developer-platform/api-token-registry.ts
@@ -466,7 +466,10 @@ export const LiveApiTokenRegistry: Layer.Layer<
           }
           // Bump `lastUsedAt` at most once per LAST_USED_WRITE_INTERVAL_MS.
           // The per-request `api_token.used` audit event was removed: it did a
-          // second D1 write per request and flooded the governance log.
+          // second D1 write per request and flooded the governance log. The
+          // bump is best-effort telemetry — a transient write failure has no
+          // bearing on whether the token authenticates, so it is swallowed
+          // rather than failing an otherwise-valid request with 503.
           const usedAt = yield* DateTime.now
           if (
             shouldBumpLastUsedAt(row.token.lastUsedAt, DateTime.toEpochMillis(usedAt))
@@ -476,7 +479,7 @@ export const LiveApiTokenRegistry: Layer.Layer<
                 .update(apiTokens)
                 .set({ lastUsedAt: DateTime.formatIso(usedAt) })
                 .where(eq(apiTokens.id, row.token.id))
-            )
+            ).pipe(Effect.ignore)
           }
           return {
             id: row.token.id,

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.live.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.live.ts
@@ -13,8 +13,7 @@ import {
 import {
   ensureValidWebhookUrl,
   WebhookEndpoints,
-  type WebhookEndpoint,
-  type WebhookEventType
+  type WebhookEndpoint
 } from './webhook-endpoints.ts'
 import { randomHex } from '../internal/crypto.ts'
 import { newCapabilityId } from '../internal/ids.ts'
@@ -187,11 +186,9 @@ export const LiveWebhookEndpoints: Layer.Layer<
             description: input.description,
             signingSecret,
             enabled: true,
-            // Subscriptions stay free-text on the wire so producers can grow
-            // without a migration. SAFETY: every value shipped today is in the
-            // stored enum (`WEBHOOK_EVENT_TYPES`); D1 stores text either way.
-            // oxlint-disable-next-line effect/noAs, typescript/no-unsafe-type-assertion -- see above
-            events: [...input.events] as WebhookEventType[],
+            // Subscriptions stay free-text on the wire and at rest so producers
+            // can grow without a migration — the column type matches.
+            events: [...input.events],
             createdAt: DateTime.formatIso(createdAt)
           }
           // Insert + audit insert as one batch — the shared audited-mutation

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.ts
@@ -61,7 +61,7 @@ export const WEBHOOK_EVENT_TYPES = [
 export const CreateWebhookEndpointPayload = Schema.Struct({
   url: Schema.String,
   events: Schema.Array(Schema.String).check(Schema.isMinLength(1)),
-  description: Schema.optional(Schema.String)
+  description: Schema.optionalKey(Schema.String)
 })
 export type CreateWebhookEndpointPayload = typeof CreateWebhookEndpointPayload.Type
 

--- a/packages/capabilities/src/developer-platform/webhook-publisher.ts
+++ b/packages/capabilities/src/developer-platform/webhook-publisher.ts
@@ -23,7 +23,7 @@ export const WebhookQueueMessage = Schema.Struct({
   // so a strict check here would turn a cosmetic trace defect into a silently
   // dropped webhook. The consumer's decoder (`parentSpanFromHeaders`) already
   // ignores a value it cannot parse and starts its own trace instead.
-  traceparent: Schema.optional(Schema.String),
+  traceparent: Schema.optionalKey(Schema.String),
   payload: Schema.Unknown
 })
 export type WebhookQueueMessage = typeof WebhookQueueMessage.Type
@@ -94,6 +94,19 @@ export function publishWebhookEventWith(
 
 const unavailable = orUnavailable('webhook-publisher')
 
+/**
+ * Adds the producing request's `traceparent` onto a queue message. The field
+ * is an optional *key* on the wire schema, so it is only present when a span
+ * exists (tests, direct calls run without one).
+ */
+function withTraceparent(
+  message: WebhookQueueMessage,
+  traceparent: string | undefined
+): WebhookQueueMessage {
+  if (traceparent === undefined) return message
+  return { ...message, traceparent }
+}
+
 export function LiveWebhookPublisher(
   queue?: WebhookQueueBinding
 ): Layer.Layer<WebhookPublisher, never, Database> {
@@ -135,13 +148,15 @@ export function LiveWebhookPublisher(
                 try: () =>
                   queue.sendBatch(
                     subscribed.map((endpoint) => ({
-                      body: {
-                        endpointId: endpoint.id,
-                        workspaceId: ctx.workspace.id,
-                        eventType: input.eventType,
-                        traceparent,
-                        payload: input.payload
-                      }
+                      body: withTraceparent(
+                        {
+                          endpointId: endpoint.id,
+                          workspaceId: ctx.workspace.id,
+                          eventType: input.eventType,
+                          payload: input.payload
+                        },
+                        traceparent
+                      )
                     }))
                   ),
                 catch: (cause) => cause

--- a/packages/capabilities/src/governance/audit-event-log.ts
+++ b/packages/capabilities/src/governance/audit-event-log.ts
@@ -232,7 +232,7 @@ export function SeedAuditEventLog(
         const ctx = yield* WorkspaceContext
         return pagedSeedRows(rows, ctx.workspace.id, input)
       }),
-    listGlobal: Effect.succeed(toWire(rows)),
+    listGlobal: Effect.sync(() => toWire(rows)),
     record: (input) =>
       Effect.gen(function* () {
         // Appends into this instance's store so recorded events read back

--- a/packages/capabilities/src/governance/turnstile-verification.test.ts
+++ b/packages/capabilities/src/governance/turnstile-verification.test.ts
@@ -1,4 +1,5 @@
-import { Effect } from 'effect'
+import { Effect, Fiber } from 'effect'
+import { TestClock } from 'effect/testing'
 import { describe, expect, it } from '@effect/vitest'
 import { CapabilityUnavailable } from '../errors.ts'
 import {
@@ -103,7 +104,11 @@ describe('turnstile verification', () => {
             })
           )
       })
-      expect(yield* verifier.verify({ token: 'tok' })).toEqual({
+      // The bounded retry sleeps on TestClock; advance it while verify runs
+      // so all attempts exhaust deterministically.
+      const fiber = yield* Effect.forkChild(verifier.verify({ token: 'tok' }))
+      yield* TestClock.adjust('30 seconds')
+      expect(yield* Fiber.join(fiber)).toEqual({
         outcome: 'unavailable'
       })
     })

--- a/packages/capabilities/src/governance/turnstile-verification.ts
+++ b/packages/capabilities/src/governance/turnstile-verification.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Result, Schema } from 'effect'
+import { Context, Effect, Layer, Result, Schedule, Schema } from 'effect'
 import { CapabilityUnavailable } from '../errors.ts'
 /**
  * Cloudflare Turnstile server-side verification (ADR 0031). The widget proves
@@ -13,8 +13,8 @@ import { CapabilityUnavailable } from '../errors.ts'
  */
 
 export const SiteverifyResponse = Schema.Struct({
-  success: Schema.optional(Schema.Boolean),
-  'error-codes': Schema.optional(Schema.Array(Schema.String))
+  success: Schema.optionalKey(Schema.Boolean),
+  'error-codes': Schema.optionalKey(Schema.Array(Schema.String))
 })
 export type SiteverifyResponse = typeof SiteverifyResponse.Type
 
@@ -75,21 +75,49 @@ const decodeSiteverifyResponse = Schema.decodeUnknownResult(SiteverifyResponse)
 /**
  * One JSON POST to siteverify, via the Workers global `fetch` — mirroring the
  * Stripe capability's platform-adapter stance: an HTTP client dependency would
- * add weight, not safety, to one JSON POST. Exported for tests.
+ * add weight, not safety, to one JSON POST. The call carries an `AbortSignal`
+ * from `Effect.tryPromise` so interruption and the 10s deadline reach the
+ * socket, and transport failures surface as typed `CapabilityUnavailable`
+ * instead of defects. Exported for tests.
  */
 export const liveSiteverifyCaller: SiteverifyCaller = Effect.fnUntraced(function* (
   request: SiteverifyRequest
 ) {
-  const response = yield* Effect.promise(() =>
-    // oxlint-disable-next-line effect/noGlobals, effect/noGlobals -- the Workers global fetch is the platform adapter here; JSON body encoding included; see the Stripe twin in billing.ts
-    fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      // oxlint-disable-next-line effect/noGlobals -- one JSON POST to a fixed endpoint; a Schema codec adds nothing here
-      body: JSON.stringify(request)
-    })
+  const response = yield* Effect.tryPromise({
+    try: (signal) =>
+      // oxlint-disable-next-line effect/noGlobals -- the Workers global fetch is the platform adapter here; JSON body encoding included; see the Stripe twin in billing.ts
+      fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        // oxlint-disable-next-line effect/noGlobals -- one JSON POST to a fixed endpoint; a Schema codec adds nothing here
+        body: JSON.stringify(request),
+        signal
+      }),
+    catch: () =>
+      new CapabilityUnavailable({
+        capability: 'turnstile-verification',
+        reason: 'siteverify request failed'
+      })
+  }).pipe(
+    Effect.timeout('10 seconds'),
+    // Same "siteverify unreachable" failure the transport path reports.
+    Effect.catchTag('TimeoutError', () =>
+      Effect.fail(
+        new CapabilityUnavailable({
+          capability: 'turnstile-verification',
+          reason: 'siteverify request timed out'
+        })
+      )
+    )
   )
-  const json: unknown = yield* Effect.promise(() => response.json())
+  const json: unknown = yield* Effect.tryPromise({
+    try: () => response.json(),
+    catch: () =>
+      new CapabilityUnavailable({
+        capability: 'turnstile-verification',
+        reason: `siteverify responded ${response.status} with an unparseable body`
+      })
+  })
   const decoded = decodeSiteverifyResponse(json)
   if (Result.isFailure(decoded)) {
     return yield* new CapabilityUnavailable({
@@ -148,8 +176,17 @@ export function makeTurnstileVerifier(options: {
         }
         // Siteverify trouble is infrastructure, not a bot verdict — fold the
         // typed failure into an `unavailable` outcome so `verify` never fails.
+        // Verification is idempotent, so a bounded jittered retry rides in
+        // front of the fold; checkout creation (Stripe) is not idempotent and
+        // gets none.
         const attempted = yield* Effect.result(
-          siteverify(buildRequest(secretKey, token, remoteIp))
+          siteverify(buildRequest(secretKey, token, remoteIp)).pipe(
+            Effect.retry(
+              Schedule.upTo({ times: 2 })(
+                Schedule.jittered(Schedule.exponential('100 millis'))
+              )
+            )
+          )
         )
         if (Result.isFailure(attempted)) return unavailable
         return classify(attempted.success)

--- a/packages/capabilities/src/index.test.ts
+++ b/packages/capabilities/src/index.test.ts
@@ -43,6 +43,7 @@ import {
   auditEventContractDataset,
   auditEventLogContractCases
 } from './governance/audit-event-log.contract.ts'
+import { Billing } from './billing/billing.ts'
 import {
   AuditEventLog,
   LiveAuditEventLog,
@@ -125,6 +126,25 @@ describe('seed audit event log contract', () => {
 })
 
 describe('starter capabilities', () => {
+  // Billing's audit writes must land in the same fixture log every other
+  // Seed adapter reads — a private instance would record events nothing
+  // reads back (capabilities invariant 4).
+  it.effect('seed billing audit events land in the shared fixture log', () =>
+    Effect.gen(function* () {
+      const billing = yield* Billing
+      const applied = yield* billing.applyProviderEvent({
+        workspaceId: seedWorkspaceRecord.id,
+        planId: 'team'
+      })
+      expect(applied).toBe(true)
+      const audit = yield* AuditEventLog
+      const events = yield* audit.listGlobal
+      expect(events.some((event) => event.eventType === 'billing.plan_changed')).toBe(
+        true
+      )
+    }).pipe(Effect.provide(SeedLayer))
+  )
+
   it.effect('counts unread notifications through the feed interface', () =>
     Effect.gen(function* () {
       const feed = yield* NotificationFeed

--- a/packages/capabilities/src/layers.ts
+++ b/packages/capabilities/src/layers.ts
@@ -107,19 +107,17 @@ const SeedGovernance = Layer.unwrap(
 )
 
 /**
- * Billing rides the governance seed so its audit writes land in the same
- * fixture log every other capability reads.
- */
-const SeedBillingLayer = SeedBilling().pipe(
-  Layer.provide(SeedAuditEventLog(seedAuditEvents))
-)
-
-/**
  * One fixture audit-log instance, shared by the Seed adapters that write
  * audit events below their interface — separate instances would each hold a
  * private store and recorded events would not read back.
  */
 const SeedAuditLog = SeedAuditEventLog(seedAuditEvents)
+
+/**
+ * Billing rides the governance seed so its audit writes land in the same
+ * fixture log every other capability reads.
+ */
+const SeedBillingLayer = SeedBilling().pipe(Layer.provide(SeedAuditLog))
 
 export const SeedLayer: CapabilitiesLayer = Layer.mergeAll(
   // The mutating developer-platform capabilities write audit events and fan

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -67,14 +67,6 @@ function isoTimestamp(column: string) {
   return text(column)
 }
 
-// oxlint-disable-next-line effect/noAs -- `as const`, not a type assertion
-export const webhookEventTypes = [
-  'api_token.created',
-  'api_token.revoked',
-  'webhook_endpoint.created'
-] as const
-export type WebhookEventType = (typeof webhookEventTypes)[number]
-
 /**
  * The delivery state machine written by the background worker through
  * `WebhookEndpoints.recordDeliveryAttempt` / `recordTerminalDeliveryAttempt`:
@@ -326,9 +318,11 @@ export const webhookEndpoints = sqliteTable(
     // plaintext secret. See webhook-endpoints.AGENTS.md in packages/capabilities.
     signingSecret: text('signing_secret').notNull(),
     enabled: integer('enabled', { mode: 'boolean' }).default(true).notNull(),
-    events: text('events', { mode: 'json' })
-      .$type<readonly WebhookEventType[]>()
-      .notNull(),
+    // Free-text subscriptions by design: a producer can add event types
+    // without a migration (see webhook-endpoints.AGENTS.md in
+    // packages/capabilities). The known vocabulary lives in the capabilities
+    // package as `WEBHOOK_EVENT_TYPES` for the management UI.
+    events: text('events', { mode: 'json' }).$type<readonly string[]>().notNull(),
     createdAt: isoCreatedAt()
   },
   (table) => [workspaceIdIndex('webhook_endpoints', table.workspaceId)]


### PR DESCRIPTION
## Summary
Fixes from the Effect-usage code review:

- **Seed billing audit bug**: `SeedBilling` was provided its own private `SeedAuditEventLog` instance, so billing audit events landed in a store nothing reads back. Now rides the shared `SeedAuditLog`. Also fixes `listGlobal` snapshotting rows eagerly at layer build (`Effect.succeed(toWire(rows))` -> `Effect.sync`). Covered by a new red-first contract test.
- **Webhook subscriptions typed truthfully**: stored `events` widened to `readonly string[]` (free-text by design), removing the `as WebhookEventType[]` cast and the now-unused db enum.
- **Provider fetch adapters hardened**: Stripe + siteverify use `Effect.tryPromise` with an `AbortSignal`, a 10s deadline folded into `CapabilityUnavailable` (no `TimeoutError` leak into interface channels), typed transport failures instead of defects, and a bounded jittered retry on idempotent siteverify only (checkout stays single-shot; retries driven via `TestClock.adjust` in tests).
- **`Schema.optionalKey`** for absent-key JSON fields: endpoint description, siteverify response, queue-message `traceparent`.
- **Token telemetry can't fail auth**: throttled `lastUsedAt` bump wrapped in `Effect.ignore`; publisher emits `traceparent` as an optional key end-to-end via a `withTraceparent` helper.
- Removed an unchecked cast in `billing.test.ts`.
- **Per-request memoization facility**: replaced `auth.ts`'s module-local WeakMap with `memoizePerRequest` on the request telemetry (`observability.ts`). Slots die with the request and are shared across the `Request` instances Start substitutes mid-flight — a latent double-read the WeakMap missed. Future request-scoped memoization has one sanctioned home instead of another WeakMap. Covered by four new red-first tests.

## Skipped deliberately (documented)
- Real-clock web tests / fixture date literal - sanctioned by `apps/web/AGENTS.md` and inline comments.
- `auth.ts` WeakMap dedupe - callers are independent async gates with no shared Effect scope.
- Seed base-workspace rename/remove fidelity - lifecycle contract explicitly excludes shared-workspace deletion.

## Test plan
- [x] New test fails before fix, passes after (`seed billing audit events land in the shared fixture log`)
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` - all 25 tasks green
