### PR TITLE
chore: enable strict oxlint rules and fix violations

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -88,6 +88,7 @@
     "no-lone-blocks": "error",
     "no-sequences": "error",
     "prefer-const": "error",
+    "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
     "prefer-exponentiation-operator": "error",
     "no-var": "error",
     "prefer-object-spread": "error",
@@ -98,6 +99,7 @@
     "no-constructor-return": "error",
     "no-empty": "error",
     "no-extend-native": "error",
+    "no-throw-literal": "error",
     "no-fallthrough": "error",
     "no-implied-eval": "error",
     "no-labels": "error",
@@ -117,11 +119,8 @@
     "no-useless-call": "error",
     "prefer-object-has-own": "error",
     "prefer-regex-literals": "error",
-    // `multi-line` only: a brace-less body on its own line is a footgun, because oxfmt breaks
-    // a long single-line `if` at printWidth without adding braces. One-line `if (x) return y`
-    // stays legal.
-    "curly": ["error", "multi-line"],
-    "no-unexpected-multiline": "off",
+    "curly": "error",
+    "no-unexpected-multiline": "error",
     "no-else-return": ["error", { "allowElseIf": false }],
     "no-lonely-if": "error",
     "no-nested-ternary": "error",
@@ -129,11 +128,22 @@
     "prefer-destructuring": ["error", { "array": false }],
     "prefer-template": "error",
     "default-param-last": "error",
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    // oxlint has no reporting toggle for unused variables (`vars` only takes "all"/"local"),
+    // so the requested "variables": "off" maps onto the auto-fix switch: unused imports are
+    // only removed through safe fixes, and unused variables are never auto-removed.
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "fix": { "imports": "safe-fix", "variables": "off" }
+      }
+    ],
     "no-console": ["error", { "allow": ["warn", "error"] }],
+    "no-warning-comments": ["error", { "terms": ["@nocommit"] }],
 
     "@typescript-eslint/ban-ts-comment": ["error", { "minimumDescriptionLength": 10 }],
     "no-array-constructor": "error",
+    "@typescript-eslint/array-type": ["error", { "default": "generic" }],
     "@typescript-eslint/no-duplicate-enum-values": "error",
     "@typescript-eslint/no-dynamic-delete": "error",
     "@typescript-eslint/no-empty-object-type": "error",
@@ -235,6 +245,7 @@
     "unicorn/no-abusive-eslint-disable": "error",
     "unicorn/no-await-in-promise-methods": "error",
     "unicorn/no-empty-file": "error",
+    "unicorn/no-hex-escape": "error",
     // strict, not the default loose strategy: loose skips `Error` itself, which is the
     // one builtin the repo used to probe by hand in a dozen places. The normalizers that
     // legitimately do it are exempted per file below.
@@ -258,17 +269,23 @@
     "unicorn/numeric-separators-style": "error",
     "unicorn/prefer-array-find": "error",
     "unicorn/prefer-array-flat-map": "error",
+    "unicorn/prefer-array-index-of": "error",
     "unicorn/prefer-array-some": "error",
+    "unicorn/prefer-at": "error",
     "unicorn/prefer-date-now": "error",
     "unicorn/prefer-dom-node-append": "error",
+    "unicorn/prefer-import-meta-properties": "error",
     "unicorn/prefer-logical-operator-over-ternary": "error",
     "unicorn/prefer-native-coercion-functions": "error",
     "unicorn/prefer-node-protocol": "error",
     "unicorn/prefer-number-properties": "error",
     "unicorn/prefer-object-from-entries": "error",
+    "unicorn/prefer-optional-catch-binding": "error",
     "unicorn/prefer-regexp-test": "error",
+    "unicorn/prefer-single-call": "error",
     "unicorn/prefer-set-has": "error",
     "unicorn/prefer-spread": "error",
+    "unicorn/prefer-string-raw": "error",
     "unicorn/prefer-string-replace-all": "error",
     "unicorn/prefer-string-slice": "error",
     "unicorn/require-array-join-separator": "error",
@@ -384,6 +401,7 @@
     "react/no-string-refs": "error",
     "react/no-this-in-sfc": "error",
     "react/no-unknown-property": "error",
+    "react/require-render-return": "error",
     // Automatic JSX runtime, so React is never in scope by hand (851 would-be reports).
     "react-in-jsx-scope": "off",
     // React Compiler rules (eslint-plugin-react-hooks compiler set)
@@ -438,6 +456,7 @@
     // Matches the `inline-type-imports` fixStyle on consistent-type-imports above, so both
     // halves of the type-import style are enforced instead of only what the fixer emits.
     "import/consistent-type-specifier-style": ["error", "prefer-inline"],
+    "import/export": "error",
     "import/no-absolute-path": "error",
     "import/no-cycle": "error",
     "import/no-duplicates": "error",

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -27,7 +27,7 @@ type OptionalEmailBinding = { EMAIL?: Cloudflare.Email.SendEmail }
 // Rate limits are Worker-only bindings with no backing cloud resource, so
 // they are declared inline on the Worker's `env` rather than provisioned as
 // their own resources. The `env` key is the binding name the Worker reads.
-function rateLimitBindings(specs: readonly RateLimitBindingSpec[]) {
+function rateLimitBindings(specs: ReadonlyArray<RateLimitBindingSpec>) {
   return Object.fromEntries(
     specs.map((spec) => [
       spec.name,
@@ -58,19 +58,23 @@ function requiredEnv(name: string): string {
 
 function optionalSecret(name: string): Redacted.Redacted<string> | undefined {
   const value = readEnv(name)
-  if (!value) return
+  if (!value) {
+    return
+  }
   return Redacted.make(value)
 }
 
 // Set secrets only. An unset optional secret contributes no binding at all,
 // so the module reports needs-config instead of failing the deploy.
 function presentSecretEntries(
-  names: readonly string[]
-): [string, Redacted.Redacted<string>][] {
-  const entries: [string, Redacted.Redacted<string>][] = []
+  names: ReadonlyArray<string>
+): Array<[string, Redacted.Redacted<string>]> {
+  const entries: Array<[string, Redacted.Redacted<string>]> = []
   for (const name of names) {
     const secret = optionalSecret(name)
-    if (secret) entries.push([name, secret])
+    if (secret) {
+      entries.push([name, secret])
+    }
   }
   return entries
 }
@@ -140,7 +144,9 @@ export const Stack = Alchemy.Stack(
     // Built as its own object so every worker below spreads the same optional
     // binding set: the EMAIL key exists only when the resource does.
     const emailBinding: OptionalEmailBinding = {}
-    if (transactionalEmail) emailBinding.EMAIL = transactionalEmail
+    if (transactionalEmail) {
+      emailBinding.EMAIL = transactionalEmail
+    }
 
     const api = yield* Cloudflare.Worker('api', {
       name: 'b2b-saas-starter-api',

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -19,11 +19,21 @@ export type ApiEnv = RateLimitBindings &
 // would claim configuration that does not exist.
 export function providerEnv(env: ApiEnv): ProviderEnv {
   const provider: { -readonly [K in keyof ProviderEnv]: ProviderEnv[K] } = {}
-  if (env.AI) provider.AI = env.AI
-  if (env.WORKERS_AI_ENABLED) provider.WORKERS_AI_ENABLED = env.WORKERS_AI_ENABLED
-  if (env.OPENAI_API_KEY) provider.OPENAI_API_KEY = env.OPENAI_API_KEY
-  if (env.OPENAI_BASE_URL) provider.OPENAI_BASE_URL = env.OPENAI_BASE_URL
-  if (env.OPENAI_MODEL_ID) provider.OPENAI_MODEL_ID = env.OPENAI_MODEL_ID
+  if (env.AI) {
+    provider.AI = env.AI
+  }
+  if (env.WORKERS_AI_ENABLED) {
+    provider.WORKERS_AI_ENABLED = env.WORKERS_AI_ENABLED
+  }
+  if (env.OPENAI_API_KEY) {
+    provider.OPENAI_API_KEY = env.OPENAI_API_KEY
+  }
+  if (env.OPENAI_BASE_URL) {
+    provider.OPENAI_BASE_URL = env.OPENAI_BASE_URL
+  }
+  if (env.OPENAI_MODEL_ID) {
+    provider.OPENAI_MODEL_ID = env.OPENAI_MODEL_ID
+  }
   return provider
 }
 

--- a/apps/api/src/http.ts
+++ b/apps/api/src/http.ts
@@ -75,6 +75,8 @@ export function buildWebHandler(env: ApiEnv): {
 
 let cached: ((request: Request) => Promise<Response>) | undefined
 export function getWebHandler(env: ApiEnv): (request: Request) => Promise<Response> {
-  if (!cached) cached = buildWebHandler(env).handler
+  if (!cached) {
+    cached = buildWebHandler(env).handler
+  }
   return cached
 }

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -40,7 +40,9 @@ function handlerFor(env: ApiEnv): (request: Request) => Promise<Response> {
 }
 
 function get(path: string, headers?: Record<string, string>): Request {
-  if (!headers) return new Request(`https://api.test${path}`)
+  if (!headers) {
+    return new Request(`https://api.test${path}`)
+  }
   return new Request(`https://api.test${path}`, { headers })
 }
 

--- a/apps/api/src/mcp.test.ts
+++ b/apps/api/src/mcp.test.ts
@@ -84,7 +84,9 @@ type RpcHeaders = {
 function rpc(method: string, params?: Json, name?: string): Request {
   nextId += 1
   const envelopeParams: Record<string, Json> = {}
-  if (params !== undefined) Object.assign(envelopeParams, params)
+  if (params !== undefined) {
+    Object.assign(envelopeParams, params)
+  }
   // oxlint-disable-next-line eslint/no-underscore-dangle -- protocol-reserved key
   envelopeParams._meta = MODERN_ENVELOPE
   const envelope: JsonRpcWireRequest = {
@@ -100,7 +102,9 @@ function rpc(method: string, params?: Json, name?: string): Request {
   }
   // The handler rejects a modern request whose Mcp-Name header disagrees
   // with (or is missing next to) params.name / params.uri.
-  if (name !== undefined) headers['mcp-name'] = name
+  if (name !== undefined) {
+    headers['mcp-name'] = name
+  }
   return new Request('https://api.test/mcp', {
     method: 'POST',
     headers,

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -78,7 +78,7 @@ type ToolDefinition = {
   readonly capability: () => CapabilityRead
 }
 
-export const mcpTools: readonly ToolDefinition[] = readOperations().map(
+export const mcpTools: ReadonlyArray<ToolDefinition> = readOperations().map(
   (operation) => ({
     descriptor: {
       name: operation.toolName,
@@ -161,7 +161,9 @@ function errorResult(outcome: ToolOutcome): ToolResult {
 }
 
 function outcomeToToolResult(outcome: ToolOutcome): ToolResult {
-  if (Result.isSuccess(outcome)) return textResult(outcome.success)
+  if (Result.isSuccess(outcome)) {
+    return textResult(outcome.success)
+  }
   return errorResult(outcome)
 }
 
@@ -177,7 +179,7 @@ function outcomeToToolResult(outcome: ToolOutcome): ToolResult {
  */
 export function buildMcpServer(
   env: ApiEnv,
-  scopes: readonly ApiTokenScope[],
+  scopes: ReadonlyArray<ApiTokenScope>,
   workspaceSlug: string
 ): McpServer {
   const server = new McpServer(
@@ -250,7 +252,9 @@ export function buildMcpServer(
 function fromWeb(response: Response): HttpServerResponse.HttpServerResponse {
   const status = response.status
   const body = response.body
-  if (body === null) return HttpServerResponse.empty({ status })
+  if (body === null) {
+    return HttpServerResponse.empty({ status })
+  }
   return HttpServerResponse.stream(
     Stream.fromReadableStream({
       evaluate: () => body,
@@ -347,7 +351,9 @@ function protocolBody(env: ApiEnv, request: HttpServerRequest.HttpServerRequest)
     const modernHeaders: Record<string, string> = {}
     for (const name of ['mcp-method', 'mcp-name', 'mcp-protocol-version']) {
       const value = request.headers[name]
-      if (value !== undefined) modernHeaders[name] = value
+      if (value !== undefined) {
+        modernHeaders[name] = value
+      }
     }
     const webRequest = new Request(targetUrl, {
       method: 'POST',
@@ -375,7 +381,9 @@ export function mcpProtocolLayer(env: ApiEnv) {
         observed(env, request, 'mcp.protocol', {}, protocolBody(env, request))
       ),
       (outcome): HttpServerResponse.HttpServerResponse => {
-        if (Result.isFailure(outcome)) return failureResponse(outcome.failure)
+        if (Result.isFailure(outcome)) {
+          return failureResponse(outcome.failure)
+        }
         return outcome.success
       }
     )

--- a/apps/api/src/operations.ts
+++ b/apps/api/src/operations.ts
@@ -127,7 +127,7 @@ export const READ_OPERATIONS = {
 } satisfies Record<ReadOperationEndpoint, WorkspaceReadOperation>
 
 /** The table rows in contract order — what MCP tools and tests derive from. */
-export function readOperations(): readonly WorkspaceReadOperation[] {
+export function readOperations(): ReadonlyArray<WorkspaceReadOperation> {
   return Object.values(READ_OPERATIONS)
 }
 
@@ -154,8 +154,12 @@ export function serveRead(
 /** `notification:read`-style label, used by the permission matrix output. */
 export function permissionLabel(permission: PermissionRequest): string {
   const entry = Object.entries(permission)[0]
-  if (entry === undefined) return ''
+  if (entry === undefined) {
+    return ''
+  }
   const [key, actions] = entry
-  if (!Array.isArray(actions)) return `${key}:`
+  if (!Array.isArray(actions)) {
+    return `${key}:`
+  }
   return `${key}:${String(actions[0])}`
 }

--- a/apps/api/src/permission-matrix.test.ts
+++ b/apps/api/src/permission-matrix.test.ts
@@ -74,14 +74,14 @@ const SLUG = 'starter-lab'
  * (`operations.ts`) — the same rows the REST handlers and the MCP tools are
  * derived from — so the matrix cannot disagree with either surface.
  */
-const READ_ROWS: readonly GatedOperation[] = readOperations().map((op) => ({
+const READ_ROWS: ReadonlyArray<GatedOperation> = readOperations().map((op) => ({
   operation: `GET /workspaces/{slug}/${op.path}`,
   permission: permissionLabel(op.permission),
   expected: 200,
   request: makeRequest('GET', `/workspaces/${SLUG}/${op.path}`)
 }))
 
-const MATRIX: readonly GatedOperation[] = [
+const MATRIX: ReadonlyArray<GatedOperation> = [
   ...READ_ROWS,
 
   // Minting is the one mutation a `write` token is refused as well: a token

--- a/apps/api/src/request-guards.ts
+++ b/apps/api/src/request-guards.ts
@@ -34,7 +34,9 @@ export function bearerToken(
   request: HttpServerRequest.HttpServerRequest
 ): string | null {
   const header = request.headers.authorization
-  if (!header?.startsWith('Bearer ')) return null
+  if (!header?.startsWith('Bearer ')) {
+    return null
+  }
   return header.slice('Bearer '.length).trim()
 }
 
@@ -68,7 +70,7 @@ export function authenticate(
     readonly id: string
     readonly workspaceId: string
     readonly workspaceSlug: string
-    readonly scopes: readonly ApiTokenScope[]
+    readonly scopes: ReadonlyArray<ApiTokenScope>
   },
   Unauthorized | CapabilityUnavailable,
   ApiTokenRegistry | Scope.Scope

--- a/apps/background/src/index.test.ts
+++ b/apps/background/src/index.test.ts
@@ -130,13 +130,15 @@ function resolveTarget(
   endpointId: string,
   workspaceId: string
 ): typeof target | null {
-  if (endpointId === dispatchTarget?.id && workspaceId === 'ws_1') return dispatchTarget
+  if (endpointId === dispatchTarget?.id && workspaceId === 'ws_1') {
+    return dispatchTarget
+  }
   return null
 }
 
 function stubEndpoints(
   dispatchTarget: typeof target | null,
-  recorded: WebhookDeliveryAttemptInput[]
+  recorded: Array<WebhookDeliveryAttemptInput>
 ): Layer.Layer<WebhookEndpoints> {
   let terminalSeq = 0
   return Layer.succeed(WebhookEndpoints)({
@@ -203,7 +205,7 @@ describe('processWebhookMessage', () => {
     input: unknown = message,
     messageId?: string
   ) {
-    const recorded: WebhookDeliveryAttemptInput[] = []
+    const recorded: Array<WebhookDeliveryAttemptInput> = []
     const captured: CapturedRequest = {}
     return runScoped(
       processWebhookMessage(
@@ -356,8 +358,8 @@ describe('processDeadLetterMessage', () => {
   function runDeadLetter(
     input: unknown,
     attempts = 4
-  ): Effect.Effect<WebhookDeliveryAttemptInput[]> {
-    const recorded: WebhookDeliveryAttemptInput[] = []
+  ): Effect.Effect<Array<WebhookDeliveryAttemptInput>> {
+    const recorded: Array<WebhookDeliveryAttemptInput> = []
     return runScoped(
       processDeadLetterMessage({ body: input, attempts }).pipe(
         Effect.provide(stubEndpoints(target, recorded))

--- a/apps/background/src/webhook-consumer.ts
+++ b/apps/background/src/webhook-consumer.ts
@@ -195,7 +195,9 @@ export function processWebhookMessage(
     // recorded on the wide event only and acked — mirroring how permanent
     // delivery failures ack instead of retrying forever.
     const message = yield* decodeEnvelope(envelope, 'failed_permanent')
-    if (!message) return 'ack' satisfies DeliveryOutcome
+    if (!message) {
+      return 'ack' satisfies DeliveryOutcome
+    }
     const attempts = envelope.attempts
     yield* annotateMessageFields(message)
     const webhooks = yield* WebhookEndpoints
@@ -333,7 +335,9 @@ export function processDeadLetterMessage(
     // Same boundary decode as `processWebhookMessage`: a malformed dead letter
     // has no trusted endpointId for a delivery row, so log-and-ack only.
     const message = yield* decodeEnvelope(envelope, 'dead_lettered')
-    if (!message) return
+    if (!message) {
+      return
+    }
     yield* annotateMessageFields(message)
     const webhooks = yield* WebhookEndpoints
     yield* webhooks.recordTerminalDeliveryAttempt({

--- a/apps/web/src/components/admin-user-actions.tsx
+++ b/apps/web/src/components/admin-user-actions.tsx
@@ -115,14 +115,17 @@ export function BanUserAction({ user }: { readonly user: SystemUser }) {
   )
 }
 
-export function AdminUserActions({ users }: { readonly users: readonly SystemUser[] }) {
+export function AdminUserActions({
+  users
+}: {
+  readonly users: ReadonlyArray<SystemUser>
+}) {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
   const [selectedId, setSelectedId] = useState<string>(users[0]?.id ?? '')
-  const [memberships, setMemberships] = useState<
-    readonly WorkspaceWithMembership[] | null
-  >(null)
+  const [memberships, setMemberships] =
+    useState<ReadonlyArray<WorkspaceWithMembership> | null>(null)
 
   async function settle(run: () => Promise<void>, busyKey: string, message: string) {
     setError(null)
@@ -165,7 +168,9 @@ export function AdminUserActions({ users }: { readonly users: readonly SystemUse
       'Role change',
       'Role change'
     )
-    if (!settled) return
+    if (!settled) {
+      return
+    }
     // Re-read the memberships through the same folded call so a read failure
     // lands in error state instead of escaping as an unhandled rejection.
     const read = await callServerFn(() => {
@@ -219,7 +224,9 @@ export function AdminUserActions({ users }: { readonly users: readonly SystemUse
           {busy === 'Workspaces' ? <Spinner data-icon="inline-end" /> : null}
         </Button>
         {(() => {
-          if (memberships === null) return null
+          if (memberships === null) {
+            return null
+          }
           if (memberships.length === 0) {
             return (
               <p className="text-xs text-muted-foreground">
@@ -266,9 +273,11 @@ function MembershipRow(input: {
 }) {
   // One pass over the fixed role vocabulary: keep every role this member does
   // not already hold.
-  const targets: WorkspaceRole[] = []
+  const targets: Array<WorkspaceRole> = []
   for (const role of WORKSPACE_ROLES) {
-    if (role !== input.member.role) targets.push(role)
+    if (role !== input.member.role) {
+      targets.push(role)
+    }
   }
   return (
     <li className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">

--- a/apps/web/src/components/api-token-form.tsx
+++ b/apps/web/src/components/api-token-form.tsx
@@ -20,7 +20,7 @@ const CREATE_TOKEN_FAILED = 'Failed to create token'
 
 type ApiTokenValues = {
   name: string
-  scopes: readonly ApiTokenScope[]
+  scopes: ReadonlyArray<ApiTokenScope>
 }
 
 const DEFAULT_TOKEN_VALUES: ApiTokenValues = {
@@ -29,8 +29,12 @@ const DEFAULT_TOKEN_VALUES: ApiTokenValues = {
 }
 
 function validateTokenName(value: string): string | undefined {
-  if (value.trim().length === 0) return 'Token name is required'
-  if (value.length > 80) return 'Token name must be under 80 characters'
+  if (value.trim().length === 0) {
+    return 'Token name is required'
+  }
+  if (value.length > 80) {
+    return 'Token name must be under 80 characters'
+  }
   return
 }
 
@@ -44,7 +48,7 @@ export type CreateApiToken = (input: {
   readonly data: {
     readonly workspaceSlug: string
     readonly name: string
-    readonly scopes: readonly ApiTokenScope[]
+    readonly scopes: ReadonlyArray<ApiTokenScope>
   }
 }) => Promise<CreatedApiToken>
 

--- a/apps/web/src/components/api-tokens-panel.tsx
+++ b/apps/web/src/components/api-tokens-panel.tsx
@@ -36,7 +36,9 @@ export type RevokeApiToken = (input: {
 
 // An explicit locale and timezone keeps SSR and the browser in agreement.
 function formatDate(iso: string | null): string {
-  if (iso === null) return 'never'
+  if (iso === null) {
+    return 'never'
+  }
   return new Date(iso).toLocaleString('en-US', { timeZone: 'UTC' })
 }
 
@@ -54,7 +56,7 @@ export function ApiTokensPanel({
   createToken
 }: {
   readonly workspaceSlug: string
-  readonly tokens: readonly ApiToken[]
+  readonly tokens: ReadonlyArray<ApiToken>
   readonly viewer: Viewer
   readonly revokeToken?: RevokeApiToken
   readonly createToken?: CreateApiToken

--- a/apps/web/src/components/auth/auth-card-form.tsx
+++ b/apps/web/src/components/auth/auth-card-form.tsx
@@ -50,7 +50,9 @@ export function AuthCardForm({
   const hydrated = useHydrated()
   const errorRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
-    if (error) errorRef.current?.focus()
+    if (error) {
+      errorRef.current?.focus()
+    }
   }, [error])
   return (
     <PublicLayout>

--- a/apps/web/src/components/auth/auth-validators.ts
+++ b/apps/web/src/components/auth/auth-validators.ts
@@ -8,8 +8,12 @@
  * shallow — Better Auth owns the real check.
  */
 export function emailValidator({ value }: { value: string }): string | undefined {
-  if (value.length === 0) return 'Email is required'
-  if (!value.includes('@')) return 'Enter a valid email'
+  if (value.length === 0) {
+    return 'Email is required'
+  }
+  if (!value.includes('@')) {
+    return 'Enter a valid email'
+  }
   return
 }
 

--- a/apps/web/src/components/auth/turnstile-widget.tsx
+++ b/apps/web/src/components/auth/turnstile-widget.tsx
@@ -10,7 +10,9 @@ const SCRIPT_ID = 'cf-turnstile-script'
 let scriptPromise: Promise<TurnstileApi> | undefined
 
 function loadTurnstileScript(): Promise<TurnstileApi> {
-  if (scriptPromise !== undefined) return scriptPromise
+  if (scriptPromise !== undefined) {
+    return scriptPromise
+  }
   scriptPromise = new Promise((resolve, reject) => {
     function settle() {
       if (window.turnstile === undefined) {
@@ -80,7 +82,9 @@ export function TurnstileWidget({
     let cancelled = false
 
     function mount(api: TurnstileApi) {
-      if (cancelled || containerRef.current === null) return
+      if (cancelled || containerRef.current === null) {
+        return
+      }
       widgetId = api.render(containerRef.current, {
         sitekey: siteKey,
         callback: (token) => onTokenRef.current(token),

--- a/apps/web/src/components/chart-colors.ts
+++ b/apps/web/src/components/chart-colors.ts
@@ -1,7 +1,7 @@
 /** Non-empty by construction, so `CHART_COLORS[0]` is always a usable fallback.
  *  Catppuccin accent hues (blue, green, mauve, peach, red, teal, yellow, pink,
  *  sky, flamingo) so charts harmonize with the semantic token palette. */
-export const CHART_COLORS: readonly [string, ...string[]] = [
+export const CHART_COLORS: readonly [string, ...Array<string>] = [
   '#89b4fa',
   '#a6e3a1',
   '#cba6f7',

--- a/apps/web/src/components/charts/webhook-success-chart.tsx
+++ b/apps/web/src/components/charts/webhook-success-chart.tsx
@@ -14,7 +14,7 @@ import { AXIS_TICK, CHART_MARGIN, TOOLTIP_STYLE } from '../chart-defaults'
 export function WebhookSuccessChart({
   webhooks
 }: {
-  readonly webhooks: readonly WebhookEndpoint[]
+  readonly webhooks: ReadonlyArray<WebhookEndpoint>
 }) {
   const data = webhooks.map((endpoint) => ({
     label: new URL(endpoint.url).host,

--- a/apps/web/src/components/confirm-button.tsx
+++ b/apps/web/src/components/confirm-button.tsx
@@ -45,11 +45,15 @@ export function ConfirmButton({
   const onCancelRef = useRef(onCancel)
 
   useEffect(() => {
-    if (!isArmed) return
+    if (!isArmed) {
+      return
+    }
     onCancelRef.current = onCancel
     confirmRef.current?.focus()
     function disarm(event: KeyboardEvent) {
-      if (event.key !== 'Escape') return
+      if (event.key !== 'Escape') {
+        return
+      }
       setArmedHere(false)
       onCancelRef.current?.()
     }

--- a/apps/web/src/components/create-workspace-form.tsx
+++ b/apps/web/src/components/create-workspace-form.tsx
@@ -28,8 +28,12 @@ function suggestSlug(name: string): string {
 }
 
 function validateName(value: string): string | undefined {
-  if (value.trim().length === 0) return 'Workspace name is required'
-  if (value.length > 80) return 'Workspace name must be under 80 characters'
+  if (value.trim().length === 0) {
+    return 'Workspace name is required'
+  }
+  if (value.length > 80) {
+    return 'Workspace name must be under 80 characters'
+  }
   return
 }
 
@@ -105,7 +109,9 @@ export function CreateWorkspaceForm({
             onBlur={field.handleBlur}
             onChange={(next) => {
               field.handleChange(next)
-              if (!slugEdited.current) form.setFieldValue('slug', suggestSlug(next))
+              if (!slugEdited.current) {
+                form.setFieldValue('slug', suggestSlug(next))
+              }
             }}
             placeholder="Acme Corp"
           />

--- a/apps/web/src/components/data-table.test.tsx
+++ b/apps/web/src/components/data-table.test.tsx
@@ -7,12 +7,12 @@ type Row = {
   readonly category: string
 }
 
-const columns: DataTableColumnDef<Row>[] = [
+const columns: Array<DataTableColumnDef<Row>> = [
   { accessorKey: 'name', header: 'Name', enableSorting: true },
   { accessorKey: 'category', header: 'Category', enableSorting: false }
 ]
 
-const rows: readonly Row[] = [
+const rows: ReadonlyArray<Row> = [
   { name: 'Alpha', category: 'catalog' },
   { name: 'Bravo', category: 'governance' },
   { name: 'Charlie', category: 'catalog' },

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -99,8 +99,8 @@ const SORT_STATE = {
 } satisfies Record<'asc' | 'desc' | 'false', SortState>
 
 type DataTableProps<TData extends RowData> = {
-  readonly columns: readonly DataTableColumnDef<TData>[]
-  readonly data: readonly TData[]
+  readonly columns: ReadonlyArray<DataTableColumnDef<TData>>
+  readonly data: ReadonlyArray<TData>
   readonly filterPlaceholder?: string
   readonly filterColumnId?: string
   readonly pageSize?: number

--- a/apps/web/src/components/form-text-field.tsx
+++ b/apps/web/src/components/form-text-field.tsx
@@ -9,7 +9,7 @@ type FormTextFieldProps = Omit<
   readonly name: string
   readonly label: string
   readonly value: string
-  readonly errors: readonly unknown[]
+  readonly errors: ReadonlyArray<unknown>
   readonly onBlur: () => void
   readonly onChange: (value: string) => void
 }
@@ -19,10 +19,14 @@ type FormTextFieldProps = Omit<
 // string from our validators, or an object carrying a `message`. This is the
 // parse step for that boundary: the shape probes live here once and nowhere else.
 function errorMessageOf(error: unknown): string | undefined {
-  if (typeof error === 'string') return error
+  if (typeof error === 'string') {
+    return error
+  }
   if (typeof error === 'object' && error !== null && 'message' in error) {
     const { message } = error
-    if (typeof message === 'string') return message
+    if (typeof message === 'string') {
+      return message
+    }
   }
   return undefined
 }

--- a/apps/web/src/components/invitation-panel.tsx
+++ b/apps/web/src/components/invitation-panel.tsx
@@ -46,8 +46,12 @@ const DEFAULT_INVITATION_VALUES: InvitationValues = {
 }
 
 function validateEmail(value: string): string | undefined {
-  if (value.trim().length === 0) return 'Email is required'
-  if (!EMAIL_PATTERN.test(value)) return 'Enter a valid email address'
+  if (value.trim().length === 0) {
+    return 'Email is required'
+  }
+  if (!EMAIL_PATTERN.test(value)) {
+    return 'Enter a valid email address'
+  }
   return
 }
 
@@ -56,7 +60,7 @@ export function InvitationPanel({
   invitations
 }: {
   readonly workspaceSlug: string
-  readonly invitations: readonly Invitation[]
+  readonly invitations: ReadonlyArray<Invitation>
 }) {
   const router = useRouter()
   const [sent, setSent] = useState<SentInvitation | null>(null)

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -4,7 +4,7 @@ import { GithubIcon } from '@/components/icons/github'
 import { ArchitectureSchematic } from '@/components/landing/architecture-schematic'
 import { GITHUB_URL } from '@/components/landing/github-url'
 
-const BILL_OF_MATERIALS: readonly string[] = [
+const BILL_OF_MATERIALS: ReadonlyArray<string> = [
   'TanStack Start',
   'Effect v4',
   'Drizzle D1',

--- a/apps/web/src/components/landing/runtime-map-section.tsx
+++ b/apps/web/src/components/landing/runtime-map-section.tsx
@@ -1,6 +1,6 @@
 type RuntimeRow = { readonly label: string; readonly value: string }
 
-const CLOUDFLARE_RUNTIME: readonly RuntimeRow[] = [
+const CLOUDFLARE_RUNTIME: ReadonlyArray<RuntimeRow> = [
   { label: 'apps/web', value: 'Worker' },
   { label: 'apps/api', value: 'Worker' },
   { label: 'apps/background', value: 'Worker (queue consumer)' },

--- a/apps/web/src/components/live-notifications.test.tsx
+++ b/apps/web/src/components/live-notifications.test.tsx
@@ -12,7 +12,7 @@ import {
 // of the declared shape, so the module under test is the one that ships.
 const listNotifications = vi.fn<ListNotifications>()
 
-const fallback: readonly NotificationPreview[] = [
+const fallback: ReadonlyArray<NotificationPreview> = [
   { id: 'n1', title: 'Webhook delivered', message: 'Delivery succeeded.', read: false },
   { id: 'n2', title: 'Catalog refreshed', message: 'Refresh completed.', read: true }
 ]
@@ -24,7 +24,7 @@ function renderWithClient(ui: ReactElement) {
   return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
 }
 
-function renderCard(cardFallback: readonly NotificationPreview[]) {
+function renderCard(cardFallback: ReadonlyArray<NotificationPreview>) {
   return renderWithClient(
     <LiveNotifications
       workspaceSlug="starter-lab"

--- a/apps/web/src/components/live-notifications.tsx
+++ b/apps/web/src/components/live-notifications.tsx
@@ -40,7 +40,7 @@ export type NotificationPreview = Pick<
  */
 export type ListNotifications = (input: {
   readonly data: { readonly workspaceSlug: string }
-}) => Promise<readonly NotificationPreview[]>
+}) => Promise<ReadonlyArray<NotificationPreview>>
 
 export function LiveNotifications({
   workspaceSlug,
@@ -48,7 +48,7 @@ export function LiveNotifications({
   listNotifications = listNotificationsServerFn
 }: {
   readonly workspaceSlug: string
-  readonly fallback: readonly NotificationPreview[]
+  readonly fallback: ReadonlyArray<NotificationPreview>
   readonly listNotifications?: ListNotifications
 }) {
   const { data, error, isFetching, refetch } = useQuery({

--- a/apps/web/src/components/mdx-chart.tsx
+++ b/apps/web/src/components/mdx-chart.tsx
@@ -42,9 +42,9 @@ type SeriesKey = {
 }
 
 type MdxLineChartProps = {
-  readonly data: readonly MdxChartDatum[]
+  readonly data: ReadonlyArray<MdxChartDatum>
   readonly xKey: string
-  readonly lines: readonly SeriesKey[]
+  readonly lines: ReadonlyArray<SeriesKey>
   readonly height?: number
   /** Text alternative announced to screen readers; charts are otherwise images. */
   readonly title?: string
@@ -88,9 +88,9 @@ export function MdxLineChart({
 }
 
 type MdxBarChartProps = {
-  readonly data: readonly MdxChartDatum[]
+  readonly data: ReadonlyArray<MdxChartDatum>
   readonly xKey: string
-  readonly bars: readonly SeriesKey[]
+  readonly bars: ReadonlyArray<SeriesKey>
   readonly height?: number
   /** Text alternative announced to screen readers; charts are otherwise images. */
   readonly title?: string
@@ -130,11 +130,11 @@ export function MdxBarChart({
 }
 
 type MdxPieChartProps = {
-  readonly data: readonly MdxChartDatum[]
+  readonly data: ReadonlyArray<MdxChartDatum>
   readonly nameKey: string
   readonly valueKey: string
   readonly height?: number
-  readonly colors?: readonly string[]
+  readonly colors?: ReadonlyArray<string>
   /** Text alternative announced to screen readers; charts are otherwise images. */
   readonly title?: string
 }

--- a/apps/web/src/components/mdx-mermaid.tsx
+++ b/apps/web/src/components/mdx-mermaid.tsx
@@ -4,7 +4,7 @@ export function MdxMermaid({ chart }: { readonly chart: string }) {
   const id = useId().replaceAll(':', '_')
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const processedChart = chart.replaceAll('\\n', '<br/>')
+  const processedChart = chart.replaceAll(String.raw`\n`, '<br/>')
 
   useEffect(() => {
     const cancelled = { current: false }

--- a/apps/web/src/components/members-panel.tsx
+++ b/apps/web/src/components/members-panel.tsx
@@ -26,13 +26,17 @@ import { callServerFn } from '@/lib/server-call'
 const CHANGE_FAILED = 'Failed to change the role'
 
 function roleVariant(role: WorkspaceRole): 'default' | 'secondary' | 'outline' {
-  if (role === 'owner') return 'default'
-  if (role === 'admin') return 'secondary'
+  if (role === 'owner') {
+    return 'default'
+  }
+  if (role === 'admin') {
+    return 'secondary'
+  }
   return 'outline'
 }
 
 /** The roles a member can be moved to from their current one. */
-function otherRoles(current: WorkspaceRole): readonly WorkspaceRole[] {
+function otherRoles(current: WorkspaceRole): ReadonlyArray<WorkspaceRole> {
   return WORKSPACE_ROLES.filter((role) => role !== current)
 }
 
@@ -47,7 +51,7 @@ export function MembersPanel({
   viewer
 }: {
   readonly workspaceSlug: string
-  readonly members: readonly Member[]
+  readonly members: ReadonlyArray<Member>
   readonly viewer: Viewer
 }) {
   const router = useRouter()

--- a/apps/web/src/components/notification-card.stories.tsx
+++ b/apps/web/src/components/notification-card.stories.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 function NotificationCard({
   notifications
 }: {
-  readonly notifications: readonly NotificationPreview[]
+  readonly notifications: ReadonlyArray<NotificationPreview>
 }) {
   return (
     <Card className="w-112">

--- a/apps/web/src/components/secret-reveal.tsx
+++ b/apps/web/src/components/secret-reveal.tsx
@@ -3,7 +3,9 @@ import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 
 function maskSecret(secret: string) {
-  if (secret.length <= 8) return `••••••••${secret.slice(-4)}`
+  if (secret.length <= 8) {
+    return `••••••••${secret.slice(-4)}`
+  }
   return `${secret.slice(0, 3)}…${secret.slice(-4)}`
 }
 export function SecretReveal({

--- a/apps/web/src/components/sessions-panel.tsx
+++ b/apps/web/src/components/sessions-panel.tsx
@@ -42,7 +42,7 @@ export type SessionRecord = {
  * of replacing `@/lib/auth-client`.
  */
 export type ListSessions = () => Promise<{
-  readonly data?: readonly SessionRecord[] | null
+  readonly data?: ReadonlyArray<SessionRecord> | null
   readonly error?: { readonly message?: string | undefined } | null
 }>
 
@@ -68,17 +68,25 @@ function revokeOtherSessionsWithAuthClient() {
 }
 
 function describeUserAgent(userAgent: string | null | undefined): string {
-  if (!userAgent) return 'Unknown device'
+  if (!userAgent) {
+    return 'Unknown device'
+  }
   if (userAgent.includes('iPhone') || userAgent.includes('Android')) {
     return 'Mobile browser'
   }
-  if (userAgent.includes('Macintosh')) return 'Mac'
-  if (userAgent.includes('Windows')) return 'Windows'
-  if (userAgent.includes('Linux')) return 'Linux'
+  if (userAgent.includes('Macintosh')) {
+    return 'Mac'
+  }
+  if (userAgent.includes('Windows')) {
+    return 'Windows'
+  }
+  if (userAgent.includes('Linux')) {
+    return 'Linux'
+  }
   return 'Browser'
 }
 
-function toViewModels(sessions: readonly SessionRecord[]): SessionRowView[] {
+function toViewModels(sessions: ReadonlyArray<SessionRecord>): Array<SessionRowView> {
   // Formatting happens here — inside the caller's post-mount effect or action,
   // never during render — so SSR and the browser cannot disagree on the date.
   return sessions
@@ -107,7 +115,7 @@ function toViewModels(sessions: readonly SessionRecord[]): SessionRowView[] {
  * hydration. `enabled` waits for hydration — the Better Auth client endpoint
  * is browser-only (relative fetch), so the server render must not fetch.
  */
-const SESSIONS_QUERY_KEY: readonly unknown[] = ['account', 'sessions']
+const SESSIONS_QUERY_KEY: ReadonlyArray<unknown> = ['account', 'sessions']
 
 export function SessionsPanel({
   currentSessionToken,
@@ -128,7 +136,7 @@ export function SessionsPanel({
     refetch
   } = useQuery({
     queryKey: SESSIONS_QUERY_KEY,
-    queryFn: async (): Promise<readonly SessionRowView[]> => {
+    queryFn: async (): Promise<ReadonlyArray<SessionRowView>> => {
       const result = await listSessions()
       if (result.error) {
         // oxlint-disable-next-line effect/noThrowStatement, effect/noNewError -- TanStack Query surfaces failure states by rejecting the query function; there is no Effect channel here

--- a/apps/web/src/components/settings-panel.stories.tsx
+++ b/apps/web/src/components/settings-panel.stories.tsx
@@ -11,7 +11,7 @@ type FeatureToggleRow = {
   readonly enabled: boolean
 }
 
-function SettingsPanel({ rows }: { readonly rows: readonly FeatureToggleRow[] }) {
+function SettingsPanel({ rows }: { readonly rows: ReadonlyArray<FeatureToggleRow> }) {
   return (
     <Card className="w-128">
       <CardHeader>

--- a/apps/web/src/components/table-of-contents.tsx
+++ b/apps/web/src/components/table-of-contents.tsx
@@ -10,7 +10,9 @@ export function TableOfContents({
 }) {
   const { headings, activeIds } = useHeadingObserver({ containerRef })
 
-  if (headings.length === 0) return null
+  if (headings.length === 0) {
+    return null
+  }
 
   return (
     <nav aria-label="Table of contents" className="sticky top-8">

--- a/apps/web/src/components/two-factor-panel.tsx
+++ b/apps/web/src/components/two-factor-panel.tsx
@@ -24,7 +24,7 @@ export type EnableTwoFactor = (input: { readonly password: string }) => Promise<
   readonly data?:
     | {
         readonly totpURI?: string | undefined
-        readonly backupCodes?: string[] | undefined
+        readonly backupCodes?: Array<string> | undefined
       }
     | { readonly method?: string }
     | null
@@ -38,7 +38,10 @@ export type DisableTwoFactor = (input: { readonly password: string }) => Promise
 }>
 
 export type GenerateBackupCodes = (input: { readonly password: string }) => Promise<{
-  readonly data?: { readonly backupCodes?: string[] | undefined } | null | undefined
+  readonly data?:
+    | { readonly backupCodes?: Array<string> | undefined }
+    | null
+    | undefined
   readonly error?: { readonly message?: string | undefined } | null
 }>
 
@@ -58,7 +61,7 @@ type PanelState = {
   /** 'idle' → 'enrolling' (one-time QR reveal) → idle with the enabled flag. */
   readonly step: 'idle' | 'enrolling'
   readonly totpURI: string | null
-  readonly backupCodes: readonly string[] | null
+  readonly backupCodes: ReadonlyArray<string> | null
   readonly password: string
   readonly code: string
   readonly submitError: string | null
@@ -68,7 +71,9 @@ type PanelState = {
 /** Reads the `secret` query parameter off a TOTP URI; an unparseable URI or
  * one without a secret yields null rather than a mangled substring. */
 function parseSecretFromUri(uri: string | null): string | null {
-  if (uri === null || !URL.canParse(uri)) return null
+  if (uri === null || !URL.canParse(uri)) {
+    return null
+  }
   return new URL(uri).searchParams.get('secret')
 }
 
@@ -78,11 +83,11 @@ type PanelAction =
   | {
       readonly type: 'enrolled'
       readonly totpURI: string
-      readonly backupCodes: readonly string[] | null
+      readonly backupCodes: ReadonlyArray<string> | null
     }
   | { readonly type: 'verified' }
   | { readonly type: 'disabled' }
-  | { readonly type: 'regenerated'; readonly backupCodes: readonly string[] }
+  | { readonly type: 'regenerated'; readonly backupCodes: ReadonlyArray<string> }
   | { readonly type: 'dismissCodes' }
   | { readonly type: 'failed'; readonly message: string }
   | { readonly type: 'clearStatus' }
@@ -203,7 +208,7 @@ export function TwoFactorPanel({
     | {
         readonly error?: { readonly message?: string | undefined } | null
         readonly totpURI: string | null
-        readonly backupCodes: readonly string[] | null
+        readonly backupCodes: ReadonlyArray<string> | null
       }
   > {
     const result = await enableTwoFactor({ password: state.password })
@@ -221,7 +226,9 @@ export function TwoFactorPanel({
 
   function startSetup() {
     void runAction(beginEnrollment, 'Could not start setup', (result) => {
-      if (!('totpURI' in result) || result.totpURI === null) return
+      if (!('totpURI' in result) || result.totpURI === null) {
+        return
+      }
       dispatch({
         type: 'enrolled',
         totpURI: result.totpURI,
@@ -267,7 +274,9 @@ export function TwoFactorPanel({
       },
       'Could not regenerate backup codes',
       (result) => {
-        if (!('backupCodes' in result) || result.backupCodes === null) return
+        if (!('backupCodes' in result) || result.backupCodes === null) {
+          return
+        }
         dispatch({ type: 'regenerated', backupCodes: result.backupCodes })
       }
     )
@@ -461,7 +470,7 @@ function BackupCodesSection({
   intro,
   onDismiss
 }: {
-  readonly codes: readonly string[]
+  readonly codes: ReadonlyArray<string>
   readonly intro?: string
   readonly onDismiss?: () => void
 }) {

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -36,7 +36,9 @@ const TOAST_OPTIONS = {
 // next-themes types its active theme as a plain string, so it is narrowed to
 // Sonner's contract here rather than asserted onto it.
 function toToasterTheme(theme: string | undefined): NonNullable<ToasterProps['theme']> {
-  if (theme === 'light' || theme === 'dark') return theme
+  if (theme === 'light' || theme === 'dark') {
+    return theme
+  }
   return 'system'
 }
 

--- a/apps/web/src/components/webhook-form.tsx
+++ b/apps/web/src/components/webhook-form.tsx
@@ -19,7 +19,7 @@ const CREATE_WEBHOOK_FAILED = 'Failed to create webhook endpoint'
 
 type WebhookValues = {
   url: string
-  events: readonly WebhookEventType[]
+  events: ReadonlyArray<WebhookEventType>
 }
 
 const DEFAULT_VALUES: WebhookValues = {
@@ -28,7 +28,9 @@ const DEFAULT_VALUES: WebhookValues = {
 }
 
 function validateUrl(value: string): string | undefined {
-  if (value.trim().length === 0) return 'Endpoint URL is required'
+  if (value.trim().length === 0) {
+    return 'Endpoint URL is required'
+  }
   return
 }
 
@@ -42,7 +44,7 @@ export type CreateWebhookEndpoint = (input: {
   readonly data: {
     readonly workspaceSlug: string
     readonly url: string
-    readonly events: readonly string[]
+    readonly events: ReadonlyArray<string>
   }
 }) => Promise<CreatedWebhookEndpoint>
 

--- a/apps/web/src/components/webhooks-panel.tsx
+++ b/apps/web/src/components/webhooks-panel.tsx
@@ -53,14 +53,16 @@ export type RotateWebhookSecret = (input: {
 
 // An explicit locale and timezone keeps SSR and the browser in agreement.
 function formatDate(iso: string | null): string {
-  if (iso === null) return 'never'
+  if (iso === null) {
+    return 'never'
+  }
   return new Date(iso).toLocaleString('en-US', { timeZone: 'UTC' })
 }
 
 function Deliveries({
   deliveries
 }: {
-  readonly deliveries: readonly WebhookDelivery[]
+  readonly deliveries: ReadonlyArray<WebhookDelivery>
 }) {
   if (deliveries.length === 0) {
     return <p className="text-xs text-muted-foreground">No delivery attempts yet.</p>
@@ -101,9 +103,11 @@ export function WebhooksPanel({
   createEndpoint
 }: {
   readonly workspaceSlug: string
-  readonly endpoints: readonly (WebhookEndpoint & {
-    readonly deliveries: readonly WebhookDelivery[]
-  })[]
+  readonly endpoints: ReadonlyArray<
+    WebhookEndpoint & {
+      readonly deliveries: ReadonlyArray<WebhookDelivery>
+    }
+  >
   readonly viewer: Viewer
   readonly disableEndpoint?: DisableWebhookEndpoint
   readonly rotateSecret?: RotateWebhookSecret
@@ -157,7 +161,9 @@ export function WebhooksPanel({
     }
     // `null` means no endpoint matched in this workspace — nothing was
     // rotated and there is no secret to show.
-    if (outcome.value !== null) setRotatedSecret({ endpointId, secret: outcome.value })
+    if (outcome.value !== null) {
+      setRotatedSecret({ endpointId, secret: outcome.value })
+    }
     await router.invalidate()
   }
 

--- a/apps/web/src/components/workspace-assistant-page.tsx
+++ b/apps/web/src/components/workspace-assistant-page.tsx
@@ -58,7 +58,7 @@ function TranscriptBody({
   transcript
 }: {
   readonly canUseAssistant: boolean
-  readonly transcript: readonly TranscriptEntry[]
+  readonly transcript: ReadonlyArray<TranscriptEntry>
 }) {
   if (transcript.length > 0) {
     return (
@@ -122,7 +122,7 @@ export function WorkspaceAssistantPage({
 }) {
   const [question, setQuestion] = useState('')
   const [pending, setPending] = useState(false)
-  const [transcript, setTranscript] = useState<readonly TranscriptEntry[]>([])
+  const [transcript, setTranscript] = useState<ReadonlyArray<TranscriptEntry>>([])
 
   // Presentation gate, mirroring the loader's hard gate: when no provider is
   // configured the form is absent and the honest copy stands in for it.
@@ -131,7 +131,9 @@ export function WorkspaceAssistantPage({
 
   async function submit() {
     const trimmed = question.trim()
-    if (trimmed.length === 0 || pending) return
+    if (trimmed.length === 0 || pending) {
+      return
+    }
     setPending(true)
     setQuestion('')
     setTranscript((entries) => [...entries, entry('user', trimmed)])

--- a/apps/web/src/components/workspace-audit-page.tsx
+++ b/apps/web/src/components/workspace-audit-page.tsx
@@ -59,7 +59,9 @@ const SELECT_CLASSES = 'h-9 rounded-md border border-input bg-transparent px-3 t
 function compact(search: WorkspaceAuditSearchUpdate): WorkspaceAuditSearchUpdate {
   const next: Record<string, string> = {}
   for (const [key, value] of Object.entries(search)) {
-    if (value !== '') next[key] = value
+    if (value !== '') {
+      next[key] = value
+    }
   }
   return next
 }
@@ -80,7 +82,9 @@ export function WorkspaceAuditPage({
     applySearch(compact({ ...filters, ...patch }))
   }
   function nextPage() {
-    if (nextCursor === null) return
+    if (nextCursor === null) {
+      return
+    }
     applySearch(compact({ ...filters, cursor: nextCursor }))
   }
 

--- a/apps/web/src/components/workspace-billing.tsx
+++ b/apps/web/src/components/workspace-billing.tsx
@@ -65,7 +65,7 @@ export function WorkspaceBillingPage({
 }: {
   readonly workspaceSlug: string
   readonly currentPlanId: string
-  readonly plans: readonly BillingPlan[]
+  readonly plans: ReadonlyArray<BillingPlan>
   readonly stripeConfigured: boolean
   /** Whether the viewer may change the plan (`organization:update`). */
   readonly canManageBilling: boolean

--- a/apps/web/src/components/workspace-general-settings.tsx
+++ b/apps/web/src/components/workspace-general-settings.tsx
@@ -23,8 +23,12 @@ export type DeleteWorkspace = (input: {
 }) => Promise<void>
 
 function validateName(value: string): string | undefined {
-  if (value.trim().length === 0) return 'Workspace name is required'
-  if (value.length > 80) return 'Workspace name must be under 80 characters'
+  if (value.trim().length === 0) {
+    return 'Workspace name is required'
+  }
+  if (value.length > 80) {
+    return 'Workspace name must be under 80 characters'
+  }
   return
 }
 

--- a/apps/web/src/hooks/use-heading-observer.ts
+++ b/apps/web/src/hooks/use-heading-observer.ts
@@ -25,7 +25,9 @@ export function useHeadingObserver({
 
   useEffect(() => {
     const container = containerRef.current
-    if (!container) return
+    if (!container) {
+      return
+    }
 
     const visible = visibleIds.current
     let intersectionObserver: IntersectionObserver | null = null
@@ -44,7 +46,9 @@ export function useHeadingObserver({
       setHeadings(extracted)
       setActiveIds(new Set())
 
-      if (extracted.length === 0) return
+      if (extracted.length === 0) {
+        return
+      }
 
       intersectionObserver = new IntersectionObserver((entries) => {
         for (const entry of entries) {

--- a/apps/web/src/lib/audit-labels.ts
+++ b/apps/web/src/lib/audit-labels.ts
@@ -87,10 +87,10 @@ export function auditEventLabel(eventType: string): string {
  * The dropdown options for the event-type filter: every known type, sorted,
  * with their human labels.
  */
-export const AUDIT_EVENT_FILTER_OPTIONS: readonly {
+export const AUDIT_EVENT_FILTER_OPTIONS: ReadonlyArray<{
   readonly value: string
   readonly label: string
-}[] = AUDIT_EVENT_TYPES.map((eventType) => ({
+}> = AUDIT_EVENT_TYPES.map((eventType) => ({
   value: eventType,
   label: auditEventLabel(eventType)
 })).toSorted((a, b) => a.label.localeCompare(b.label))

--- a/apps/web/src/lib/badge-variants.ts
+++ b/apps/web/src/lib/badge-variants.ts
@@ -5,15 +5,23 @@ export type BadgeVariant = NonNullable<React.ComponentProps<typeof Badge>['varia
 
 /** `pending` is the only status a workspace can still act on, so it leads. */
 export function invitationStatusVariant(status: Invitation['status']): BadgeVariant {
-  if (status === 'pending') return 'default'
-  if (status === 'accepted') return 'secondary'
+  if (status === 'pending') {
+    return 'default'
+  }
+  if (status === 'accepted') {
+    return 'secondary'
+  }
   return 'outline'
 }
 
 // A fallback keeps unknown free-text statuses visible rather than crashing
 // the render — the column is free-text by design.
 export function webhookDeliveryStatusVariant(status: string): BadgeVariant {
-  if (status === 'delivered') return 'default'
-  if (status === 'failed') return 'destructive'
+  if (status === 'delivered') {
+    return 'default'
+  }
+  if (status === 'failed') {
+    return 'destructive'
+  }
   return 'outline'
 }

--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -7,7 +7,7 @@ type BlogFrontmatter = {
   readonly description: string
   readonly date: string
   readonly author: string
-  readonly tags: readonly string[]
+  readonly tags: ReadonlyArray<string>
 }
 
 type BlogPost = {
@@ -25,7 +25,7 @@ function getSlugFromPath(path: string): string {
   return path.replace('../../content/blog/', '').replace('.mdx', '')
 }
 
-const ALL_POSTS: readonly BlogPost[] = Object.entries(modules)
+const ALL_POSTS: ReadonlyArray<BlogPost> = Object.entries(modules)
   .map(([path, mod]) => ({
     slug: getSlugFromPath(path),
     frontmatter: mod.frontmatter,
@@ -38,7 +38,7 @@ const ALL_POSTS: readonly BlogPost[] = Object.entries(modules)
 
 const POSTS_BY_SLUG = new Map(ALL_POSTS.map((post) => [post.slug, post]))
 
-export function getAllPosts(): readonly BlogPost[] {
+export function getAllPosts(): ReadonlyArray<BlogPost> {
   return ALL_POSTS
 }
 

--- a/apps/web/src/lib/capabilities.ts
+++ b/apps/web/src/lib/capabilities.ts
@@ -45,7 +45,9 @@ export type CapabilityBindings = Pick<
 /** Stripe checkout configuration from the Worker env; `undefined` when unset. */
 function stripeBillingConfig(): StarterEnv['billing'] | undefined {
   const secretKey = cloudflareEnv.STRIPE_SECRET_KEY
-  if (secretKey === undefined) return undefined
+  if (secretKey === undefined) {
+    return undefined
+  }
   const priceIds: Record<string, string> = {}
   if (cloudflareEnv.STRIPE_PRICE_ID_TEAM !== undefined) {
     priceIds.team = cloudflareEnv.STRIPE_PRICE_ID_TEAM
@@ -73,8 +75,10 @@ function rethrowCapabilityFailure(cause: Cause.Cause<unknown>): never {
   const failure = Cause.findErrorOption(cause)
   if (Option.isSome(failure)) {
     const error = failure.value
-    // oxlint-disable-next-line effect/noThrowStatement -- `throw notFound()` is TanStack Router's 404 control-flow API
-    if (error instanceof WorkspaceNotFound) throw notFound()
+    if (error instanceof WorkspaceNotFound) {
+      // oxlint-disable-next-line effect/noThrowStatement -- `throw notFound()` is TanStack Router's 404 control-flow API
+      throw notFound()
+    }
     if (error instanceof CapabilityUnavailable) {
       // oxlint-disable-next-line effect/noThrowStatement -- rejects the loader promise so router.tsx's defaultErrorComponent renders the degraded state
       throw new CapabilityUnavailableError(error.capability, error.reason)
@@ -131,7 +135,9 @@ export async function runWorkspaceCapabilities<A, E>(
       )
     )
   )
-  if (Exit.isSuccess(exit)) return exit.value
+  if (Exit.isSuccess(exit)) {
+    return exit.value
+  }
   return rethrowCapabilityFailure(exit.cause)
 }
 
@@ -152,6 +158,8 @@ export async function runCapabilities<A, E>(
       Effect.provide(effect, selectCapabilitiesLayer({ ...starterEnv, ...bindings }))
     )
   )
-  if (Exit.isSuccess(exit)) return exit.value
+  if (Exit.isSuccess(exit)) {
+    return exit.value
+  }
   return rethrowCapabilityFailure(exit.cause)
 }

--- a/apps/web/src/lib/cause-message.ts
+++ b/apps/web/src/lib/cause-message.ts
@@ -16,6 +16,8 @@
  */
 // oxlint-disable-next-line anti-slop/no-unknown-parameters -- `unknown` is the input: this is the parse step for a rejected promise's value, which no schema can narrow before the catch handler runs
 export function causeMessage(thrown: unknown, fallback: string): string {
-  if (thrown instanceof Error && thrown.message.length > 0) return thrown.message
+  if (thrown instanceof Error && thrown.message.length > 0) {
+    return thrown.message
+  }
   return fallback
 }

--- a/apps/web/src/lib/cloudflare-workers-shim-dev.ts
+++ b/apps/web/src/lib/cloudflare-workers-shim-dev.ts
@@ -41,13 +41,17 @@ function loadNodeTimers() {
 }
 
 async function provisionLocalD1(): Promise<D1Database | undefined> {
-  if (!import.meta.env.SSR) return undefined
+  if (!import.meta.env.SSR) {
+    return undefined
+  }
   // oxlint-disable-next-line effect/noNewPromise -- platform boundary: this module is awaited before any Effect runtime exists, same as the Promise.race below
   const [{ join }, localD1State] = await Promise.all([
     loadNodePath(),
     loadLocalD1State()
   ])
-  if (!localD1State.hasLocalD1State()) return undefined
+  if (!localD1State.hasLocalD1State()) {
+    return undefined
+  }
   // oxlint-disable-next-line effect/noNewPromise -- platform boundary: this module is awaited before any Effect runtime exists, same as the Promise.race below
   const [{ getPlatformProxy }, { setTimeout: delay }] = await Promise.all([
     loadWrangler(),

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -7,7 +7,7 @@ type PublicLink = {
   readonly label: string
 }
 
-export const publicLinks: readonly PublicLink[] = [
+export const publicLinks: ReadonlyArray<PublicLink> = [
   { to: '/docs', label: 'Docs' },
   { to: '/blog', label: 'Blog' },
   { to: '/pricing', label: 'Pricing' },
@@ -21,7 +21,7 @@ type OptionalProviderModule = {
   readonly icon: ComponentType<SVGProps<SVGSVGElement>>
 }
 
-export const optionalProviderModules: readonly OptionalProviderModule[] = [
+export const optionalProviderModules: ReadonlyArray<OptionalProviderModule> = [
   {
     id: 'stripe',
     name: 'Stripe',
@@ -56,7 +56,7 @@ export const optionalProviderModules: readonly OptionalProviderModule[] = [
 
 type FaqItem = { readonly question: string; readonly answer: string }
 
-export const faqItems: readonly FaqItem[] = [
+export const faqItems: ReadonlyArray<FaqItem> = [
   {
     question: 'Why TanStack Start instead of Next.js or Remix?',
     answer:
@@ -98,10 +98,10 @@ type ChangelogEntry = {
   readonly version: string
   readonly date: string
   readonly title: string
-  readonly changes: readonly string[]
+  readonly changes: ReadonlyArray<string>
 }
 
-export const changelog: readonly ChangelogEntry[] = [
+export const changelog: ReadonlyArray<ChangelogEntry> = [
   {
     version: '0.1.0',
     date: '2026-05-16',

--- a/apps/web/src/lib/docs.ts
+++ b/apps/web/src/lib/docs.ts
@@ -7,7 +7,7 @@ type DocFrontmatter = {
   readonly description: string
   readonly category: string
   readonly order: number
-  readonly tags?: readonly string[]
+  readonly tags?: ReadonlyArray<string>
   readonly updated?: string
 }
 
@@ -33,7 +33,7 @@ export function isDocCategory(value: string): value is DocCategory {
   return Object.hasOwn(DOC_CATEGORIES, value)
 }
 
-export const DOC_CATEGORY_ORDER: readonly DocCategory[] = [
+export const DOC_CATEGORY_ORDER: ReadonlyArray<DocCategory> = [
   'getting-started',
   'architecture',
   'capability-interfaces',
@@ -53,10 +53,10 @@ type DocPath = { category: string; slug: string }
 function parsePath(path: string): DocPath {
   const relative = path.replace('../../content/docs/', '').replace('.mdx', '')
   const parts = relative.split('/')
-  return { category: parts[0] ?? '', slug: parts[parts.length - 1] ?? '' }
+  return { category: parts[0] ?? '', slug: parts.at(-1) ?? '' }
 }
 
-const ALL_DOCS: readonly DocArticle[] = Object.entries(modules)
+const ALL_DOCS: ReadonlyArray<DocArticle> = Object.entries(modules)
   .map(([path, mod]) => {
     const { category, slug } = parsePath(path)
     return {
@@ -68,7 +68,7 @@ const ALL_DOCS: readonly DocArticle[] = Object.entries(modules)
   })
   .toSorted((a, b) => a.frontmatter.order - b.frontmatter.order)
 
-const DOCS_BY_CATEGORY = new Map<string, readonly DocArticle[]>()
+const DOCS_BY_CATEGORY = new Map<string, ReadonlyArray<DocArticle>>()
 const DOCS_BY_KEY = new Map<string, DocArticle>()
 const DOC_INDEX_IN_CATEGORY = new Map<string, number>()
 for (const doc of ALL_DOCS) {
@@ -78,11 +78,11 @@ for (const doc of ALL_DOCS) {
   DOCS_BY_KEY.set(`${doc.category}/${doc.slug}`, doc)
 }
 
-export function getAllDocs(): readonly DocArticle[] {
+export function getAllDocs(): ReadonlyArray<DocArticle> {
   return ALL_DOCS
 }
 
-export function getDocsByCategory(category: string): readonly DocArticle[] {
+export function getDocsByCategory(category: string): ReadonlyArray<DocArticle> {
   return DOCS_BY_CATEGORY.get(category) ?? []
 }
 
@@ -99,7 +99,9 @@ export type AdjacentDocs = {
 export function getAdjacentDocs(category: string, slug: string): AdjacentDocs {
   const list = DOCS_BY_CATEGORY.get(category)
   const index = DOC_INDEX_IN_CATEGORY.get(`${category}/${slug}`)
-  if (!list || index === undefined) return { prev: null, next: null }
+  if (!list || index === undefined) {
+    return { prev: null, next: null }
+  }
   return {
     prev: index > 0 ? (list[index - 1] ?? null) : null,
     next: index < list.length - 1 ? (list[index + 1] ?? null) : null

--- a/apps/web/src/lib/local-d1-state.ts
+++ b/apps/web/src/lib/local-d1-state.ts
@@ -4,14 +4,10 @@
 // dynamically behind its `import.meta.env.SSR` guard so the browser never
 // evaluates the node:* imports.
 import { existsSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 /** Absolute path to packages/db, resolved from this module's location. */
-export const dbPackageDir = join(
-  dirname(fileURLToPath(import.meta.url)),
-  '../../../../packages/db'
-)
+export const dbPackageDir = join(import.meta.dirname, '../../../../packages/db')
 
 /** Wrangler persist root passed to getPlatformProxy. */
 export const localD1PersistPath = join(dbPackageDir, '.wrangler/state/v3')

--- a/apps/web/src/lib/observability.test.ts
+++ b/apps/web/src/lib/observability.test.ts
@@ -42,12 +42,12 @@ const decodeNested = Schema.decodeUnknownSync(
  * through `Logger.consoleJson`, so spying here exercises the real logger set
  * and the real runtime instead of a stand-in.
  */
-let lines: Captured[] = []
+let lines: Array<Captured> = []
 
 beforeEach(() => {
   lines = []
   ambient.request = undefined
-  vi.spyOn(console, 'log').mockImplementation((...args: readonly unknown[]) => {
+  vi.spyOn(console, 'log').mockImplementation((...args: ReadonlyArray<unknown>) => {
     lines.push(decodeLine(args[0]))
   })
 })
@@ -60,12 +60,14 @@ afterEach(() => {
 function only(): Captured {
   expect(lines).toHaveLength(1)
   const [record] = lines
-  if (!record) throw new Error('no canonical line was emitted')
+  if (!record) {
+    throw new Error('no canonical line was emitted')
+  }
   return record
 }
 
 /** The `nested` array the request folded its child runs into. */
-function nestedEntries(record: Captured): readonly Record<string, unknown>[] {
+function nestedEntries(record: Captured): ReadonlyArray<Record<string, unknown>> {
   return decodeNested(record.annotations['nested'])
 }
 

--- a/apps/web/src/lib/observability.ts
+++ b/apps/web/src/lib/observability.ts
@@ -86,7 +86,9 @@ export type CurrentRequest = () => Request | undefined
 
 function currentTelemetry(lookupRequest: CurrentRequest): RequestTelemetry | undefined {
   const request = lookupRequest()
-  if (!request) return undefined
+  if (!request) {
+    return undefined
+  }
   return registry.get(request)
 }
 
@@ -129,7 +131,9 @@ export function memoizePerRequest<A>(
 ): Promise<A> {
   const request = lookupRequest()
   const telemetry = request === undefined ? undefined : registry.get(request)
-  if (!telemetry) return make()
+  if (!telemetry) {
+    return make()
+  }
   const existing = telemetry.memo.get(key)
   if (existing) {
     // SAFETY: slots are keyed by the caller's `key`, so every promise stored
@@ -157,7 +161,9 @@ export function runWebRequestScope(
   lookupRequest: CurrentRequest = currentRequest
 ): Promise<Response> {
   const metadata: WebRequestMetadata = { handlerType: options.handlerType }
-  if (options.serverFnId) metadata.serverFnId = options.serverFnId
+  if (options.serverFnId) {
+    metadata.serverFnId = options.serverFnId
+  }
   return loggerRuntime
     .runPromiseExit(
       withInvocationExporters(
@@ -199,7 +205,9 @@ function registerAndRun(
     // (Start re-wraps the request as it flows through the handler chain), so
     // register the ambient one too when it differs.
     const ambient = lookupRequest()
-    if (ambient && ambient !== request) registry.set(ambient, telemetry)
+    if (ambient && ambient !== request) {
+      registry.set(ambient, telemetry)
+    }
     const response = yield* runNext(next)
     yield* Effect.annotateLogsScoped({ statusCode: response.status })
     if (telemetry.nested.length > 0) {
@@ -219,7 +227,9 @@ function runNext(next: () => Promise<Response>): Effect.Effect<Response, unknown
 }
 
 function settle(exit: Exit.Exit<Response, unknown>): Response {
-  if (Exit.isSuccess(exit)) return exit.value
+  if (Exit.isSuccess(exit)) {
+    return exit.value
+  }
   // The handler's own failure where there is one, the squashed cause otherwise.
   // Inlined rather than a helper: the value is whatever the handler failed with,
   // so naming a return type for it would only be `unknown` under another name.
@@ -250,7 +260,9 @@ export function withWebRequestScope<A, E, R>(
 ): Effect.Effect<A, E, Exclude<R, Scope.Scope>> {
   return Effect.suspend(() => {
     const telemetry = currentTelemetry(lookupRequest)
-    if (!telemetry) return standalone(options, effect)
+    if (!telemetry) {
+      return standalone(options, effect)
+    }
     return nested(telemetry, options, effect)
   })
 }

--- a/apps/web/src/lib/permissions.ts
+++ b/apps/web/src/lib/permissions.ts
@@ -20,6 +20,8 @@ import { type WorkspaceViewer } from '@b2b-saas-starter/capabilities/governance/
 export type Viewer = WorkspaceViewer | null
 
 export function viewerCan(viewer: Viewer, permission: PermissionRequest): boolean {
-  if (!viewer) return false
+  if (!viewer) {
+    return false
+  }
   return authorize(memberPrincipal(viewer.role), permission).success
 }

--- a/apps/web/src/lib/rate-limit.test.ts
+++ b/apps/web/src/lib/rate-limit.test.ts
@@ -29,7 +29,7 @@ describe('rate limiter fallback (no Cloudflare bindings)', () => {
     }
 
     const key = `test-${Date.now()}-${Math.random()}`
-    const outcomes: boolean[] = []
+    const outcomes: Array<boolean> = []
     for (let i = 0; i < 21; i += 1) {
       outcomes.push(await runScoped(take(key)))
     }
@@ -61,7 +61,7 @@ describe('authRateLimitBucket', () => {
       }).pipe(Effect.provide(makeRateLimiterLayer({})))
     }
     const key = `sign-in-${Date.now()}-${Math.random()}`
-    const outcomes: boolean[] = []
+    const outcomes: Array<boolean> = []
     for (let i = 0; i < 6; i += 1) {
       outcomes.push(await runScoped(take(key)))
     }

--- a/apps/web/src/lib/server-call.ts
+++ b/apps/web/src/lib/server-call.ts
@@ -14,7 +14,9 @@ export async function callServerFn<A>(
   const exit = await Effect.runPromiseExit(
     Effect.tryPromise({ try: run, catch: (cause) => describe(cause) })
   )
-  if (Exit.isSuccess(exit)) return { ok: true, value: exit.value }
+  if (Exit.isSuccess(exit)) {
+    return { ok: true, value: exit.value }
+  }
   return {
     ok: false,
     message: Option.getOrElse(Cause.findErrorOption(exit.cause), () => fallback)

--- a/apps/web/src/lib/server/admin.ts
+++ b/apps/web/src/lib/server/admin.ts
@@ -26,7 +26,7 @@ export type SystemUser = {
  * surface fails closed twice.
  */
 export const listSystemUsersServerFn = createServerFn({ method: 'GET' }).handler(
-  async (): Promise<readonly SystemUser[]> => {
+  async (): Promise<ReadonlyArray<SystemUser>> => {
     const users = await runCapabilities(
       Effect.gen(function* () {
         const admin = yield* PlatformUserAdmin
@@ -96,7 +96,7 @@ export const unbanSystemUserServerFn = createServerFn({ method: 'POST' })
  */
 export const listUserWorkspacesServerFn = createServerFn({ method: 'POST' })
   .validator((input: { userId: string }) => input)
-  .handler(async ({ data }): Promise<readonly WorkspaceWithMembership[]> => {
+  .handler(async ({ data }): Promise<ReadonlyArray<WorkspaceWithMembership>> => {
     await requireAdminSession()
     return runCapabilities(
       Effect.gen(function* () {

--- a/apps/web/src/lib/server/api-tokens.test.ts
+++ b/apps/web/src/lib/server/api-tokens.test.ts
@@ -43,7 +43,7 @@ function actor(role: WorkspaceRole): Actor {
 const OWNER = actor('owner')
 const MEMBER = actor('member')
 
-const seedTokens: readonly ApiToken[] = [
+const seedTokens: ReadonlyArray<ApiToken> = [
   {
     id: 'tok_1',
     name: 'Local client',

--- a/apps/web/src/lib/server/api-tokens.ts
+++ b/apps/web/src/lib/server/api-tokens.ts
@@ -61,7 +61,7 @@ export const createApiTokenServerFn = createServerFn({ method: 'POST' })
 export type WorkspaceApiTokensPayload = {
   readonly viewer: { readonly role: WorkspaceRole } | null
   readonly unreadCount: number
-  readonly tokens: readonly ApiToken[]
+  readonly tokens: ReadonlyArray<ApiToken>
 }
 
 /**

--- a/apps/web/src/lib/server/assistant.ts
+++ b/apps/web/src/lib/server/assistant.ts
@@ -31,7 +31,9 @@ export const ASSISTANT_UNCONFIGURED_MESSAGE =
  * claim a configuration that does not exist (same rule as `apps/api`). */
 function assistantProviderEnv(): ProviderEnv {
   const provider: { -readonly [K in keyof ProviderEnv]: ProviderEnv[K] } = {}
-  if (cloudflareEnv.AI) provider.AI = cloudflareEnv.AI
+  if (cloudflareEnv.AI) {
+    provider.AI = cloudflareEnv.AI
+  }
   if (cloudflareEnv.WORKERS_AI_ENABLED) {
     provider.WORKERS_AI_ENABLED = cloudflareEnv.WORKERS_AI_ENABLED
   }

--- a/apps/web/src/lib/server/auth-audit/admin.ts
+++ b/apps/web/src/lib/server/auth-audit/admin.ts
@@ -148,7 +148,9 @@ export function adminAuditInput(exchange: {
   readonly targetUserId: string | null
 }): RecordAuditEventInput | null {
   const row = adminExchangeRow(exchange.pathname)
-  if (row === null) return null
+  if (row === null) {
+    return null
+  }
   const success = exchange.status >= 200 && exchange.status < 300
   return {
     workspaceId: null,
@@ -174,7 +176,9 @@ export function recordAdminAudit(args: {
 }): Effect.Effect<AuthAuditOutcome, never, Scope.Scope> {
   return Effect.gen(function* () {
     const { pathname, response, run, admin } = args
-    if (adminExchangeRow(pathname) === null) return 'skipped'
+    if (adminExchangeRow(pathname) === null) {
+      return 'skipped'
+    }
 
     let targetUserId: string | null = null
     if (admin.request !== undefined) {
@@ -192,7 +196,9 @@ export function recordAdminAudit(args: {
       actorUserId: admin.actorUserId,
       targetUserId
     })
-    if (!input) return 'skipped'
+    if (!input) {
+      return 'skipped'
+    }
 
     return yield* writeAndReport(input, run)
   })

--- a/apps/web/src/lib/server/auth-audit/lifecycle.ts
+++ b/apps/web/src/lib/server/auth-audit/lifecycle.ts
@@ -213,7 +213,9 @@ export function authAuditInput(exchange: {
   readonly locationHeader?: string | null
 }): RecordAuditEventInput | null {
   const row = lifecycleExchangeRow(exchange)
-  if (row === null) return null
+  if (row === null) {
+    return null
+  }
 
   const success =
     (exchange.status >= 200 && exchange.status < 300) ||
@@ -250,7 +252,9 @@ export function authAuditInput(exchange: {
 /** Whether a redirect Location is Better Auth's failure shape (`?error=`). */
 function locationCarriesError(location: string | null): boolean {
   // An unparseable or absent Location is not a success this audit vouches for.
-  if (location === null) return true
+  if (location === null) {
+    return true
+  }
   return URL.parse(location)?.searchParams.has('error') ?? true
 }
 
@@ -285,7 +289,9 @@ export function recordAuthAudit(
     }
 
     const row = lifecycleExchangeRow({ method, pathname })
-    if (row === null) return 'skipped'
+    if (row === null) {
+      return 'skipped'
+    }
 
     let userId: string | null = null
     if (row.actorFromSession === true) {
@@ -306,7 +312,9 @@ export function recordAuthAudit(
       userId,
       locationHeader: response.headers.get('location')
     })
-    if (!input) return 'skipped'
+    if (!input) {
+      return 'skipped'
+    }
 
     return yield* writeAndReport(input, run)
   })

--- a/apps/web/src/lib/server/authorize.ts
+++ b/apps/web/src/lib/server/authorize.ts
@@ -54,8 +54,12 @@ export function whenPermitted<A, E, R>(
 ): Effect.Effect<A | null, E, R | WorkspaceContext> {
   return Effect.gen(function* () {
     const ctx = yield* WorkspaceContext
-    if (!ctx.actor) return null
-    if (!authorize(memberPrincipal(ctx.actor.role), permission).success) return null
+    if (!ctx.actor) {
+      return null
+    }
+    if (!authorize(memberPrincipal(ctx.actor.role), permission).success) {
+      return null
+    }
     return yield* effect
   })
 }

--- a/apps/web/src/lib/server/billing.ts
+++ b/apps/web/src/lib/server/billing.ts
@@ -27,7 +27,7 @@ export type WorkspaceBillingPayload = {
   readonly viewer: { readonly role: WorkspaceRole } | null
   readonly workspaceName: string
   readonly unreadCount: number
-  readonly plans: readonly Plan[]
+  readonly plans: ReadonlyArray<Plan>
   readonly currentPlanId: string
   /** True when `STRIPE_SECRET_KEY` (and every paid plan's price id) is set. */
   readonly stripeConfigured: boolean

--- a/apps/web/src/lib/server/env-gate.test.ts
+++ b/apps/web/src/lib/server/env-gate.test.ts
@@ -30,7 +30,7 @@ describe('enforceRequiredEnvAudit', () => {
   })
 
   it('refuses to serve when production required env is insecure', () => {
-    const problems: readonly RequiredEnvProblem[] = [
+    const problems: ReadonlyArray<RequiredEnvProblem> = [
       { key: 'BETTER_AUTH_SECRET', reason: 'placeholder' },
       { key: 'BETTER_AUTH_URL', reason: 'missing' }
     ]

--- a/apps/web/src/lib/server/env-gate.ts
+++ b/apps/web/src/lib/server/env-gate.ts
@@ -22,7 +22,9 @@ export class InsecureProductionEnvError extends Error {
 
 /** The pure decision, exported for tests: production + problems → throw. */
 export function enforceRequiredEnvAudit(audit: RequiredEnvAudit): void {
-  if (audit.mode !== 'production' || audit.problems.length === 0) return
+  if (audit.mode !== 'production' || audit.problems.length === 0) {
+    return
+  }
   // oxlint-disable-next-line effect/noThrowStatement -- the TanStack request middleware has no Effect error channel; this throw crossing that boundary IS the gate
   throw new InsecureProductionEnvError(audit.problems)
 }
@@ -46,7 +48,9 @@ let verdict: 'ok' | 'warned' | undefined
  *   and reason, never by value — and the app keeps serving.
  */
 export function enforceRequiredEnvOnce(): void {
-  if (verdict === 'ok') return
+  if (verdict === 'ok') {
+    return
+  }
   const audit = auditRequiredEnv(cloudflareEnv)
   if (audit.problems.length === 0) {
     verdict = 'ok'
@@ -56,7 +60,9 @@ export function enforceRequiredEnvOnce(): void {
     // oxlint-disable-next-line effect/noThrowStatement -- deliberate refusal to serve: the request middleware has no error channel, and failing every request until the deployment is fixed is the point
     throw new InsecureProductionEnvError(audit.problems)
   }
-  if (verdict === 'warned') return
+  if (verdict === 'warned') {
+    return
+  }
   verdict = 'warned'
   // Standalone scope, not nested in the triggering request: this is a
   // boot-time config event, one per isolate, not traffic telemetry. The

--- a/apps/web/src/lib/server/invitation-binding.test.ts
+++ b/apps/web/src/lib/server/invitation-binding.test.ts
@@ -52,7 +52,7 @@ type BindingCall = {
   readonly call: () => Promise<void>
 }
 
-const CALLS: readonly BindingCall[] = [
+const CALLS: ReadonlyArray<BindingCall> = [
   {
     name: 'create',
     call: () =>

--- a/apps/web/src/lib/server/invitation-binding.ts
+++ b/apps/web/src/lib/server/invitation-binding.ts
@@ -36,8 +36,10 @@ class MissingRequestHeaders extends Schema.TaggedError<MissingRequestHeaders>()(
 ) {}
 
 function requireHeaders(headers: Headers | undefined): Headers {
-  // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the WorkspaceInvitationBinding port returns; there is no Effect error channel on this side of it
-  if (!headers) throw new MissingRequestHeaders({ message: 'no_request_headers' })
+  if (!headers) {
+    // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the WorkspaceInvitationBinding port returns; there is no Effect error channel on this side of it
+    throw new MissingRequestHeaders({ message: 'no_request_headers' })
+  }
   return headers
 }
 

--- a/apps/web/src/lib/server/invitations.test.ts
+++ b/apps/web/src/lib/server/invitations.test.ts
@@ -85,7 +85,7 @@ function invitation(overrides: Partial<Invitation> = {}): Invitation {
 }
 
 /** Every message the dispatcher was handed, so a test can read the recipient. */
-type Outbox = { readonly sent: EmailMessage[] }
+type Outbox = { readonly sent: Array<EmailMessage> }
 
 function emailDispatcher(outbox: Outbox, fails = false): Layer.Layer<EmailDispatcher> {
   return Layer.succeed(EmailDispatcher)({
@@ -121,8 +121,8 @@ type TestServices =
 
 type Harness = {
   readonly actor?: Actor | null
-  readonly seed?: readonly Invitation[]
-  readonly members?: readonly Member[]
+  readonly seed?: ReadonlyArray<Invitation>
+  readonly members?: ReadonlyArray<Member>
   readonly emailFails?: boolean
 }
 
@@ -139,7 +139,7 @@ function run<A, E>(
   }) => Effect.Effect<A, E, TestServices>
 ): Promise<{
   readonly result: A
-  readonly roster: readonly Member[]
+  readonly roster: ReadonlyArray<Member>
   readonly outbox: Outbox
 }> {
   const outbox: Outbox = { sent: [] }
@@ -310,11 +310,11 @@ describe('invitationPreview', () => {
   // One opaque answer for every other outcome: an invitation id is a URL
   // parameter, so anything disclosed for a mismatched address tells a
   // link-guesser which workspaces exist.
-  const opaque: readonly {
+  const opaque: ReadonlyArray<{
     readonly name: string
     readonly harness: Harness
     readonly viewerEmail: string
-  }[] = [
+  }> = [
     { name: 'an unknown id', harness: { seed: [] }, viewerEmail: INVITEE },
     {
       name: 'an accepted invitation',
@@ -365,12 +365,12 @@ describe('acceptInvitation', () => {
     expect(roster.map((member) => member.id)).toEqual([ownerMember.id, 'usr_invitee'])
   })
 
-  const refusals: readonly {
+  const refusals: ReadonlyArray<{
     readonly name: string
     readonly harness: Harness
     readonly email: string
     readonly reason: string
-  }[] = [
+  }> = [
     {
       name: 'an address the invitation was not sent to',
       harness: { seed: [invitation()] },

--- a/apps/web/src/lib/server/invitations.ts
+++ b/apps/web/src/lib/server/invitations.ts
@@ -78,7 +78,9 @@ const decodeAccept = Schema.decodeUnknownSync(AcceptInvitationInput)
  */
 function requestOrigin(): string {
   const request = currentRequest()
-  if (!request) return ''
+  if (!request) {
+    return ''
+  }
   return new URL(request.url).origin
 }
 
@@ -215,9 +217,13 @@ export function invitationPreview(input: {
   return Effect.gen(function* () {
     const invitations = yield* WorkspaceInvitations
     const found = yield* invitations.find(input.invitationId)
-    if (Option.isNone(found)) return UNAVAILABLE
+    if (Option.isNone(found)) {
+      return UNAVAILABLE
+    }
     const invitation = found.value
-    if (invitation.status !== 'pending') return UNAVAILABLE
+    if (invitation.status !== 'pending') {
+      return UNAVAILABLE
+    }
     if (invitation.email.toLowerCase() !== input.viewerEmail.toLowerCase()) {
       return UNAVAILABLE
     }

--- a/apps/web/src/lib/server/member-binding.test.ts
+++ b/apps/web/src/lib/server/member-binding.test.ts
@@ -57,7 +57,7 @@ type BindingCall = {
   readonly call: () => Promise<void>
 }
 
-const CALLS: readonly BindingCall[] = [
+const CALLS: ReadonlyArray<BindingCall> = [
   {
     name: 'removeMember',
     call: () =>

--- a/apps/web/src/lib/server/member-binding.ts
+++ b/apps/web/src/lib/server/member-binding.ts
@@ -37,8 +37,10 @@ class MissingRequestHeaders extends Schema.TaggedError<MissingRequestHeaders>()(
 ) {}
 
 function requireHeaders(headers: Headers | undefined): Headers {
-  // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the WorkspaceMemberBinding port returns; there is no Effect error channel on this side of it
-  if (!headers) throw new MissingRequestHeaders({ message: 'no_request_headers' })
+  if (!headers) {
+    // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the WorkspaceMemberBinding port returns; there is no Effect error channel on this side of it
+    throw new MissingRequestHeaders({ message: 'no_request_headers' })
+  }
   return headers
 }
 

--- a/apps/web/src/lib/server/telemetry-config.ts
+++ b/apps/web/src/lib/server/telemetry-config.ts
@@ -14,8 +14,12 @@ export type ClientTelemetryConfig = {
 
 /** Absent and empty both count as unset — no empty-string DSNs reach an SDK. */
 function nonEmptyEnvValue(value: string | undefined): string | undefined {
-  if (value === undefined) return undefined
-  if (value.length === 0) return undefined
+  if (value === undefined) {
+    return undefined
+  }
+  if (value.length === 0) {
+    return undefined
+  }
   return value
 }
 

--- a/apps/web/src/lib/server/turnstile.ts
+++ b/apps/web/src/lib/server/turnstile.ts
@@ -19,7 +19,9 @@ export function makeTurnstileLayer() {
 // site key (safe to expose) crosses the server-function boundary below.
 const readSiteKey = createServerOnlyFn((): string | null => {
   const siteKey = env.TURNSTILE_SITE_KEY
-  if (siteKey === undefined || siteKey.length === 0) return null
+  if (siteKey === undefined || siteKey.length === 0) {
+    return null
+  }
   return siteKey
 })
 

--- a/apps/web/src/lib/server/two-factor-notification.ts
+++ b/apps/web/src/lib/server/two-factor-notification.ts
@@ -12,7 +12,9 @@ export function isTwoFactorChangeExchange(exchange: {
   readonly method: string
   readonly pathname: string
 }): boolean {
-  if (exchange.method !== 'POST') return false
+  if (exchange.method !== 'POST') {
+    return false
+  }
   return (
     exchange.pathname.endsWith('/two-factor/enable') ||
     exchange.pathname.endsWith('/two-factor/disable')

--- a/apps/web/src/lib/server/user-admin-binding.ts
+++ b/apps/web/src/lib/server/user-admin-binding.ts
@@ -31,8 +31,10 @@ class MissingRequestHeaders extends Schema.TaggedError<MissingRequestHeaders>()(
 ) {}
 
 function requireHeaders(headers: Headers | undefined): Headers {
-  // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the PlatformUserAdminBinding port returns; there is no Effect error channel on this side of it
-  if (!headers) throw new MissingRequestHeaders({ message: 'no_request_headers' })
+  if (!headers) {
+    // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the PlatformUserAdminBinding port returns; there is no Effect error channel on this side of it
+    throw new MissingRequestHeaders({ message: 'no_request_headers' })
+  }
   return headers
 }
 

--- a/apps/web/src/lib/server/webhooks.test.ts
+++ b/apps/web/src/lib/server/webhooks.test.ts
@@ -50,7 +50,7 @@ const OWNER = actor('owner')
 const ADMIN = actor('admin')
 const MEMBER = actor('member')
 
-const seedEndpoints: readonly WebhookEndpoint[] = [
+const seedEndpoints: ReadonlyArray<WebhookEndpoint> = [
   {
     id: 'wh_1',
     url: 'https://example.com/hooks/starter',

--- a/apps/web/src/lib/server/webhooks.ts
+++ b/apps/web/src/lib/server/webhooks.ts
@@ -58,9 +58,11 @@ export const createWebhookEndpointServerFn = createServerFn({ method: 'POST' })
 export type WorkspaceWebhooksPayload = {
   readonly viewer: { readonly role: WorkspaceRole } | null
   readonly unreadCount: number
-  readonly endpoints: readonly (WebhookEndpoint & {
-    readonly deliveries: readonly WebhookDelivery[]
-  })[]
+  readonly endpoints: ReadonlyArray<
+    WebhookEndpoint & {
+      readonly deliveries: ReadonlyArray<WebhookDelivery>
+    }
+  >
 }
 
 /**

--- a/apps/web/src/lib/server/workspace-audit.test.ts
+++ b/apps/web/src/lib/server/workspace-audit.test.ts
@@ -25,7 +25,9 @@ function load(overrides?: {
     userId: OWNER,
     filters: overrides?.filters ?? {}
   }
-  if (overrides?.cursor !== undefined) input.cursor = overrides.cursor
+  if (overrides?.cursor !== undefined) {
+    input.cursor = overrides.cursor
+  }
   return loadWorkspaceAuditEvents(input)
 }
 
@@ -74,7 +76,9 @@ describe('loadWorkspaceAuditEvents', () => {
 
   it('walks pages forward with the opaque cursor', async () => {
     const first = await load()
-    if (first.nextCursor === null) return
+    if (first.nextCursor === null) {
+      return
+    }
     const second = await load({ cursor: first.nextCursor })
     const firstIds = new Set(first.events.map((event) => event.id))
     for (const event of second.events) {

--- a/apps/web/src/lib/server/workspace-audit.ts
+++ b/apps/web/src/lib/server/workspace-audit.ts
@@ -46,12 +46,12 @@ export type LoadWorkspaceAuditEventsInput = {
  */
 export type WorkspaceAuditPayload = {
   readonly viewer: WorkspaceViewer | null
-  readonly events: readonly AuditEvent[]
+  readonly events: ReadonlyArray<AuditEvent>
   /** Opaque keyset cursor for the next older page, or null on the last one. */
   readonly nextCursor: string | null
   /** The filters this page was loaded with, echoed back for the controls. */
   readonly filters: WorkspaceAuditFilters
-  readonly members: readonly { readonly id: string; readonly name: string }[]
+  readonly members: ReadonlyArray<{ readonly id: string; readonly name: string }>
 }
 
 /** The capability-level filter input, widened to mutable bounds so the
@@ -78,7 +78,9 @@ export function loadWorkspaceAuditEvents(
   if (input.filters.until !== undefined) {
     listInput.until = `${input.filters.until}T23:59:59.999Z`
   }
-  if (input.cursor !== undefined) listInput.cursor = input.cursor
+  if (input.cursor !== undefined) {
+    listInput.cursor = input.cursor
+  }
   return runWorkspaceCapabilities(
     input.workspaceSlug,
     Effect.gen(function* () {

--- a/apps/web/src/lib/server/workspace-dashboard.ts
+++ b/apps/web/src/lib/server/workspace-dashboard.ts
@@ -25,7 +25,7 @@ import { requireWorkspacePermission, whenPermitted } from './authorize'
  */
 export type WorkspaceDashboardPayload = WorkspaceDashboardProjection & {
   readonly viewer: WorkspaceViewer | null
-  readonly webhooks: readonly WebhookEndpoint[] | null
+  readonly webhooks: ReadonlyArray<WebhookEndpoint> | null
 }
 
 const dashboardPayload: Effect.Effect<

--- a/apps/web/src/lib/server/workspace-members.test.ts
+++ b/apps/web/src/lib/server/workspace-members.test.ts
@@ -57,7 +57,7 @@ function memberOf(a: Actor): Member {
 
 type Harness = {
   readonly actor?: Actor | null
-  readonly members?: readonly Member[]
+  readonly members?: ReadonlyArray<Member>
 }
 
 /**
@@ -67,7 +67,7 @@ type Harness = {
 function run<A, E>(
   harness: Harness,
   body: () => Effect.Effect<A, E, Scope.Scope | WorkspaceContext | WorkspaceMembership>
-): Promise<{ readonly result: A; readonly roster: readonly Member[] }> {
+): Promise<{ readonly result: A; readonly roster: ReadonlyArray<Member> }> {
   const members = harness.members ?? [memberOf(OWNER), memberOf(MEMBER)]
   return Effect.runPromise(
     Effect.gen(function* () {

--- a/apps/web/src/lib/server/workspace-members.ts
+++ b/apps/web/src/lib/server/workspace-members.ts
@@ -34,7 +34,7 @@ import { webMemberBinding } from './member-binding'
 export type WorkspaceMembersPayload = {
   readonly viewer: { readonly role: WorkspaceRole } | null
   readonly unreadCount: number
-  readonly members: readonly Member[]
+  readonly members: ReadonlyArray<Member>
 }
 
 /**

--- a/apps/web/src/lib/server/workspace-settings.ts
+++ b/apps/web/src/lib/server/workspace-settings.ts
@@ -35,7 +35,7 @@ export type WorkspaceSettingsPayload = {
   readonly unreadCount: number
   readonly apiTokenCount: number | null
   readonly webhookCount: number | null
-  readonly invitations: readonly Invitation[] | null
+  readonly invitations: ReadonlyArray<Invitation> | null
 }
 
 /**

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { Schema } from 'effect'
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: Array<ClassValue>) {
   return twMerge(clsx(inputs))
 }
 

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -18,11 +18,13 @@ import { requireAdmin } from '@/lib/server/auth'
 // Column definitions are static — module scope keeps the cell renderers out of
 // the render body (they would remount every render) and drops a useMemo.
 function renderStatus(banned: boolean) {
-  if (banned) return <Badge variant="destructive">banned</Badge>
+  if (banned) {
+    return <Badge variant="destructive">banned</Badge>
+  }
   return <Badge variant="outline">active</Badge>
 }
 
-const userColumns: DataTableColumnDef<SystemUser>[] = [
+const userColumns: Array<DataTableColumnDef<SystemUser>> = [
   {
     accessorKey: 'name',
     header: 'Name',
@@ -49,7 +51,7 @@ const userColumns: DataTableColumnDef<SystemUser>[] = [
   }
 ]
 
-const auditColumns: DataTableColumnDef<AuditEvent>[] = [
+const auditColumns: Array<DataTableColumnDef<AuditEvent>> = [
   { accessorKey: 'eventType', header: 'Event', enableSorting: true },
   { accessorKey: 'targetType', header: 'Target', enableSorting: true },
   { accessorKey: 'actor', header: 'Actor', enableSorting: true },

--- a/apps/web/src/routes/api.auth.$.ts
+++ b/apps/web/src/routes/api.auth.$.ts
@@ -61,7 +61,9 @@ async function readAuthAuditContext(
       )
     )
     .catch(() => null)
-  if (!session) return undefined
+  if (!session) {
+    return undefined
+  }
   return {
     actorUserId: session.user.id,
     actorEmail: session.user.email,

--- a/apps/web/src/routes/blog.$slug.tsx
+++ b/apps/web/src/routes/blog.$slug.tsx
@@ -9,7 +9,9 @@ import { getPostBySlug } from '@/lib/blog'
 export const Route = createFileRoute('/blog/$slug')({
   loader: ({ params }) => {
     const post = getPostBySlug(params.slug)
-    if (!post) throw notFound()
+    if (!post) {
+      throw notFound()
+    }
     const jsonLdString = JSON.stringify({
       '@context': 'https://schema.org',
       '@graph': [
@@ -37,7 +39,9 @@ export const Route = createFileRoute('/blog/$slug')({
   component: BlogPostPage,
   head: ({ params }) => {
     const post = getPostBySlug(params.slug)
-    if (!post) return {}
+    if (!post) {
+      return {}
+    }
 
     const { title, description, date, tags, author } = post.frontmatter
     const fullTitle = `${title} | B2B SaaS Starter`

--- a/apps/web/src/routes/docs.$category.$slug.tsx
+++ b/apps/web/src/routes/docs.$category.$slug.tsx
@@ -13,7 +13,9 @@ import {
 export const Route = createFileRoute('/docs/$category/$slug')({
   loader: ({ params }) => {
     const article = getDocBySlug(params.category, params.slug)
-    if (!article) throw notFound()
+    if (!article) {
+      throw notFound()
+    }
     const { prev, next } = getAdjacentDocs(params.category, params.slug)
     const categoryName = isDocCategory(params.category)
       ? DOC_CATEGORIES[params.category]
@@ -52,7 +54,9 @@ export const Route = createFileRoute('/docs/$category/$slug')({
   component: DocArticlePage,
   head: ({ params }) => {
     const article = getDocBySlug(params.category, params.slug)
-    if (!article) return {}
+    if (!article) {
+      return {}
+    }
 
     const { title, description, tags } = article.frontmatter
     const fullTitle = `${title} | Documentation | B2B SaaS Starter`

--- a/apps/web/src/routes/docs.index.tsx
+++ b/apps/web/src/routes/docs.index.tsx
@@ -36,7 +36,9 @@ function DocsIndex() {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {DOC_CATEGORY_ORDER.map((slug) => {
           const articles = getDocsByCategory(slug)
-          if (articles.length === 0) return null
+          if (articles.length === 0) {
+            return null
+          }
           return (
             <div
               key={slug}

--- a/apps/web/src/routes/docs.tsx
+++ b/apps/web/src/routes/docs.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/docs')({
 
 function DocsLayout() {
   const matches = useMatches()
-  const currentPath = matches[matches.length - 1]?.fullPath ?? ''
+  const currentPath = matches.at(-1)?.fullPath ?? ''
 
   return (
     <PublicLayout>
@@ -17,7 +17,9 @@ function DocsLayout() {
           <nav aria-label="Documentation" className="sticky top-20 flex flex-col gap-5">
             {DOC_CATEGORY_ORDER.map((slug) => {
               const articles = getDocsByCategory(slug)
-              if (articles.length === 0) return null
+              if (articles.length === 0) {
+                return null
+              }
               return (
                 <div key={slug}>
                   {/* Group label, not a heading: the page's first heading is the

--- a/apps/web/src/routes/invitations.accept.tsx
+++ b/apps/web/src/routes/invitations.accept.tsx
@@ -49,7 +49,9 @@ export const Route = createFileRoute('/invitations/accept')({
   // `async` so the no-id branch returns a resolved promise without reaching for
   // a Promise constructor; the loader contract is promise-returning either way.
   loader: async ({ deps }) => {
-    if (deps.invitation === undefined) return UNUSABLE
+    if (deps.invitation === undefined) {
+      return UNUSABLE
+    }
     return invitationPreviewServerFn({ data: { invitationId: deps.invitation } })
   },
   pendingComponent: RoutePending,
@@ -88,7 +90,9 @@ export function AcceptInvitationPage({
   readonly accept: AcceptInvitation
 }) {
   // One opaque outcome for every unusable invitation — see `InvitationPreview`.
-  if (preview.state === 'unavailable') return <UnusableInvitation />
+  if (preview.state === 'unavailable') {
+    return <UnusableInvitation />
+  }
   // Split rather than branching inside one component: the accept handler is a
   // closure, and a closure defined after an early return does not inherit the
   // narrowing that return produced.

--- a/apps/web/src/routes/pricing.tsx
+++ b/apps/web/src/routes/pricing.tsx
@@ -30,7 +30,7 @@ type Plan = {
   readonly featured?: boolean
 }
 
-const plans: readonly Plan[] = [
+const plans: ReadonlyArray<Plan> = [
   {
     name: 'Starter',
     price: '$0',

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -149,7 +149,9 @@ export function ResetPasswordPage({
         name="confirm"
         validators={{
           onChange: ({ value, fieldApi }) => {
-            if (value.length === 0) return 'Confirm your password'
+            if (value.length === 0) {
+              return 'Confirm your password'
+            }
             if (value !== fieldApi.form.getFieldValue('password')) {
               return 'Passwords do not match'
             }

--- a/apps/web/src/routes/workspaces.$workspaceSlug.audit.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.audit.tsx
@@ -33,10 +33,18 @@ const decodeSearch = Schema.decodeUnknownSync(AuditSearch)
 
 function filtersFromSearch(search: AuditSearch): WorkspaceAuditFilters {
   const filters: WorkspaceAuditFilters = {}
-  if (search.actor !== undefined) filters.actorUserId = search.actor
-  if (search.eventType !== undefined) filters.eventType = search.eventType
-  if (search.since !== undefined) filters.since = search.since
-  if (search.until !== undefined) filters.until = search.until
+  if (search.actor !== undefined) {
+    filters.actorUserId = search.actor
+  }
+  if (search.eventType !== undefined) {
+    filters.eventType = search.eventType
+  }
+  if (search.since !== undefined) {
+    filters.since = search.since
+  }
+  if (search.until !== undefined) {
+    filters.until = search.until
+  }
   return filters
 }
 
@@ -49,7 +57,9 @@ export const Route = createFileRoute('/workspaces/$workspaceSlug/audit')({
       userId: context.session.user.id,
       filters: filtersFromSearch(deps.search)
     }
-    if (deps.search.cursor !== undefined) input.cursor = deps.search.cursor
+    if (deps.search.cursor !== undefined) {
+      input.cursor = deps.search.cursor
+    }
     return loadWorkspaceAuditEvents(input)
   },
   pendingComponent: RoutePending,

--- a/apps/web/src/test/router-harness.tsx
+++ b/apps/web/src/test/router-harness.tsx
@@ -29,7 +29,7 @@ export async function renderWithRouter(
   ui: ReactNode,
   options?: {
     readonly path?: string
-    readonly destinations?: readonly string[]
+    readonly destinations?: ReadonlyArray<string>
     readonly initialEntry?: string
   }
 ): Promise<RenderResult & { readonly router: AnyRouter }> {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -25,10 +25,14 @@ function remarkMermaid() {
     }
     function visit(node: Record<string, unknown>) {
       const children = childrenOf(node)
-      if (!children) return
+      if (!children) {
+        return
+      }
       for (let i = 0; i < children.length; i++) {
         const child = children[i]
-        if (!child) continue
+        if (!child) {
+          continue
+        }
         if (child.type === 'code' && child.lang === 'mermaid') {
           children[i] = {
             type: 'mdxJsxFlowElement',

--- a/infra/bindings.test.ts
+++ b/infra/bindings.test.ts
@@ -3,8 +3,7 @@
 // platform APIs available to it. Pulling in `@effect/platform` FileSystem/Path
 // would mean an Effect runtime per test for three synchronous file reads.
 import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   apiRateLimits,
@@ -22,7 +21,7 @@ import {
 // suite parses each wrangler config and fails red on any drift — the same
 // pattern as apps/api/src/contract-sync.test.ts for HTTP contracts.
 
-const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const repoRoot = join(import.meta.dirname, '..')
 
 // Minimal JSONC → JSON: strips // and /* */ comments outside of strings.
 // (No jsonc parser ships in the repo's dependency set.)
@@ -103,10 +102,10 @@ type WranglerQueueProducer = {
 // Only the slice of wrangler.jsonc this suite asserts on. Declaring it as the
 // parse result keeps every reader below cast-free.
 type WranglerConfig = {
-  readonly unsafe?: { readonly bindings?: readonly WranglerRateLimitBinding[] }
+  readonly unsafe?: { readonly bindings?: ReadonlyArray<WranglerRateLimitBinding> }
   readonly queues?: {
-    readonly consumers?: readonly WranglerQueueConsumer[]
-    readonly producers?: readonly WranglerQueueProducer[]
+    readonly consumers?: ReadonlyArray<WranglerQueueConsumer>
+    readonly producers?: ReadonlyArray<WranglerQueueProducer>
   }
 }
 
@@ -115,15 +114,15 @@ function readWranglerConfig(app: string): WranglerConfig {
   return JSON.parse(stripJsonComments(raw))
 }
 
-function rateLimitBindings(config: WranglerConfig): WranglerRateLimitBinding[] {
+function rateLimitBindings(config: WranglerConfig): Array<WranglerRateLimitBinding> {
   return [...(config.unsafe?.bindings ?? [])].filter(
     (binding) => binding.type === 'ratelimit'
   )
 }
 
 function expectRateLimitSync(
-  wrangler: readonly WranglerRateLimitBinding[],
-  specs: readonly RateLimitBindingSpec[]
+  wrangler: ReadonlyArray<WranglerRateLimitBinding>,
+  specs: ReadonlyArray<RateLimitBindingSpec>
 ) {
   expect(wrangler.map((binding) => binding.name)).toEqual(
     specs.map((spec) => spec.name)
@@ -150,7 +149,9 @@ function expectConsumerSync(
   deadLetterQueue?: string
 ) {
   expect(consumer, `no wrangler consumer declared for queue ${queue}`).toBeDefined()
-  if (!consumer) return
+  if (!consumer) {
+    return
+  }
   expect(consumer.max_batch_size).toBe(settings.batchSize)
   // wrangler declares the batch timeout in seconds; alchemy in milliseconds.
   expect(consumer.max_batch_timeout * 1000).toBe(settings.maxWaitTimeMs)

--- a/infra/bindings.ts
+++ b/infra/bindings.ts
@@ -12,14 +12,14 @@ export type RateLimitBindingSpec = {
   readonly period: 10 | 60
 }
 
-export const apiRateLimits: readonly RateLimitBindingSpec[] = [
+export const apiRateLimits: ReadonlyArray<RateLimitBindingSpec> = [
   { name: 'RATE_LIMITER_REST', namespaceId: '1001', limit: 60, period: 60 },
   { name: 'RATE_LIMITER_REST_WRITE', namespaceId: '1002', limit: 20, period: 60 },
   { name: 'RATE_LIMITER_ASSISTANT', namespaceId: '1004', limit: 20, period: 60 },
   { name: 'RATE_LIMITER_MCP', namespaceId: '1005', limit: 30, period: 60 }
 ]
 
-export const webRateLimits: readonly RateLimitBindingSpec[] = [
+export const webRateLimits: ReadonlyArray<RateLimitBindingSpec> = [
   { name: 'RATE_LIMITER_AUTH_READ', namespaceId: '2001', limit: 60, period: 60 },
   { name: 'RATE_LIMITER_AUTH_WRITE', namespaceId: '2002', limit: 20, period: 60 },
   // Credential sign-in only — tighter than the generic write bucket so a

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -226,8 +226,12 @@ export function selectAssistantLayer(env: ProviderEnv): Layer.Layer<AssistantSer
     // Assigned only when set so the layer's own defaults (api.openai.com,
     // gpt-4o-mini) still apply for absent vars.
     const config: Writable<OpenAIConfig> = { apiKey: env.OPENAI_API_KEY }
-    if (env.OPENAI_BASE_URL) config.baseUrl = env.OPENAI_BASE_URL
-    if (env.OPENAI_MODEL_ID) config.modelId = env.OPENAI_MODEL_ID
+    if (env.OPENAI_BASE_URL) {
+      config.baseUrl = env.OPENAI_BASE_URL
+    }
+    if (env.OPENAI_MODEL_ID) {
+      config.modelId = env.OPENAI_MODEL_ID
+    }
     return makeOpenAILayer(config)
   }
   return MockAssistantLayer

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -39,7 +39,7 @@ export type AuthConfigInterface = {
   readonly db: DrizzleDatabase
   readonly secret: string
   readonly baseURL: string
-  readonly trustedOrigins: readonly string[]
+  readonly trustedOrigins: ReadonlyArray<string>
   readonly emails: AuthEmailSender
   /**
    * Better Auth's `requireEmailVerification`, decided by the app from

--- a/packages/auth/src/live-auth.test.ts
+++ b/packages/auth/src/live-auth.test.ts
@@ -22,11 +22,11 @@ let authLayer: Layer.Layer<AuthService>
 
 // The lifecycle-email port, capturing what Better Auth hands it instead of
 // sending: these tests assert on the URLs and the calls, not on delivery.
-const sentEmails: {
+const sentEmails: Array<{
   readonly kind: 'reset' | 'verification'
   readonly email: string
   readonly url: string
-}[] = []
+}> = []
 
 const capturingEmailSender: AuthEmailSender = {
   sendPasswordReset: ({ email, url }) => {
@@ -281,10 +281,12 @@ describe('two-factor plugin', () => {
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
     let buffer = 0
     let bits = 0
-    const bytes: number[] = []
+    const bytes: Array<number> = []
     for (const char of encoded) {
       const value = alphabet.indexOf(char)
-      if (value === -1) throw new Error(`bad base32 char: ${char}`)
+      if (value === -1) {
+        throw new Error(`bad base32 char: ${char}`)
+      }
       buffer = (buffer << 5) | value
       bits += 5
       if (bits >= 8) {

--- a/packages/authz/src/guard.ts
+++ b/packages/authz/src/guard.ts
@@ -20,14 +20,16 @@ import {
  * `tokenPrincipal`.
  */
 
-function actionsOf(requested: RequestedActions): readonly string[] {
-  if ('actions' in requested) return requested.actions
+function actionsOf(requested: RequestedActions): ReadonlyArray<string> {
+  if ('actions' in requested) {
+    return requested.actions
+  }
   return requested
 }
 
 /** `apiToken:list+create webhook:create` — one field on the wide event. */
 function describe(request: PermissionRequest): string {
-  const parts: string[] = []
+  const parts: Array<string> = []
   for (const [resource, requested] of Object.entries(request)) {
     parts.push(`${resource}:${actionsOf(requested).join('+')}`)
   }
@@ -55,7 +57,9 @@ export function requirePermission(
     }
 
     const decision = authorize(principal, request)
-    if (decision.success) return
+    if (decision.success) {
+      return
+    }
 
     yield* Effect.annotateLogsScoped({
       outcome: 'forbidden',

--- a/packages/authz/src/index.test.ts
+++ b/packages/authz/src/index.test.ts
@@ -43,7 +43,7 @@ const PERMISSIONS = [
   { label: 'notification:read', request: { notification: ['read'] } },
   { label: 'assistant:read', request: { assistant: ['read'] } },
   { label: 'mcp:read', request: { mcp: ['read'] } }
-] satisfies readonly Permission[]
+] satisfies ReadonlyArray<Permission>
 
 const EVERY_LABEL = PERMISSIONS.map((permission) => permission.label)
 
@@ -58,11 +58,11 @@ const READ_ONLY = [
   'mcp:read'
 ]
 
-const GRANTS: readonly {
+const GRANTS: ReadonlyArray<{
   readonly name: string
   readonly principal: Principal
-  readonly granted: readonly string[]
-}[] = [
+  readonly granted: ReadonlyArray<string>
+}> = [
   { name: 'owner role', principal: memberPrincipal('owner'), granted: EVERY_LABEL },
   {
     name: 'admin role',

--- a/packages/authz/src/principal.ts
+++ b/packages/authz/src/principal.ts
@@ -26,8 +26,8 @@ export type PermissionRequest = RoleAuthorizeRequest<StarterStatements>
  * named union is what keeps the guard's request handling off duck-typing.
  */
 export type RequestedActions =
-  | readonly string[]
-  | { readonly actions: readonly string[] }
+  | ReadonlyArray<string>
+  | { readonly actions: ReadonlyArray<string> }
 
 /**
  * The actor's authorization identity, independent of how it authenticated. A
@@ -35,13 +35,13 @@ export type RequestedActions =
  */
 export type Principal =
   | { readonly kind: 'member'; readonly role: WorkspaceRole }
-  | { readonly kind: 'token'; readonly scopes: readonly ApiTokenScope[] }
+  | { readonly kind: 'token'; readonly scopes: ReadonlyArray<ApiTokenScope> }
 
 export function memberPrincipal(role: WorkspaceRole): Principal {
   return { kind: 'member', role }
 }
 
-export function tokenPrincipal(scopes: readonly ApiTokenScope[]): Principal {
+export function tokenPrincipal(scopes: ReadonlyArray<ApiTokenScope>): Principal {
   return { kind: 'token', scopes }
 }
 
@@ -61,7 +61,9 @@ export function authorize(
   let denial = 'no token scope grants this permission'
   for (const scope of principal.scopes) {
     const response = apiTokenScopeAccess[scope].authorize(request)
-    if (response.success) return response
+    if (response.success) {
+      return response
+    }
     denial = response.error
   }
   return { success: false, error: denial }

--- a/packages/capabilities/src/billing/billing.ts
+++ b/packages/capabilities/src/billing/billing.ts
@@ -46,7 +46,7 @@ export const STARTER_PLAN: Plan = {
   limits: { apiTokens: 2, webhookEndpoints: 1 }
 }
 
-export const PLANS: readonly Plan[] = [
+export const PLANS: ReadonlyArray<Plan> = [
   STARTER_PLAN,
   {
     id: 'team',
@@ -72,7 +72,9 @@ export function planById(planId: string): Plan {
 /** The audit metadata for a plan change: the plan plus any provider detail. */
 function planChangeMetadata(planId: string, detail?: JsonObject): JsonObject {
   const metadata: JsonObject = { planId }
-  if (detail === undefined) return metadata
+  if (detail === undefined) {
+    return metadata
+  }
   return { ...metadata, ...detail }
 }
 
@@ -80,7 +82,9 @@ function planChangeMetadata(planId: string, detail?: JsonObject): JsonObject {
 export type EntitlementResource = 'api_token' | 'webhook_endpoint'
 
 function limitFor(plan: Plan, resource: EntitlementResource): number | null {
-  if (resource === 'api_token') return plan.limits.apiTokens
+  if (resource === 'api_token') {
+    return plan.limits.apiTokens
+  }
   return plan.limits.webhookEndpoints
 }
 
@@ -229,7 +233,9 @@ export function SeedBilling(options?: {
         applyProviderEvent: (input) =>
           Effect.gen(function* () {
             const known = PLANS.some((plan) => plan.id === input.planId)
-            if (!known) return false
+            if (!known) {
+              return false
+            }
             yield* Ref.update(planOverrides, (map) => {
               const next = new Map(map)
               next.set(input.workspaceId, input.planId)
@@ -393,7 +399,9 @@ export const createStripeCheckoutSession = Effect.fnUntraced(function* (input: {
  * enterprise is sold, not self-served.
  */
 export function stripePriceEnvName(planId: string): string | null {
-  if (planId === 'team') return 'STRIPE_PRICE_ID_TEAM'
+  if (planId === 'team') {
+    return 'STRIPE_PRICE_ID_TEAM'
+  }
   return null
 }
 
@@ -492,7 +500,9 @@ export function LiveBilling(
           }),
         applyProviderEvent: (input) =>
           Effect.gen(function* () {
-            if (!PLANS.some((plan) => plan.id === input.planId)) return false
+            if (!PLANS.some((plan) => plan.id === input.planId)) {
+              return false
+            }
             // Resolve first, then write: an unknown workspace id yields `false`
             // without writing a system audit event for a row that does not
             // exist. The two statements below are not atomic with the read,
@@ -506,7 +516,9 @@ export function LiveBilling(
                 .where(eq(workspaces.id, input.workspaceId))
                 .limit(1)
             )
-            if (existing.length === 0) return false
+            if (existing.length === 0) {
+              return false
+            }
             const auditRecorded = yield* audit.prepareRecord({
               // A system event: the actor is the provider webhook, not a user.
               workspaceId: input.workspaceId,
@@ -549,22 +561,34 @@ export async function verifyStripeSignature(input: {
   readonly header: string | null
   readonly toleranceSeconds?: number | undefined
 }): Promise<boolean> {
-  if (input.header === null) return false
+  if (input.header === null) {
+    return false
+  }
   const parts = new Map<string, string>()
   for (const pair of input.header.split(',')) {
     const [key, value] = pair.split('=', 2)
-    if (key !== undefined && value !== undefined) parts.set(key.trim(), value.trim())
+    if (key !== undefined && value !== undefined) {
+      parts.set(key.trim(), value.trim())
+    }
   }
   const timestamp = parts.get('t')
   const signature = parts.get('v1')
-  if (timestamp === undefined || signature === undefined) return false
+  if (timestamp === undefined || signature === undefined) {
+    return false
+  }
   // oxlint-disable-next-line effect/noGlobals -- replay tolerance is a wall-clock comparison by definition; Clock would tie a pure verification helper to an Effect runtime
   const age = Math.abs(Math.floor(Date.now() / 1000) - Number(timestamp))
-  if (!Number.isFinite(age)) return false
-  if (age > (input.toleranceSeconds ?? 300)) return false
+  if (!Number.isFinite(age)) {
+    return false
+  }
+  if (age > (input.toleranceSeconds ?? 300)) {
+    return false
+  }
   // oxlint-disable-next-line effect/noAsyncFunction -- Web Crypto awaits; see the note on the function
   const expected = await hmacSha256Hex(input.secret, `${timestamp}.${input.payload}`)
-  if (expected.length !== signature.length) return false
+  if (expected.length !== signature.length) {
+    return false
+  }
   let diff = 0
   for (let i = 0; i < expected.length; i++) {
     diff |= expected.charCodeAt(i) ^ signature.charCodeAt(i)

--- a/packages/capabilities/src/developer-platform/api-token-registry.ts
+++ b/packages/capabilities/src/developer-platform/api-token-registry.ts
@@ -39,12 +39,12 @@ export type VerifiedApiToken = {
   readonly id: string
   readonly workspaceId: string
   readonly workspaceSlug: string
-  readonly scopes: readonly ApiTokenScope[]
+  readonly scopes: ReadonlyArray<ApiTokenScope>
 }
 
 export type CreateApiTokenInput = {
   readonly name: string
-  readonly scopes: readonly ApiTokenScope[]
+  readonly scopes: ReadonlyArray<ApiTokenScope>
   readonly actorUserId?: string
 }
 
@@ -74,7 +74,7 @@ export type RevokeApiTokenInput = {
 
 export type ApiTokenRegistryInterface = {
   readonly list: Effect.Effect<
-    readonly ApiToken[],
+    ReadonlyArray<ApiToken>,
     CapabilityUnavailable,
     WorkspaceContext
   >
@@ -132,9 +132,13 @@ export const LAST_USED_WRITE_INTERVAL_MS = 60_000
 
 /** Pure throttle decision for the `lastUsedAt` bump — exported for tests. */
 export function shouldBumpLastUsedAt(lastUsedAt: string | null, now: number): boolean {
-  if (!lastUsedAt) return true
+  if (!lastUsedAt) {
+    return true
+  }
   const parsed = Date.parse(lastUsedAt)
-  if (Number.isNaN(parsed)) return true
+  if (Number.isNaN(parsed)) {
+    return true
+  }
   return now - parsed >= LAST_USED_WRITE_INTERVAL_MS
 }
 
@@ -144,7 +148,7 @@ export function shouldBumpLastUsedAt(lastUsedAt: string | null, now: number): bo
  * is the expected case, and `Map#get` reports it as `undefined` without an
  * index signature claiming every string is a fixture token.
  */
-const SEED_TOKEN_SCOPES = new Map<string, readonly ApiTokenScope[]>([
+const SEED_TOKEN_SCOPES = new Map<string, ReadonlyArray<ApiTokenScope>>([
   [SEED_API_TOKEN, API_TOKEN_SCOPES],
   [SEED_READONLY_API_TOKEN, ['read']]
 ])
@@ -164,7 +168,7 @@ type SeedTokenEntry = {
 }
 
 export function SeedApiTokenRegistry(
-  seed: readonly ApiToken[]
+  seed: ReadonlyArray<ApiToken>
 ): Layer.Layer<ApiTokenRegistry, never, AuditEventLog | WebhookPublisher> {
   return Layer.effect(ApiTokenRegistry)(
     Effect.gen(function* () {
@@ -174,7 +178,7 @@ export function SeedApiTokenRegistry(
       // list back, revoked ones disappear from `list` and cannot be revoked
       // twice, audit events land in the shared fixture log, and the plan gate
       // can actually trip instead of being unreachable.
-      const entries: SeedTokenEntry[] = seed.map((token) => ({
+      const entries: Array<SeedTokenEntry> = seed.map((token) => ({
         token,
         workspaceId: SEED_WORKSPACE_ID,
         revokedAt: null
@@ -192,8 +196,12 @@ export function SeedApiTokenRegistry(
           return activeIn(ctx.workspace.id)
             .map((entry) => entry.token)
             .toSorted((a, b) => {
-              if (a.createdAt > b.createdAt) return -1
-              if (a.createdAt < b.createdAt) return 1
+              if (a.createdAt > b.createdAt) {
+                return -1
+              }
+              if (a.createdAt < b.createdAt) {
+                return 1
+              }
               return 0
             })
         }),
@@ -245,7 +253,9 @@ export function SeedApiTokenRegistry(
             )
             // No active token in this workspace to revoke — skip both the write
             // and the audit event instead of recording a phantom revocation.
-            if (!entry) return false
+            if (!entry) {
+              return false
+            }
             entry.revokedAt = DateTime.formatIso(yield* DateTime.now)
             yield* audit.record({
               workspaceId: ctx.workspace.id,
@@ -307,7 +317,9 @@ function activeTokenWhere(tokenId: string | undefined, workspaceId: string) {
     eq(apiTokens.workspaceId, workspaceId),
     isNull(apiTokens.revokedAt)
   ]
-  if (tokenId !== undefined) conditions.push(eq(apiTokens.id, tokenId))
+  if (tokenId !== undefined) {
+    conditions.push(eq(apiTokens.id, tokenId))
+  }
   return and(...conditions)
 }
 
@@ -436,7 +448,9 @@ export const LiveApiTokenRegistry: Layer.Layer<
                 .set({ revokedAt: DateTime.formatIso(revokedAt) })
                 .where(activeTokenWhere(input.tokenId, ctx.workspace.id))
           })
-          if (!applied) return false
+          if (!applied) {
+            return false
+          }
           yield* publishWebhookEventWith(publisher, {
             eventType: 'api_token.revoked',
             payload: { tokenId: input.tokenId }

--- a/packages/capabilities/src/developer-platform/developer-platform.contract.ts
+++ b/packages/capabilities/src/developer-platform/developer-platform.contract.ts
@@ -50,7 +50,7 @@ export type ContractExpect = <A>(
 
 export function developerPlatformContractCases(
   expect: ContractExpect
-): readonly DeveloperPlatformContractCase[] {
+): ReadonlyArray<DeveloperPlatformContractCase> {
   return [
     {
       name: 'created token lists back and disappears after revoke',
@@ -235,7 +235,7 @@ export function developerPlatformContractCases(
  */
 export function planLimitContractCases(
   expect: ContractExpect
-): readonly PlanLimitContractCase[] {
+): ReadonlyArray<PlanLimitContractCase> {
   return [
     {
       name: 'creating past the plan token cap fails PlanLimitExceeded',

--- a/packages/capabilities/src/developer-platform/webhook-delivery-plan.ts
+++ b/packages/capabilities/src/developer-platform/webhook-delivery-plan.ts
@@ -53,9 +53,15 @@ export type DeliveryDecision = 'delivered' | 'retry' | 'terminal'
  * failures except 408 (request timeout) and 429 (rate limited).
  */
 export function classifyResponseStatus(status: number): DeliveryDecision {
-  if (status >= 200 && status < 300) return 'delivered'
-  if (status === 408 || status === 429) return 'retry'
-  if (status >= 400 && status < 500) return 'terminal'
+  if (status >= 200 && status < 300) {
+    return 'delivered'
+  }
+  if (status === 408 || status === 429) {
+    return 'retry'
+  }
+  if (status >= 400 && status < 500) {
+    return 'terminal'
+  }
   return 'retry'
 }
 
@@ -63,14 +69,20 @@ export function classifyResponseStatus(status: number): DeliveryDecision {
 function deliveryStatus(
   decision: DeliveryDecision
 ): 'delivered' | 'failed_permanent' | 'failed' {
-  if (decision === 'delivered') return 'delivered'
-  if (decision === 'terminal') return 'failed_permanent'
+  if (decision === 'delivered') {
+    return 'delivered'
+  }
+  if (decision === 'terminal') {
+    return 'failed_permanent'
+  }
   return 'failed'
 }
 
 /** `0` stands for "no HTTP response at all", which is persisted as null. */
 function recordedResponseStatus(status: number): number | null {
-  if (status === 0) return null
+  if (status === 0) {
+    return null
+  }
   return status
 }
 

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.live.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.live.ts
@@ -27,7 +27,9 @@ function randomSecret(): string {
 
 /** An endpoint with no delivery attempts yet reports a full success rate. */
 function deliverySuccessRate(total: number, delivered: number): number {
-  if (total === 0) return 100
+  if (total === 0) {
+    return 100
+  }
   return Math.round((delivered / total) * 100)
 }
 
@@ -292,7 +294,9 @@ export const LiveWebhookEndpoints: Layer.Layer<
                 .where(scopedEndpointWhere(input.endpointId, ctx.workspace.id))
             }
           })
-          if (!applied) return Option.none()
+          if (!applied) {
+            return Option.none()
+          }
           return Option.some({ signingSecret })
         }),
       getDispatchTarget: (endpointId, workspaceId) =>
@@ -305,7 +309,9 @@ export const LiveWebhookEndpoints: Layer.Layer<
         ).pipe(
           Effect.map((rows) => {
             const endpoint = rows[0]
-            if (!endpoint || !endpoint.enabled) return null
+            if (!endpoint || !endpoint.enabled) {
+              return null
+            }
             return {
               id: endpoint.id,
               url: endpoint.url,
@@ -329,7 +335,7 @@ export function toEndpointProjection(endpoint: {
   readonly id: string
   readonly url: string
   readonly enabled: boolean
-  readonly events: readonly string[]
+  readonly events: ReadonlyArray<string>
 }): WebhookEndpoint {
   return {
     id: endpoint.id,

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.seed.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.seed.ts
@@ -26,7 +26,7 @@ export type SeedWebhookEndpointFixture = {
   readonly id: string
   readonly url: string
   readonly enabled: boolean
-  readonly events: readonly string[]
+  readonly events: ReadonlyArray<string>
   readonly successRate: number
   readonly signingSecret?: string
   readonly workspaceId?: string
@@ -40,7 +40,7 @@ type SeedEndpointRow = {
   readonly workspaceId: string
   readonly url: string
   enabled: boolean
-  readonly events: readonly string[]
+  readonly events: ReadonlyArray<string>
   readonly successRate: number
   signingSecret: string
 }
@@ -71,7 +71,7 @@ function toProjection(endpoint: SeedEndpointRow): WebhookEndpoint {
 }
 
 export function SeedWebhookEndpoints(
-  seedFixtures: readonly SeedWebhookEndpointFixture[]
+  seedFixtures: ReadonlyArray<SeedWebhookEndpointFixture>
 ): Layer.Layer<WebhookEndpoints, never, AuditEventLog | WebhookPublisher> {
   return Layer.effect(WebhookEndpoints)(
     Effect.gen(function* () {
@@ -81,7 +81,7 @@ export function SeedWebhookEndpoints(
       // endpoint becomes dispatchable, a recorded attempt becomes listable,
       // the plan gate can actually trip. The membership seed roster sets the
       // same precedent; contract cases run unmodified against both adapters.
-      const endpoints: SeedEndpointRow[] = seedFixtures.map((fixture) => ({
+      const endpoints: Array<SeedEndpointRow> = seedFixtures.map((fixture) => ({
         id: fixture.id,
         workspaceId: fixture.workspaceId ?? SEED_WORKSPACE_ID,
         url: fixture.url,
@@ -90,7 +90,7 @@ export function SeedWebhookEndpoints(
         successRate: fixture.successRate,
         signingSecret: fixture.signingSecret ?? 'whsec_seed_fixture'
       }))
-      const deliveries: SeedDeliveryRow[] = []
+      const deliveries: Array<SeedDeliveryRow> = []
       let deliverySeq = 0
 
       /** Next insertion sequence — the newest-first tie-break in listDeliveries. */
@@ -165,9 +165,11 @@ export function SeedWebhookEndpoints(
       return {
         list: Effect.gen(function* () {
           const ctx = yield* WorkspaceContext
-          const projections: WebhookEndpoint[] = []
+          const projections: Array<WebhookEndpoint> = []
           for (const endpoint of endpoints) {
-            if (endpoint.workspaceId !== ctx.workspace.id) continue
+            if (endpoint.workspaceId !== ctx.workspace.id) {
+              continue
+            }
             projections.push(toProjection(endpoint))
           }
           return projections
@@ -228,8 +230,12 @@ export function SeedWebhookEndpoints(
             // `lastAttemptAt` DESC, insertion recency as the tie-break —
             // mirrors Live's `orderBy(lastAttemptAt desc)` read.
             matched.sort((a, b) => {
-              if (a.lastAttemptAt > b.lastAttemptAt) return -1
-              if (a.lastAttemptAt < b.lastAttemptAt) return 1
+              if (a.lastAttemptAt > b.lastAttemptAt) {
+                return -1
+              }
+              if (a.lastAttemptAt < b.lastAttemptAt) {
+                return 1
+              }
               return b.seq - a.seq
             })
             return matched.slice(0, 20)
@@ -237,7 +243,9 @@ export function SeedWebhookEndpoints(
         disable: (input) =>
           Effect.gen(function* () {
             const endpoint = yield* inWorkspace(input.endpointId)
-            if (!endpoint || !endpoint.enabled) return false
+            if (!endpoint || !endpoint.enabled) {
+              return false
+            }
             endpoint.enabled = false
             const ctx = yield* WorkspaceContext
             yield* audit.record({
@@ -253,7 +261,9 @@ export function SeedWebhookEndpoints(
         rotateSecret: (input) =>
           Effect.gen(function* () {
             const endpoint = yield* inWorkspace(input.endpointId)
-            if (!endpoint) return Option.none()
+            if (!endpoint) {
+              return Option.none()
+            }
             endpoint.signingSecret = 'whsec_seed_rotated'
             const ctx = yield* WorkspaceContext
             yield* audit.record({
@@ -269,7 +279,9 @@ export function SeedWebhookEndpoints(
         getDispatchTarget: (endpointId, workspaceId) =>
           Effect.sync(() => {
             const endpoint = endpointFor(endpointId, workspaceId)
-            if (!endpoint || !endpoint.enabled) return null
+            if (!endpoint || !endpoint.enabled) {
+              return null
+            }
             return {
               id: endpoint.id,
               url: endpoint.url,

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.ts
@@ -31,7 +31,7 @@ export type CreatedWebhookEndpoint = {
 
 export type CreateWebhookEndpointInput = {
   readonly url: string
-  readonly events: readonly string[]
+  readonly events: ReadonlyArray<string>
   // `| undefined` on purpose: callers read `description` off an optional request
   // field, and both adapters treat an absent key and an explicit `undefined` the
   // same way. Without it every caller has to hand-build the input key by key.
@@ -55,7 +55,7 @@ export const WEBHOOK_EVENT_TYPES = [
   'api_token.created',
   'api_token.revoked',
   'webhook_endpoint.created'
-] as const satisfies readonly WebhookEventType[]
+] as const satisfies ReadonlyArray<WebhookEventType>
 
 /** Wire payload for endpoint creation, shared by the REST contract and the API worker. */
 export const CreateWebhookEndpointPayload = Schema.Struct({
@@ -77,7 +77,7 @@ export type RotateWebhookSecretInput = {
 
 export type WebhookEndpointsInterface = {
   readonly list: Effect.Effect<
-    readonly WebhookEndpoint[],
+    ReadonlyArray<WebhookEndpoint>,
     CapabilityUnavailable,
     WorkspaceContext
   >
@@ -98,7 +98,7 @@ export type WebhookEndpointsInterface = {
   readonly listDeliveries: (
     input: ListWebhookDeliveriesInput
   ) => Effect.Effect<
-    readonly WebhookDelivery[],
+    ReadonlyArray<WebhookDelivery>,
     CapabilityUnavailable,
     WorkspaceContext
   >
@@ -172,6 +172,8 @@ export function ensureValidWebhookUrl(
   url: string
 ): Effect.Effect<void, InvalidWebhookUrl> {
   const check = validateWebhookUrl(url)
-  if (check.valid) return Effect.void
+  if (check.valid) {
+    return Effect.void
+  }
   return Effect.fail(new InvalidWebhookUrl({ url, reason: check.reason }))
 }

--- a/packages/capabilities/src/developer-platform/webhook-publisher.ts
+++ b/packages/capabilities/src/developer-platform/webhook-publisher.ts
@@ -103,7 +103,9 @@ function withTraceparent(
   message: WebhookQueueMessage,
   traceparent: string | undefined
 ): WebhookQueueMessage {
-  if (traceparent === undefined) return message
+  if (traceparent === undefined) {
+    return message
+  }
   return { ...message, traceparent }
 }
 
@@ -119,7 +121,9 @@ export function LiveWebhookPublisher(
           Effect.gen(function* () {
             // Provider-light: without a queue binding the publisher no-ops
             // instead of failing the app.
-            if (!queue) return
+            if (!queue) {
+              return
+            }
             const ctx = yield* WorkspaceContext
             // Stamp the producing request's trace context onto the message so
             // the background consumer continues this trace instead of starting
@@ -142,7 +146,9 @@ export function LiveWebhookPublisher(
             const subscribed = endpoints.filter((endpoint) =>
               endpoint.events.some((event) => event === input.eventType)
             )
-            if (subscribed.length === 0) return
+            if (subscribed.length === 0) {
+              return
+            }
             yield* unavailable(
               Effect.tryPromise({
                 try: () =>

--- a/packages/capabilities/src/developer-platform/webhook-url.ts
+++ b/packages/capabilities/src/developer-platform/webhook-url.ts
@@ -17,14 +17,26 @@ export type WebhookUrlValidation =
 
 const IPV4_PATTERN = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
 
-function isPrivateIpv4(octets: readonly number[]): boolean {
+function isPrivateIpv4(octets: ReadonlyArray<number>): boolean {
   const [a, b = 0] = octets
-  if (a === 0) return true // "this network" (0.0.0.0/8)
-  if (a === 10) return true // 10.0.0.0/8
-  if (a === 127) return true // loopback (127.0.0.0/8)
-  if (a === 169 && b === 254) return true // link-local (169.254.0.0/16)
-  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12
-  if (a === 192 && b === 168) return true // 192.168.0.0/16
+  if (a === 0) {
+    return true
+  } // "this network" (0.0.0.0/8)
+  if (a === 10) {
+    return true
+  } // 10.0.0.0/8
+  if (a === 127) {
+    return true
+  } // loopback (127.0.0.0/8)
+  if (a === 169 && b === 254) {
+    return true
+  } // link-local (169.254.0.0/16)
+  if (a === 172 && b >= 16 && b <= 31) {
+    return true
+  } // 172.16.0.0/12
+  if (a === 192 && b === 168) {
+    return true
+  } // 192.168.0.0/16
   return false
 }
 
@@ -33,12 +45,16 @@ const PRIVATE_RANGE_REASON =
 
 function checkIpv4Literal(hostname: string): string | null {
   const match = IPV4_PATTERN.exec(hostname)
-  if (!match) return null
+  if (!match) {
+    return null
+  }
   const octets = match.slice(1).map(Number)
   if (octets.some((octet) => octet > 255)) {
     return 'hostname is not a valid IPv4 address'
   }
-  if (isPrivateIpv4(octets)) return PRIVATE_RANGE_REASON
+  if (isPrivateIpv4(octets)) {
+    return PRIVATE_RANGE_REASON
+  }
   return null
 }
 
@@ -61,7 +77,9 @@ function checkIpv6Literal(hostname: string): string | null {
     const high = Number.parseInt(highGroup, 16)
     const low = Number.parseInt(lowGroup, 16)
     const octets = [high >> 8, high & 0xff, low >> 8, low & 0xff]
-    if (isPrivateIpv4(octets)) return PRIVATE_RANGE_REASON
+    if (isPrivateIpv4(octets)) {
+      return PRIVATE_RANGE_REASON
+    }
     return null
   }
   const firstGroup = literal.split(':', 1)[0] ?? ''
@@ -113,7 +131,9 @@ export function validateWebhookUrl(raw: string): WebhookUrlValidation {
   }
   if (hostname.startsWith('[') && hostname.endsWith(']')) {
     const reason = checkIpv6Literal(hostname)
-    if (reason) return { valid: false, reason }
+    if (reason) {
+      return { valid: false, reason }
+    }
     return { valid: true }
   }
   const ipv4Reason = checkIpv4Literal(hostname)

--- a/packages/capabilities/src/governance/audit-event-log.contract.ts
+++ b/packages/capabilities/src/governance/audit-event-log.contract.ts
@@ -41,7 +41,7 @@ export type ContractExpect = <A>(
  */
 export function auditEventContractDataset(
   workspaceId: string
-): readonly SeedAuditEventRow[] {
+): ReadonlyArray<SeedAuditEventRow> {
   return [
     {
       id: 'aud_c_old',
@@ -86,7 +86,7 @@ export function auditEventLogContractCases(
     AuditEventLog | WorkspaceContext
   >,
   expect: ContractExpect
-): readonly AuditEventLogContractCase[] {
+): ReadonlyArray<AuditEventLogContractCase> {
   return [
     {
       name: 'lists events most-recent-first with ties broken by id',

--- a/packages/capabilities/src/governance/audit-event-log.ts
+++ b/packages/capabilities/src/governance/audit-event-log.ts
@@ -37,7 +37,7 @@ export type ListAuditEventsInput = {
 }
 
 export type AuditEventPage = {
-  readonly events: readonly AuditEvent[]
+  readonly events: ReadonlyArray<AuditEvent>
   /** Cursor for the next older page, or null when this page is the last. */
   readonly nextCursor: string | null
 }
@@ -57,9 +57,13 @@ function decodeCursor(
   cursor: string
 ): { readonly createdAt: string; readonly id: string } | null {
   const decoded = Encoding.decodeBase64String(cursor)
-  if (Result.isFailure(decoded)) return null
+  if (Result.isFailure(decoded)) {
+    return null
+  }
   const [createdAt, id] = decoded.success.split(' ')
-  if (!createdAt || !id) return null
+  if (!createdAt || !id) {
+    return null
+  }
   return { createdAt, id }
 }
 
@@ -95,7 +99,7 @@ export type AuditEventLogInterface = {
   readonly list: (
     input?: ListAuditEventsInput
   ) => Effect.Effect<AuditEventPage, CapabilityUnavailable, WorkspaceContext>
-  readonly listGlobal: Effect.Effect<readonly AuditEvent[], CapabilityUnavailable>
+  readonly listGlobal: Effect.Effect<ReadonlyArray<AuditEvent>, CapabilityUnavailable>
   readonly record: (
     input: RecordAuditEventInput
   ) => Effect.Effect<void, CapabilityUnavailable>
@@ -147,7 +151,7 @@ function toSeedWire(row: SeedAuditEventRow): AuditEvent {
   }
 }
 
-function toWire(rows: readonly SeedAuditEventRow[]): readonly AuditEvent[] {
+function toWire(rows: ReadonlyArray<SeedAuditEventRow>): ReadonlyArray<AuditEvent> {
   return rows.map(toSeedWire)
 }
 
@@ -157,11 +161,11 @@ function toWire(rows: readonly SeedAuditEventRow[]): readonly AuditEvent[] {
  * off — never for an exact multiple, whose next page would be empty.
  */
 function buildPage<T>(
-  rows: readonly T[],
+  rows: ReadonlyArray<T>,
   mapToWire: (row: T) => AuditEvent
 ): AuditEventPage {
   const events = rows.slice(0, AUDIT_EVENT_PAGE_SIZE).map(mapToWire)
-  const last = events[events.length - 1]
+  const last = events.at(-1)
   let nextCursor: string | null = null
   if (last !== undefined && rows.length > AUDIT_EVENT_PAGE_SIZE) {
     nextCursor = encodeCursor(last)
@@ -174,7 +178,7 @@ function buildPage<T>(
  * one, in memory over its fixture rows.
  */
 function pagedSeedRows(
-  rows: readonly SeedAuditEventRow[],
+  rows: ReadonlyArray<SeedAuditEventRow>,
   workspaceId: string | undefined,
   input: ListAuditEventsInput | undefined
 ): AuditEventPage {
@@ -204,23 +208,31 @@ function pagedSeedRows(
     )
   }
   const ordered = matched.toSorted((a, b) => {
-    if (a.createdAt > b.createdAt) return -1
-    if (a.createdAt < b.createdAt) return 1
+    if (a.createdAt > b.createdAt) {
+      return -1
+    }
+    if (a.createdAt < b.createdAt) {
+      return 1
+    }
     // Same instant: id DESC breaks the tie.
-    if (a.id > b.id) return -1
-    if (a.id < b.id) return 1
+    if (a.id > b.id) {
+      return -1
+    }
+    if (a.id < b.id) {
+      return 1
+    }
     return 0
   })
   return buildPage(ordered, toSeedWire)
 }
 
 export function SeedAuditEventLog(
-  seed: readonly SeedAuditEventRow[]
+  seed: ReadonlyArray<SeedAuditEventRow>
 ): Layer.Layer<AuditEventLog> {
   // A private copy: `record` appends without mutating the caller's fixture
   // array. Sharing state across adapters happens by providing one instance of
   // this layer (see layers.ts), not by sharing the fixture array.
-  const rows: SeedAuditEventRow[] = [...seed]
+  const rows: Array<SeedAuditEventRow> = [...seed]
   return Layer.succeed(AuditEventLog)({
     // Same scoping as Live: the per-workspace read filters on the resolved
     // workspace from `WorkspaceContext` (invariant 1) — never an unscoped pass
@@ -261,7 +273,7 @@ export const LiveAuditEventLog: Layer.Layer<AuditEventLog, never, Database> =
       const db = yield* Database
 
       function pageQuery(workspaceId: string, input?: ListAuditEventsInput) {
-        const conditions: SQL[] = [eq(auditEvents.workspaceId, workspaceId)]
+        const conditions: Array<SQL> = [eq(auditEvents.workspaceId, workspaceId)]
         if (input?.actorUserId !== undefined) {
           conditions.push(eq(auditEvents.actorUserId, input.actorUserId))
         }
@@ -279,7 +291,9 @@ export const LiveAuditEventLog: Layer.Layer<AuditEventLog, never, Database> =
         // lexicographically, so plain string comparison is correct here.
         if (input?.cursor !== undefined) {
           const cursor = decodeCursor(input.cursor)
-          if (cursor === null) return null
+          if (cursor === null) {
+            return null
+          }
           const older = or(
             lt(auditEvents.createdAt, cursor.createdAt),
             and(
@@ -287,7 +301,9 @@ export const LiveAuditEventLog: Layer.Layer<AuditEventLog, never, Database> =
               lt(auditEvents.id, cursor.id)
             )
           )
-          if (older !== undefined) conditions.push(older)
+          if (older !== undefined) {
+            conditions.push(older)
+          }
         }
         const query = db
           .select({ event: auditEvents, actor: user })
@@ -301,19 +317,21 @@ export const LiveAuditEventLog: Layer.Layer<AuditEventLog, never, Database> =
           .limit(AUDIT_EVENT_PAGE_SIZE + 1)
       }
 
-      function toPage(rows: readonly AuditRow[]): AuditEventPage {
+      function toPage(rows: ReadonlyArray<AuditRow>): AuditEventPage {
         return buildPage(rows, toWireRow)
       }
 
       function pagedRows(workspaceId: string, input: ListAuditEventsInput | undefined) {
         const query = pageQuery(workspaceId, input)
         // An undecodable cursor addresses no position — empty page.
-        if (query === null) return Effect.succeed<AuditRow[]>([])
+        if (query === null) {
+          return Effect.succeed<Array<AuditRow>>([])
+        }
         return orUnavailable('audit-event-log')(query)
       }
 
       function queryRows(workspaceId?: string) {
-        const conditions: SQL[] = []
+        const conditions: Array<SQL> = []
         if (workspaceId !== undefined) {
           conditions.push(eq(auditEvents.workspaceId, workspaceId))
         }

--- a/packages/capabilities/src/governance/audit-event-taxonomy.ts
+++ b/packages/capabilities/src/governance/audit-event-taxonomy.ts
@@ -21,7 +21,7 @@
  * assertion (which the lint rules disallow), so the exported unions derive
  * exactly from these tuples.
  */
-function literalTuple<T extends readonly string[]>(...values: T): T {
+function literalTuple<T extends ReadonlyArray<string>>(...values: T): T {
   return values
 }
 

--- a/packages/capabilities/src/governance/audited-mutation.ts
+++ b/packages/capabilities/src/governance/audited-mutation.ts
@@ -64,7 +64,9 @@ export function auditedMutations(deps: AuditedMutationDeps) {
     input: AuditedMutationInput
   ): Effect.Effect<boolean, CapabilityUnavailable> {
     return Effect.gen(function* () {
-      if (!(yield* input.matched)) return false
+      if (!(yield* input.matched)) {
+        return false
+      }
       const auditStatement = yield* deps.prepareAuditRecord(input.auditEvent)
       yield* deps.unavailable(batch(deps.d1, [input.write(), auditStatement]))
       return true

--- a/packages/capabilities/src/governance/platform-user-admin.contract.ts
+++ b/packages/capabilities/src/governance/platform-user-admin.contract.ts
@@ -42,7 +42,7 @@ export type UserAdminContractExpect = <A>(
 export function platformUserAdminContractCases(
   ids: UserAdminContractIds,
   expect: UserAdminContractExpect
-): readonly UserAdminContractCase[] {
+): ReadonlyArray<UserAdminContractCase> {
   return [
     {
       name: 'lists every account with its system role',

--- a/packages/capabilities/src/governance/platform-user-admin.ts
+++ b/packages/capabilities/src/governance/platform-user-admin.ts
@@ -47,7 +47,10 @@ export type ChangeWorkspaceRoleInput = BanInput & {
 
 export type PlatformUserAdminInterface = {
   /** Every account, for `/admin`'s user list. Not paginated yet — neither is the plugin read it replaces. */
-  readonly listUsers: Effect.Effect<readonly SystemUserAccount[], CapabilityUnavailable>
+  readonly listUsers: Effect.Effect<
+    ReadonlyArray<SystemUserAccount>,
+    CapabilityUnavailable
+  >
   readonly banUser: (
     input: BanInput
   ) => Effect.Effect<void, CapabilityUnavailable | UserAdminRejected>
@@ -223,13 +226,13 @@ export type SeedMembership = {
 }
 
 export function SeedPlatformUserAdmin(
-  users: readonly SystemUserAccount[],
-  memberships: readonly SeedMembership[] = []
+  users: ReadonlyArray<SystemUserAccount>,
+  memberships: ReadonlyArray<SeedMembership> = []
 ): Layer.Layer<PlatformUserAdmin> {
   return Layer.effect(
     PlatformUserAdmin,
     Effect.gen(function* () {
-      const roster = yield* Ref.make<readonly SystemUserAccount[]>(users)
+      const roster = yield* Ref.make<ReadonlyArray<SystemUserAccount>>(users)
       // Roles keyed `${workspaceId}:${userId}`, seeded from `memberships`.
       const overrides = yield* Ref.make<ReadonlyMap<string, WorkspaceRole>>(
         new Map(memberships.map((m) => [`${m.workspaceId}:${m.userId}`, m.role]))
@@ -250,7 +253,9 @@ export function SeedPlatformUserAdmin(
       function setBanned(userId: string, banned: boolean) {
         return Ref.update(roster, (current) =>
           current.map((account) => {
-            if (account.id === userId) return { ...account, banned }
+            if (account.id === userId) {
+              return { ...account, banned }
+            }
             return account
           })
         )

--- a/packages/capabilities/src/governance/plugin-binding-failure.ts
+++ b/packages/capabilities/src/governance/plugin-binding-failure.ts
@@ -32,7 +32,9 @@ export type PluginBindingFailure = {
 
 /** The message to carry into the typed error, whatever was thrown. */
 function reasonOf(cause: unknown): string {
-  if (cause instanceof Error) return cause.message
+  if (cause instanceof Error) {
+    return cause.message
+  }
   return String(cause)
 }
 
@@ -83,7 +85,9 @@ export function makeBindingCaller<Binding, RejectedError>(options: {
     binding: Binding | undefined,
     call: (bound: Binding) => Promise<void>
   ) {
-    if (!binding) return Effect.fail(noBinding)
+    if (!binding) {
+      return Effect.fail(noBinding)
+    }
     return Effect.tryPromise({
       try: () => call(binding),
       catch: classifyBindingFailure

--- a/packages/capabilities/src/governance/turnstile-verification.ts
+++ b/packages/capabilities/src/governance/turnstile-verification.ts
@@ -49,7 +49,7 @@ export type TurnstileOutcome =
   | {
       readonly outcome: 'rejected'
       /** Cloudflare's own error codes (`invalid-input-response`, …), for logs. */
-      readonly codes: readonly string[]
+      readonly codes: ReadonlyArray<string>
     }
 
 export type TurnstileVerifierInterface = {
@@ -135,7 +135,9 @@ export const liveSiteverifyCaller: SiteverifyCaller = Effect.fnUntraced(function
 })
 
 function classify(response: SiteverifyResponse): TurnstileOutcome {
-  if (response.success === true) return { outcome: 'verified' }
+  if (response.success === true) {
+    return { outcome: 'verified' }
+  }
   return { outcome: 'rejected', codes: response['error-codes'] ?? [] }
 }
 
@@ -188,7 +190,9 @@ export function makeTurnstileVerifier(options: {
             )
           )
         )
-        if (Result.isFailure(attempted)) return unavailable
+        if (Result.isFailure(attempted)) {
+          return unavailable
+        }
         return classify(attempted.success)
       })
   }

--- a/packages/capabilities/src/governance/workspace-identity.ts
+++ b/packages/capabilities/src/governance/workspace-identity.ts
@@ -76,7 +76,9 @@ type MemberRow = {
 
 /** Only the stored `admin` role grants the admin system role; everything else is a user. */
 export function toSystemRole(role: string | null): SystemRole {
-  if (role === 'admin') return 'admin'
+  if (role === 'admin') {
+    return 'admin'
+  }
   return 'user'
 }
 
@@ -142,7 +144,9 @@ export function requireMemberRowId<E>(
   ).pipe(
     Effect.flatMap((rows) => {
       const row = rows[0]
-      if (!row) return Effect.fail(makeRejection())
+      if (!row) {
+        return Effect.fail(makeRejection())
+      }
       return Effect.succeed(row.id)
     })
   )

--- a/packages/capabilities/src/governance/workspace-invitations.contract.ts
+++ b/packages/capabilities/src/governance/workspace-invitations.contract.ts
@@ -77,7 +77,7 @@ export type InvitationContractCase = {
 export function workspaceInvitationsContractCases(
   ids: InvitationContractIds,
   expect: ContractExpect
-): readonly InvitationContractCase[] {
+): ReadonlyArray<InvitationContractCase> {
   return [
     {
       name: 'creates a pending invitation that then appears in list',

--- a/packages/capabilities/src/governance/workspace-invitations.ts
+++ b/packages/capabilities/src/governance/workspace-invitations.ts
@@ -81,7 +81,7 @@ export type AcceptedInvitation = typeof AcceptedInvitation.Type
 export type WorkspaceInvitationsInterface = {
   /** Every invitation of the current workspace, newest first. */
   readonly list: Effect.Effect<
-    readonly Invitation[],
+    ReadonlyArray<Invitation>,
     CapabilityUnavailable,
     WorkspaceContext
   >
@@ -210,13 +210,15 @@ function requireUnexpired(
 
 /** Moves a stored fixture invitation to a terminal status. */
 function settle(
-  store: Ref.Ref<readonly Invitation[]>,
+  store: Ref.Ref<ReadonlyArray<Invitation>>,
   invitationId: string,
   status: InvitationStatus
 ): Effect.Effect<void> {
   return Ref.update(store, (rows) =>
     rows.map((row) => {
-      if (row.id !== invitationId) return row
+      if (row.id !== invitationId) {
+        return row
+      }
       return { ...row, status }
     })
   )
@@ -227,7 +229,7 @@ function settle(
  * act on, so the shared contract holds on both sides.
  */
 function requirePending(
-  store: Ref.Ref<readonly Invitation[]>,
+  store: Ref.Ref<ReadonlyArray<Invitation>>,
   invitationId: string
 ): Effect.Effect<Invitation, MembershipChangeRejected> {
   return Ref.get(store).pipe(
@@ -256,11 +258,11 @@ export function SeedWorkspaceInvitations(options: {
   readonly roster: SeedRoster
   /** The fixture workspace every seed invitation belongs to. */
   readonly workspace: Workspace
-  readonly seed?: readonly Invitation[]
+  readonly seed?: ReadonlyArray<Invitation>
 }): Layer.Layer<WorkspaceInvitations> {
   return Layer.effect(WorkspaceInvitations)(
     Effect.gen(function* () {
-      const store = yield* Ref.make<readonly Invitation[]>(options.seed ?? [])
+      const store = yield* Ref.make<ReadonlyArray<Invitation>>(options.seed ?? [])
 
       return {
         list: Ref.get(store),
@@ -268,7 +270,9 @@ export function SeedWorkspaceInvitations(options: {
           Ref.get(store).pipe(
             Effect.map((rows) => {
               const found = rows.find((row) => row.id === invitationId)
-              if (!found) return Option.none()
+              if (!found) {
+                return Option.none()
+              }
               return Option.some({
                 ...found,
                 workspaceSlug: options.workspace.slug,

--- a/packages/capabilities/src/governance/workspace-lifecycle.contract.ts
+++ b/packages/capabilities/src/governance/workspace-lifecycle.contract.ts
@@ -41,7 +41,7 @@ export type ContractExpect = <A>(
 export function workspaceLifecycleContractCases(
   ids: LifecycleContractIds,
   expect: ContractExpect
-): readonly LifecycleContractCase[] {
+): ReadonlyArray<LifecycleContractCase> {
   return [
     {
       name: 'creates a workspace and reads it back by its slug',

--- a/packages/capabilities/src/governance/workspace-lifecycle.ts
+++ b/packages/capabilities/src/governance/workspace-lifecycle.ts
@@ -106,11 +106,11 @@ export function SeedWorkspaceLifecycle(options: {
 }): Layer.Layer<WorkspaceLifecycle> {
   return Layer.effect(WorkspaceLifecycle)(
     Effect.gen(function* () {
-      const created = yield* Ref.make<readonly CreatedWorkspace[]>([])
+      const created = yield* Ref.make<ReadonlyArray<CreatedWorkspace>>([])
 
       const requireAvailableSlug = Effect.fnUntraced(function* (
         slug: string,
-        taken: readonly string[]
+        taken: ReadonlyArray<string>
       ) {
         if (taken.includes(slug)) {
           return yield* Effect.fail(
@@ -150,7 +150,7 @@ export function SeedWorkspaceLifecycle(options: {
             const ctx = yield* WorkspaceContext
             const renamed: Workspace = { ...ctx.workspace, name: input.name }
             yield* Ref.update(created, (rows) => {
-              const next: CreatedWorkspace[] = []
+              const next: Array<CreatedWorkspace> = []
               for (const each of rows) {
                 if (each.id === ctx.workspace.id) {
                   next.push({ ...each, name: input.name })

--- a/packages/capabilities/src/governance/workspace-membership.contract.ts
+++ b/packages/capabilities/src/governance/workspace-membership.contract.ts
@@ -47,7 +47,7 @@ export type MembershipContractCase = {
 export function workspaceMembershipContractCases(
   ids: MembershipContractIds,
   expect: ContractExpect
-): readonly MembershipContractCase[] {
+): ReadonlyArray<MembershipContractCase> {
   return [
     {
       name: 'adds a member who then appears in listMembers',

--- a/packages/capabilities/src/governance/workspace-membership.ts
+++ b/packages/capabilities/src/governance/workspace-membership.ts
@@ -25,7 +25,7 @@ export type WorkspaceWithMembership = typeof WorkspaceWithMembership.Type
 
 export type WorkspaceMembershipInterface = {
   readonly listMembers: Effect.Effect<
-    readonly Member[],
+    ReadonlyArray<Member>,
     CapabilityUnavailable,
     WorkspaceContext
   >
@@ -38,7 +38,7 @@ export type WorkspaceMembershipInterface = {
    */
   readonly listWorkspacesForUser: (
     userId: string
-  ) => Effect.Effect<readonly WorkspaceWithMembership[], CapabilityUnavailable>
+  ) => Effect.Effect<ReadonlyArray<WorkspaceWithMembership>, CapabilityUnavailable>
   readonly addMember: (
     input: MemberRoleInput
   ) => Effect.Effect<
@@ -84,10 +84,12 @@ export class WorkspaceMembership extends Context.Service<
  * reads, and two independent `Ref`s would let the seed adapters disagree about
  * who is a member. Live has no such seam — the plugin owns both writes.
  */
-export type SeedRoster = Ref.Ref<readonly Member[]>
+export type SeedRoster = Ref.Ref<ReadonlyArray<Member>>
 
-export function makeSeedRoster(members: readonly Member[]): Effect.Effect<SeedRoster> {
-  return Ref.make<readonly Member[]>(members)
+export function makeSeedRoster(
+  members: ReadonlyArray<Member>
+): Effect.Effect<SeedRoster> {
+  return Ref.make<ReadonlyArray<Member>>(members)
 }
 
 /**
@@ -126,7 +128,9 @@ export function SeedWorkspaceMembership(
       Ref.get(roster).pipe(
         Effect.map((current) => {
           const member = current.find((candidate) => candidate.id === userId)
-          if (!member) return []
+          if (!member) {
+            return []
+          }
           return [{ workspace, member }]
         })
       ),
@@ -151,7 +155,9 @@ export function SeedWorkspaceMembership(
         const promoted: Member = { ...member, role: input.role }
         yield* Ref.update(roster, (current) =>
           current.map((candidate) => {
-            if (candidate.id === input.userId) return promoted
+            if (candidate.id === input.userId) {
+              return promoted
+            }
             return candidate
           })
         )

--- a/packages/capabilities/src/index.test.ts
+++ b/packages/capabilities/src/index.test.ts
@@ -275,7 +275,7 @@ describe('notification feed actor scoping', () => {
   )
 })
 
-type ExecutedQuery = { readonly sql: string; readonly params: readonly unknown[] }
+type ExecutedQuery = { readonly sql: string; readonly params: ReadonlyArray<unknown> }
 
 /** The D1 binding type `layerFromD1` accepts — derived, never re-declared. */
 type D1Binding = Parameters<typeof layerFromD1>[0]
@@ -298,14 +298,14 @@ const noRowsMeta = {
 // calls on this path (sessions, exec, dump) reject instead of pretending.
 /** Shape the fake returns for `run`/`all`: no rows, success, empty metadata. */
 type EmptyD1Result = {
-  readonly results: never[]
+  readonly results: Array<never>
   readonly success: true
   readonly meta: typeof noRowsMeta
 }
 
 function makeFakeD1() {
-  const executed: ExecutedQuery[] = []
-  const batches: ExecutedQuery[][] = []
+  const executed: Array<ExecutedQuery> = []
+  const batches: Array<Array<ExecutedQuery>> = []
   // A prepared statement is handed back to the driver as a `D1PreparedStatement`,
   // so the query it carries is remembered here rather than on the object.
   const queryOf = new WeakMap<D1Statement, ExecutedQuery>()
@@ -314,18 +314,20 @@ function makeFakeD1() {
     return { results: [], success: true, meta: noRowsMeta }
   }
   function prepare(sql: string): D1Statement {
-    function statement(params: readonly unknown[]): D1Statement {
-      function raw(options: { columnNames: true }): Promise<[string[]]>
-      function raw(options?: { columnNames?: false }): Promise<unknown[][]>
+    function statement(params: ReadonlyArray<unknown>): D1Statement {
+      function raw(options: { columnNames: true }): Promise<[Array<string>]>
+      function raw(options?: { columnNames?: false }): Promise<Array<Array<unknown>>>
       function raw(options?: {
         columnNames?: boolean
-      }): Promise<[string[]] | unknown[][]> {
+      }): Promise<[Array<string>] | Array<Array<unknown>>> {
         executed.push({ sql, params })
-        if (options?.columnNames === true) return Promise.resolve([[]])
+        if (options?.columnNames === true) {
+          return Promise.resolve([[]])
+        }
         return Promise.resolve([])
       }
       const prepared: D1Statement = {
-        bind: (...next: readonly unknown[]) => statement(next),
+        bind: (...next: ReadonlyArray<unknown>) => statement(next),
         first: () => Promise.resolve(null),
         run: () => Promise.resolve(record({ sql, params })),
         all: () => Promise.resolve(record({ sql, params })),
@@ -342,7 +344,9 @@ function makeFakeD1() {
       batches.push(
         statements.flatMap((statement) => {
           const query = queryOf.get(statement)
-          if (query === undefined) return []
+          if (query === undefined) {
+            return []
+          }
           return [query]
         })
       )

--- a/packages/capabilities/src/internal/failure-tag.ts
+++ b/packages/capabilities/src/internal/failure-tag.ts
@@ -19,10 +19,16 @@ const decodeTaggedError = Schema.decodeUnknownOption(TaggedError)
  * `workspace-invitations.contract.ts`, which assert the same way.
  */
 export function failureTag(outcome: Exit.Exit<unknown, unknown>): string | undefined {
-  if (Exit.isSuccess(outcome)) return undefined
+  if (Exit.isSuccess(outcome)) {
+    return undefined
+  }
   const error = Cause.findErrorOption(outcome.cause)
-  if (Option.isNone(error)) return undefined
+  if (Option.isNone(error)) {
+    return undefined
+  }
   const tagged = decodeTaggedError(error.value)
-  if (Option.isNone(tagged)) return undefined
+  if (Option.isNone(tagged)) {
+    return undefined
+  }
   return tagged.value._tag
 }

--- a/packages/capabilities/src/live-layers.test.ts
+++ b/packages/capabilities/src/live-layers.test.ts
@@ -460,7 +460,7 @@ layer(TestDatabase, { timeout: '120 seconds' })('live capability layers', (it) =
   // tests own is the capability's half of the contract — that it calls the
   // binding with the resolved workspace, reads the result back, and audits it.
   function fakeMemberBinding(db: EffectDatabase) {
-    const calls: unknown[] = []
+    const calls: Array<unknown> = []
     const binding: WorkspaceMemberBinding = {
       addMember: (input) => {
         calls.push(input)
@@ -745,7 +745,7 @@ layer(TestDatabase, { timeout: '120 seconds' })('live capability layers', (it) =
   let mintedInvitations = 0
 
   function fakeInvitationBinding(db: EffectDatabase) {
-    const calls: unknown[] = []
+    const calls: Array<unknown> = []
     const binding: WorkspaceInvitationBinding = {
       create: (input) => {
         calls.push(input)
@@ -792,7 +792,9 @@ layer(TestDatabase, { timeout: '120 seconds' })('live capability layers', (it) =
               .where(eq(workspaceInvitations.id, input.invitationId))
               .limit(1)
             const invitation = rows[0]
-            if (!invitation) return
+            if (!invitation) {
+              return
+            }
             yield* db
               .update(workspaceInvitations)
               .set({ status: 'accepted' })
@@ -856,7 +858,7 @@ layer(TestDatabase, { timeout: '120 seconds' })('live capability layers', (it) =
     let mintedWorkspaces = 0
 
     function fakeLifecycleBinding(db: EffectDatabase) {
-      const calls: unknown[] = []
+      const calls: Array<unknown> = []
       const binding: WorkspaceLifecycleBinding = {
         create: (input) => {
           calls.push(input)

--- a/packages/capabilities/src/notifications/notification-feed.ts
+++ b/packages/capabilities/src/notifications/notification-feed.ts
@@ -25,7 +25,7 @@ export type SeedNotification = Notification & {
 
 export type NotificationFeedInterface = {
   readonly list: Effect.Effect<
-    readonly Notification[],
+    ReadonlyArray<Notification>,
     CapabilityUnavailable,
     WorkspaceContext
   >
@@ -46,7 +46,7 @@ function visibleToActor(
 }
 
 export function SeedNotificationFeed(
-  seed: readonly SeedNotification[]
+  seed: ReadonlyArray<SeedNotification>
 ): Layer.Layer<NotificationFeed> {
   return Layer.succeed(NotificationFeed)({
     list: Effect.gen(function* () {
@@ -54,7 +54,9 @@ export function SeedNotificationFeed(
       const visible: Array<Omit<SeedNotification, 'userId'>> = []
       for (const entry of seed) {
         const { userId, ...notification } = entry
-        if (visibleToActor(userId, ctx.actor)) visible.push(notification)
+        if (visibleToActor(userId, ctx.actor)) {
+          visible.push(notification)
+        }
       }
       return visible
     }),

--- a/packages/capabilities/src/seed-fixture.ts
+++ b/packages/capabilities/src/seed-fixture.ts
@@ -44,7 +44,7 @@ export const demoMemberIdentity: Member = {
   systemRole: 'user'
 }
 
-export const seedMembers: readonly Member[] = [
+export const seedMembers: ReadonlyArray<Member> = [
   demoUserIdentity,
   {
     id: 'usr_martin',
@@ -63,7 +63,7 @@ export const seedMembers: readonly Member[] = [
   demoMemberIdentity
 ]
 
-export const seedSystemUsers: readonly SystemUserAccount[] = [
+export const seedSystemUsers: ReadonlyArray<SystemUserAccount> = [
   ...seedMembers.map((member) => ({
     id: member.id,
     name: member.name,
@@ -83,7 +83,7 @@ export const seedSystemUsers: readonly SystemUserAccount[] = [
 ]
 
 /** The (workspace, user) pairs the seed `changeWorkspaceRole` treats as real. */
-export const seedUserAdminMemberships: readonly SeedMembership[] = seedMembers.map(
+export const seedUserAdminMemberships: ReadonlyArray<SeedMembership> = seedMembers.map(
   (member) => ({
     workspaceId: seedWorkspaceRecord.id,
     userId: member.id,
@@ -91,7 +91,7 @@ export const seedUserAdminMemberships: readonly SeedMembership[] = seedMembers.m
   })
 )
 
-export const seedApiTokens: readonly ApiToken[] = [
+export const seedApiTokens: ReadonlyArray<ApiToken> = [
   {
     id: 'tok_docs',
     name: 'Docs automation',
@@ -110,7 +110,7 @@ export const seedApiTokens: readonly ApiToken[] = [
   }
 ]
 
-export const seedWebhookEndpoints: readonly WebhookEndpoint[] = [
+export const seedWebhookEndpoints: ReadonlyArray<WebhookEndpoint> = [
   {
     id: 'wh_release',
     url: 'https://example.com/webhooks/starter',
@@ -120,7 +120,7 @@ export const seedWebhookEndpoints: readonly WebhookEndpoint[] = [
   }
 ]
 
-export const seedAuditEvents: readonly SeedAuditEventRow[] = [
+export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   {
     id: 'aud_admin',
     eventType: 'system_admin.user_role_changed',
@@ -144,7 +144,7 @@ export const seedAuditEvents: readonly SeedAuditEventRow[] = [
   }
 ]
 
-export const seedNotifications: readonly Notification[] = [
+export const seedNotifications: ReadonlyArray<Notification> = [
   {
     id: 'not_email',
     title: 'Cloudflare Email needs configuration',

--- a/packages/capabilities/src/workspace-context.ts
+++ b/packages/capabilities/src/workspace-context.ts
@@ -54,7 +54,9 @@ export function liveWorkspaceContext(
       const row = yield* orUnavailable('workspace-context')(
         db.select().from(workspaces).where(eq(workspaces.slug, slug)).limit(1)
       ).pipe(Effect.map((rows) => rows[0]))
-      if (!row) return yield* Effect.fail(new WorkspaceNotFound({ slug }))
+      if (!row) {
+        return yield* Effect.fail(new WorkspaceNotFound({ slug }))
+      }
       let resolvedActor: Actor | null = null
       if (actor) {
         const member = yield* findWorkspaceMember(db, {
@@ -63,7 +65,9 @@ export function liveWorkspaceContext(
         })
         // Non-members get the same WorkspaceNotFound as unknown slugs so a
         // probing user cannot learn whether a workspace exists.
-        if (!member) return yield* Effect.fail(new WorkspaceNotFound({ slug }))
+        if (!member) {
+          return yield* Effect.fail(new WorkspaceNotFound({ slug }))
+        }
         resolvedActor = memberToActor(member)
       }
       return {
@@ -92,7 +96,7 @@ export function seedWorkspaceContext(
   seedWorkspace: Workspace,
   slug: string,
   actor?: ActorRef,
-  members: readonly Member[] = []
+  members: ReadonlyArray<Member> = []
 ): Layer.Layer<WorkspaceContext, WorkspaceNotFound> {
   return Layer.effect(WorkspaceContext)(
     Effect.suspend((): Effect.Effect<WorkspaceContextInterface, WorkspaceNotFound> => {

--- a/packages/capabilities/src/workspace-projections.ts
+++ b/packages/capabilities/src/workspace-projections.ts
@@ -20,7 +20,7 @@ import { WorkspaceContext } from './workspace-context.ts'
 
 export type WorkspaceOverviewProjection = {
   readonly workspace: Workspace
-  readonly notifications: readonly Notification[]
+  readonly notifications: ReadonlyArray<Notification>
 }
 
 /**
@@ -86,7 +86,7 @@ export type WorkspaceListItemProjection = {
 export function listWorkspacesForUser(
   userId: string
 ): Effect.Effect<
-  readonly WorkspaceListItemProjection[],
+  ReadonlyArray<WorkspaceListItemProjection>,
   CapabilityUnavailable,
   WorkspaceMembership | NotificationFeed
 > {

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -20,20 +20,26 @@ import { listMigrations } from '../src/migrations-fs.ts'
 
 const packageDir = join(import.meta.dir, '..')
 
-function resolveTarget(argv: readonly string[]): '--remote' | '--local' {
-  if (argv.includes('--remote')) return '--remote'
+function resolveTarget(argv: ReadonlyArray<string>): '--remote' | '--local' {
+  if (argv.includes('--remote')) {
+    return '--remote'
+  }
   return '--local'
 }
 
 const target = resolveTarget(process.argv)
 
-function jsonFlags(captureJson: boolean): string[] {
-  if (captureJson) return ['--json']
+function jsonFlags(captureJson: boolean): Array<string> {
+  if (captureJson) {
+    return ['--json']
+  }
   return []
 }
 
 function stdoutMode(captureJson: boolean): 'pipe' | 'inherit' {
-  if (captureJson) return 'pipe'
+  if (captureJson) {
+    return 'pipe'
+  }
   return 'inherit'
 }
 
@@ -41,11 +47,13 @@ async function readStdout(
   stdout: ReadableStream<Uint8Array> | undefined,
   captureJson: boolean
 ): Promise<string> {
-  if (!captureJson) return ''
+  if (!captureJson) {
+    return ''
+  }
   return new Response(stdout).text()
 }
 
-async function wranglerExecute(args: string[], captureJson: boolean) {
+async function wranglerExecute(args: Array<string>, captureJson: boolean) {
   const proc = Bun.spawn(
     [
       'bunx',

--- a/packages/db/src/migrations-fs.ts
+++ b/packages/db/src/migrations-fs.ts
@@ -13,13 +13,14 @@ const migrationsDir = join(import.meta.dirname, '..', 'migrations')
 
 /** Reads every committed migration, sorted by folder name (timestamp order). */
 export function listMigrations(): Array<{ name: string; sql: string }> {
-  const names = readdirSync(migrationsDir, { withFileTypes: true }).reduce<string[]>(
-    (folders, entry) => {
-      if (entry.isDirectory()) folders.push(entry.name)
-      return folders
-    },
-    []
-  )
+  const names = readdirSync(migrationsDir, { withFileTypes: true }).reduce<
+    Array<string>
+  >((folders, entry) => {
+    if (entry.isDirectory()) {
+      folders.push(entry.name)
+    }
+    return folders
+  }, [])
   return names.toSorted().map((name) => ({
     name,
     sql: readFileSync(join(migrationsDir, name, 'migration.sql'), 'utf8')

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -28,7 +28,7 @@ export type JsonValue =
   | number
   | boolean
   | null
-  | readonly JsonValue[]
+  | ReadonlyArray<JsonValue>
   | { readonly [key: string]: JsonValue }
 
 /** A JSON object payload — the shape of every `mode: 'json'` metadata column. */
@@ -294,7 +294,7 @@ export const apiTokens = sqliteTable(
     tokenPrefix: text('token_prefix').notNull(),
     tokenHash: text('token_hash').unique().notNull(),
     scopes: text('scopes', { mode: 'json' })
-      .$type<readonly ApiTokenScopeValue[]>()
+      .$type<ReadonlyArray<ApiTokenScopeValue>>()
       .notNull(),
     lastUsedAt: isoTimestamp('last_used_at'),
     revokedAt: isoTimestamp('revoked_at'),
@@ -322,7 +322,7 @@ export const webhookEndpoints = sqliteTable(
     // without a migration (see webhook-endpoints.AGENTS.md in
     // packages/capabilities). The known vocabulary lives in the capabilities
     // package as `WEBHOOK_EVENT_TYPES` for the management UI.
-    events: text('events', { mode: 'json' }).$type<readonly string[]>().notNull(),
+    events: text('events', { mode: 'json' }).$type<ReadonlyArray<string>>().notNull(),
     createdAt: isoCreatedAt()
   },
   (table) => [workspaceIdIndex('webhook_endpoints', table.workspaceId)]

--- a/packages/db/src/service.ts
+++ b/packages/db/src/service.ts
@@ -68,13 +68,15 @@ export type BatchStatement = {
  * `RawD1` service where a layer only holds the `Database` service.
  */
 function batchFailureReason(cause: unknown): string {
-  if (cause instanceof Error) return cause.message
+  if (cause instanceof Error) {
+    return cause.message
+  }
   return String(cause)
 }
 
 export function batch(
   d1: D1Binding,
-  statements: readonly BatchStatement[]
+  statements: ReadonlyArray<BatchStatement>
 ): Effect.Effect<void, DbBatchError> {
   return Effect.tryPromise({
     try: () =>

--- a/packages/db/src/testing.ts
+++ b/packages/db/src/testing.ts
@@ -25,7 +25,7 @@ export type TestD1 = {
  * Splits a drizzle-kit migration file into executable statements.
  * drizzle-kit separates statements with `--> statement-breakpoint` markers.
  */
-function splitStatements(sql: string): readonly string[] {
+function splitStatements(sql: string): ReadonlyArray<string> {
   // Assumes drizzle-kit's breakpoint marker never appears inside a SQL literal.
   return sql
     .split('--> statement-breakpoint')

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -21,7 +21,7 @@ export type EmailDeliveryResult = typeof EmailDeliveryResult.Type
 
 export type SendEmailBuilderArgs = {
   readonly from: string
-  readonly to: string | readonly string[]
+  readonly to: string | ReadonlyArray<string>
   readonly subject: string
   readonly text?: string
   readonly html?: string
@@ -62,7 +62,9 @@ export class EmailDispatcher extends Context.Service<
 >()('@b2b-saas-starter/email/EmailDispatcher') {}
 
 function causeMessage(cause: unknown): string {
-  if (cause instanceof Error) return cause.message
+  if (cause instanceof Error) {
+    return cause.message
+  }
   return String(cause)
 }
 

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -95,7 +95,9 @@ export type RawEnvSource = Partial<ServerEnv>
  * fails validation instead of silently booting on a development secret.
  */
 function localDefaultsFor(mode: 'local' | 'strict'): Partial<ServerEnv> {
-  if (mode === 'strict') return {}
+  if (mode === 'strict') {
+    return {}
+  }
   return {
     BETTER_AUTH_SECRET: 'local-dev-secret-change-me-minimum-32-chars',
     BETTER_AUTH_URL: 'http://localhost:3071'
@@ -131,7 +133,9 @@ const PLACEHOLDER_AUTH_SECRETS: ReadonlySet<string> = new Set([
 
 /** The documented placeholder URL and its obvious variants. */
 function isPlaceholderAuthUrl(value: string): boolean {
-  if (value === 'https://b2b-saas-starter.example.com') return true
+  if (value === 'https://b2b-saas-starter.example.com') {
+    return true
+  }
   // oxlint-disable-next-line effect/noTryCatch -- `new URL` throws on a malformed value and "not a URL" is the answer, not a failure to handle; there is no Effect context here to lift it into
   try {
     const { hostname } = new URL(value)
@@ -149,7 +153,7 @@ export type RequiredEnvProblem = {
 export type RequiredEnvAudit = {
   /** `local` — ENVIRONMENT unset (dev/test); `deployed` — set, not production. */
   readonly mode: 'local' | 'deployed' | 'production'
-  readonly problems: readonly RequiredEnvProblem[]
+  readonly problems: ReadonlyArray<RequiredEnvProblem>
 }
 
 /**
@@ -163,8 +167,12 @@ export function requireEmailVerification(environment: string | undefined): boole
 }
 
 function requiredEnvMode(source: RawEnvSource): RequiredEnvAudit['mode'] {
-  if (source.ENVIRONMENT === 'production') return 'production'
-  if (hasValue(source.ENVIRONMENT)) return 'deployed'
+  if (source.ENVIRONMENT === 'production') {
+    return 'production'
+  }
+  if (hasValue(source.ENVIRONMENT)) {
+    return 'deployed'
+  }
   return 'local'
 }
 
@@ -177,7 +185,9 @@ function requiredEnvMode(source: RawEnvSource): RequiredEnvAudit['mode'] {
  */
 export function auditRequiredEnv(source: RawEnvSource): RequiredEnvAudit {
   const mode = requiredEnvMode(source)
-  if (mode === 'local') return { mode, problems: [] }
+  if (mode === 'local') {
+    return { mode, problems: [] }
+  }
 
   const problems: Array<RequiredEnvProblem> = []
   const secret = source.BETTER_AUTH_SECRET

--- a/packages/logger/src/environment.ts
+++ b/packages/logger/src/environment.ts
@@ -39,18 +39,24 @@ const decodeString = Schema.decodeUnknownOption(Schema.String)
 function ownStringValue(source: object, key: string): string | undefined {
   const value: unknown = Object.getOwnPropertyDescriptor(source, key)?.value
   const decoded = decodeString(value)
-  if (Option.isNone(decoded) || decoded.value.length === 0) return undefined
+  if (Option.isNone(decoded) || decoded.value.length === 0) {
+    return undefined
+  }
   return decoded.value
 }
 
 function pickString(
   source: object | undefined,
-  ...keys: readonly string[]
+  ...keys: ReadonlyArray<string>
 ): string | undefined {
-  if (!source) return undefined
+  if (!source) {
+    return undefined
+  }
   for (const key of keys) {
     const value = ownStringValue(source, key)
-    if (value !== undefined) return value
+    if (value !== undefined) {
+      return value
+    }
   }
   return undefined
 }
@@ -70,18 +76,30 @@ export function readWideEventEnvironment(
   // Built by assignment so absent fields stay absent (no `key: undefined`),
   // which keeps the emitted wide event free of empty columns.
   const resolved: Writable<WideEventEnvironment> = {}
-  if (commit) resolved.commitHash = commit
-  if (version) resolved.serviceVersion = version
-  if (region) resolved.region = region
-  if (environment) resolved.environment = environment
+  if (commit) {
+    resolved.commitHash = commit
+  }
+  if (version) {
+    resolved.serviceVersion = version
+  }
+  if (region) {
+    resolved.region = region
+  }
+  if (environment) {
+    resolved.environment = environment
+  }
   return resolved
 }
 
 /** Cloudflare colo hint from an incoming request's `cf` object, if present. */
 export function readCfColo(request: Request): string | undefined {
-  if (!('cf' in request)) return undefined
+  if (!('cf' in request)) {
+    return undefined
+  }
   const cf = decodeCfProperties(request.cf)
-  if (Option.isNone(cf)) return undefined
+  if (Option.isNone(cf)) {
+    return undefined
+  }
   return cf.value.colo
 }
 
@@ -89,6 +107,8 @@ export function readCfColo(request: Request): string | undefined {
 export function coloHint(
   colo: string | undefined
 ): { readonly colo: string } | undefined {
-  if (colo === undefined) return undefined
+  if (colo === undefined) {
+    return undefined
+  }
   return { colo }
 }

--- a/packages/logger/src/index.test.ts
+++ b/packages/logger/src/index.test.ts
@@ -29,11 +29,11 @@ type Captured = {
 /** A logger layer plus the array it appends every structured record to. */
 type Collector = {
   readonly layer: Layer.Layer<never>
-  readonly records: Captured[]
+  readonly records: Array<Captured>
 }
 
 function collector(): Collector {
-  const records: Captured[] = []
+  const records: Array<Captured> = []
   const logger = Logger.map(Logger.formatStructured, (structured) => {
     records.push({
       level: structured.level,
@@ -46,10 +46,12 @@ function collector(): Collector {
 }
 
 /** The single canonical line a scope must have emitted. */
-function only(records: readonly Captured[]): Captured {
+function only(records: ReadonlyArray<Captured>): Captured {
   expect(records).toHaveLength(1)
   const [record] = records
-  if (!record) return { level: '', message: '', annotations: {}, cause: undefined }
+  if (!record) {
+    return { level: '', message: '', annotations: {}, cause: undefined }
+  }
   return record
 }
 

--- a/packages/logger/src/otlp.ts
+++ b/packages/logger/src/otlp.ts
@@ -14,16 +14,24 @@ export type ObservabilityEnv = {
 
 /** Parses the OTLP `key=value,key=value` header form used by the OTel spec. */
 function otlpHeaders(value: string | undefined): Record<string, string> | undefined {
-  if (!value) return undefined
+  if (!value) {
+    return undefined
+  }
   const entries = value.split(',').flatMap((entry) => {
     const separator = entry.indexOf('=')
-    if (separator <= 0) return []
+    if (separator <= 0) {
+      return []
+    }
     const key = entry.slice(0, separator).trim()
     const headerValue = entry.slice(separator + 1).trim()
-    if (key.length === 0 || headerValue.length === 0) return []
+    if (key.length === 0 || headerValue.length === 0) {
+      return []
+    }
     return [[key, headerValue]]
   })
-  if (entries.length === 0) return undefined
+  if (entries.length === 0) {
+    return undefined
+  }
   return Object.fromEntries(entries)
 }
 
@@ -75,7 +83,9 @@ export function makeOtlpLayer(
   env: ObservabilityEnv
 ): Layer.Layer<never> {
   const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT?.replace(/\/$/, '')
-  if (!endpoint) return Layer.empty
+  if (!endpoint) {
+    return Layer.empty
+  }
   return Otlp.layerJson({
     baseUrl: endpoint,
     headers: otlpHeaders(env.OTEL_EXPORTER_OTLP_HEADERS),

--- a/packages/logger/src/providers.ts
+++ b/packages/logger/src/providers.ts
@@ -59,9 +59,15 @@ export function makeSentryOptions(
     initialScope: { tags: { service } },
     tracesSampleRate: 1
   }
-  if (env.SENTRY_DSN) options.dsn = env.SENTRY_DSN
-  if (release) options.release = release
-  if (env.ENVIRONMENT) options.environment = env.ENVIRONMENT
+  if (env.SENTRY_DSN) {
+    options.dsn = env.SENTRY_DSN
+  }
+  if (release) {
+    options.release = release
+  }
+  if (env.ENVIRONMENT) {
+    options.environment = env.ENVIRONMENT
+  }
   return options
 }
 
@@ -84,7 +90,9 @@ let wiredEnv: ProviderGlueEnv | undefined
  */
 export function wireWideEventProviders(env: ProviderGlueEnv): void {
   if (wiredEnv !== undefined) {
-    if (env !== wiredEnv) wiredEnv = env
+    if (env !== wiredEnv) {
+      wiredEnv = env
+    }
     return
   }
   wiredEnv = env
@@ -99,9 +107,13 @@ async function dispatch(record: WideEventRecord): Promise<void> {
 async function captureSentryError(record: WideEventRecord): Promise<void> {
   // Interrupts are not errors, and without an initialized client there is
   // nothing to send to — both leave this sink silent.
-  if (record.status !== 'error' || record.errorKind === 'interrupt') return
+  if (record.status !== 'error' || record.errorKind === 'interrupt') {
+    return
+  }
   const Sentry = await import('@sentry/cloudflare')
-  if (Sentry.getClient() === undefined) return
+  if (Sentry.getClient() === undefined) {
+    return
+  }
 
   // The raw failure value keeps its stack when it is an Error; Sentry
   // serializes anything else. Interrupt-only scopes never reach this point.
@@ -129,7 +141,9 @@ async function captureSentryError(record: WideEventRecord): Promise<void> {
  */
 async function capturePostHogEvent(record: WideEventRecord): Promise<void> {
   const env = wiredEnv
-  if (env?.POSTHOG_KEY === undefined || env.POSTHOG_KEY.length === 0) return
+  if (env?.POSTHOG_KEY === undefined || env.POSTHOG_KEY.length === 0) {
+    return
+  }
   const { PostHog } = await import('posthog-node')
   let host = DEFAULT_POSTHOG_HOST
   if (env.POSTHOG_HOST !== undefined && env.POSTHOG_HOST.length > 0) {

--- a/packages/logger/src/trace.ts
+++ b/packages/logger/src/trace.ts
@@ -23,7 +23,9 @@ export function traceparentFor(span: Tracer.AnySpan): string {
 
 /** W3C trace-flags byte: bit 0 is the sampled flag, the rest are reserved. */
 function traceFlags(sampled: boolean): string {
-  if (sampled) return '01'
+  if (sampled) {
+    return '01'
+  }
   return '00'
 }
 

--- a/packages/logger/src/wide-event.ts
+++ b/packages/logger/src/wide-event.ts
@@ -32,7 +32,9 @@ const decodeTaggedFailure = Schema.decodeUnknownOption(TaggedFailure)
 
 function errorMessage(head: unknown): string {
   // oxlint-disable-next-line unicorn/no-instanceof-builtins -- vendor SDKs raise real `Error`s; a cross-realm failure here is reported as a string either way
-  if (head instanceof Error) return head.message
+  if (head instanceof Error) {
+    return head.message
+  }
   return String(head)
 }
 
@@ -53,7 +55,9 @@ function failureMetadata(head: unknown): WideEventFailure {
     error: errorMessage(head)
   }
   const tagged = decodeTaggedFailure(head)
-  if (Option.isNone(tagged)) return base
+  if (Option.isNone(tagged)) {
+    return base
+  }
   return { ...base, errorTag: tagged.value._tag }
 }
 
@@ -117,7 +121,9 @@ export function addWideEventSink(sink: WideEventSink): () => void {
   wideEventSinks.push(sink)
   return () => {
     const index = wideEventSinks.indexOf(sink)
-    if (index !== -1) wideEventSinks.splice(index, 1)
+    if (index !== -1) {
+      wideEventSinks.splice(index, 1)
+    }
   }
 }
 
@@ -264,10 +270,16 @@ function emitWideEvent(
       }
       if (outcome.status === 'error') {
         record.errorKind = outcome.errorKind
-        if (outcome.errorTag !== undefined) record.errorTag = outcome.errorTag
-        if (Exit.isFailure(exit)) record.error = failureValue(exit.cause)
+        if (outcome.errorTag !== undefined) {
+          record.errorTag = outcome.errorTag
+        }
+        if (Exit.isFailure(exit)) {
+          record.error = failureValue(exit.cause)
+        }
       }
-      if (options.environment) record.environment = options.environment
+      if (options.environment) {
+        record.environment = options.environment
+      }
       yield* Effect.promise(() => runWideEventSinks(record))
     }
   })

--- a/packages/oxlint-plugin/src/internal/ast.ts
+++ b/packages/oxlint-plugin/src/internal/ast.ts
@@ -36,7 +36,9 @@ export function unwrapExpression(
   while (current !== null && current !== undefined && isExpressionWrapper(current)) {
     current = current.expression
   }
-  if (current === null) return undefined
+  if (current === null) {
+    return undefined
+  }
   return current
 }
 
@@ -46,10 +48,16 @@ export function unwrapExpression(
 export function getPropertyName(
   node: ESTree.Node | null | undefined
 ): string | undefined {
-  if (node === null || node === undefined) return undefined
-  if (node.type === 'Identifier' || node.type === 'PrivateIdentifier') return node.name
+  if (node === null || node === undefined) {
+    return undefined
+  }
+  if (node.type === 'Identifier' || node.type === 'PrivateIdentifier') {
+    return node.name
+  }
   // oxlint-disable-next-line anti-slop/no-runtime-typeof -- oxc gives every literal `type: 'Literal'`, so `typeof value` is the only narrowing to a string literal that does not need an assertion
-  if (node.type === 'Literal' && typeof node.value === 'string') return node.value
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    return node.value
+  }
   return undefined
 }
 
@@ -58,10 +66,16 @@ export function getStringValue(
   node: ESTree.Node | null | undefined
 ): string | undefined {
   const expression = unwrapExpression(node)
-  if (expression === undefined) return undefined
-  if (expression.type !== 'Literal') return undefined
+  if (expression === undefined) {
+    return undefined
+  }
+  if (expression.type !== 'Literal') {
+    return undefined
+  }
   // oxlint-disable-next-line anti-slop/no-runtime-typeof -- see getPropertyName above
-  if (typeof expression.value !== 'string') return undefined
+  if (typeof expression.value !== 'string') {
+    return undefined
+  }
   return expression.value
 }
 
@@ -70,9 +84,15 @@ export function isIdentifier(
   node: ESTree.Node | null | undefined,
   name?: string
 ): boolean {
-  if (node === null || node === undefined) return false
-  if (node.type !== 'Identifier') return false
-  if (name === undefined) return true
+  if (node === null || node === undefined) {
+    return false
+  }
+  if (node.type !== 'Identifier') {
+    return false
+  }
+  if (name === undefined) {
+    return true
+  }
   return node.name === name
 }
 
@@ -89,6 +109,8 @@ export function isIdentifier(
 export function parentOf(node: ESTree.Node): ESTree.Node | undefined {
   const parent: ESTree.Node | null | undefined = node.parent
   // oxlint-disable-next-line typescript/no-unnecessary-condition -- the declared type says non-nullable and is wrong; oxlint passes null at the Program root, so removing this guard makes every upward walk throw
-  if (parent === null || parent === undefined) return undefined
+  if (parent === null || parent === undefined) {
+    return undefined
+  }
   return parent
 }

--- a/packages/oxlint-plugin/src/rules/no-deep-workspace-imports.ts
+++ b/packages/oxlint-plugin/src/rules/no-deep-workspace-imports.ts
@@ -25,7 +25,7 @@ function isDeepSourceImport(source: string): boolean {
 }
 
 /** Import sources worth reporting on, from every syntax form that carries one. */
-function deepWorkspaceSources(node: ESTree.Node): readonly string[] {
+function deepWorkspaceSources(node: ESTree.Node): ReadonlyArray<string> {
   if (
     node.type !== 'ImportDeclaration' &&
     node.type !== 'ImportExpression' &&
@@ -35,7 +35,9 @@ function deepWorkspaceSources(node: ESTree.Node): readonly string[] {
     return []
   }
   const source = getStringValue(node.source)
-  if (source === undefined || !isDeepSourceImport(source)) return []
+  if (source === undefined || !isDeepSourceImport(source)) {
+    return []
+  }
   return [source]
 }
 

--- a/packages/oxlint-plugin/src/rules/no-effect-escape-hatch.ts
+++ b/packages/oxlint-plugin/src/rules/no-effect-escape-hatch.ts
@@ -24,7 +24,9 @@ export default defineRule({
     return {
       MemberExpression(node) {
         const property = getPropertyName(node.property)
-        if (property === undefined || !ESCAPE_HATCHES.has(property)) return
+        if (property === undefined || !ESCAPE_HATCHES.has(property)) {
+          return
+        }
 
         context.report({
           node,

--- a/packages/oxlint-plugin/src/rules/no-effect-internal-tags.ts
+++ b/packages/oxlint-plugin/src/rules/no-effect-internal-tags.ts
@@ -15,7 +15,7 @@ import { getPropertyName, getStringValue, unwrapExpression } from '../internal/a
  */
 
 type TagOwner = {
-  readonly modules: readonly string[]
+  readonly modules: ReadonlyArray<string>
   readonly guard: string
 }
 
@@ -52,36 +52,50 @@ const TAG_OWNERS = new Map<string, TagOwner>([
 
 const EQUALITY_OPERATORS = new Set(['===', '!==', '==', '!='])
 
-function importedEffectModules(node: ESTree.ImportDeclaration): readonly string[] {
+function importedEffectModules(node: ESTree.ImportDeclaration): ReadonlyArray<string> {
   const source = node.source.value
 
   if (source.startsWith('effect/')) {
     const submodule = source.slice('effect/'.length)
-    if (EFFECT_MODULES.has(submodule)) return [submodule]
+    if (EFFECT_MODULES.has(submodule)) {
+      return [submodule]
+    }
     return []
   }
 
-  if (source !== 'effect') return []
+  if (source !== 'effect') {
+    return []
+  }
 
-  const modules: string[] = []
+  const modules: Array<string> = []
   for (const specifier of node.specifiers) {
-    if (specifier.type !== 'ImportSpecifier') continue
+    if (specifier.type !== 'ImportSpecifier') {
+      continue
+    }
     const name = getPropertyName(specifier.imported)
-    if (name !== undefined && EFFECT_MODULES.has(name)) modules.push(name)
+    if (name !== undefined && EFFECT_MODULES.has(name)) {
+      modules.push(name)
+    }
   }
   return modules
 }
 
 function getTagAccess(node: ESTree.Node): ESTree.MemberExpression | undefined {
   const expression = unwrapExpression(node)
-  if (expression?.type !== 'MemberExpression') return undefined
+  if (expression?.type !== 'MemberExpression') {
+    return undefined
+  }
 
   if (expression.computed) {
-    if (getStringValue(expression.property) !== '_tag') return undefined
+    if (getStringValue(expression.property) !== '_tag') {
+      return undefined
+    }
     return expression
   }
 
-  if (getPropertyName(expression.property) !== '_tag') return undefined
+  if (getPropertyName(expression.property) !== '_tag') {
+    return undefined
+  }
   return expression
 }
 
@@ -90,8 +104,12 @@ function ownerForImportedModules(
   imported: ReadonlySet<string>
 ): TagOwner | undefined {
   const owner = TAG_OWNERS.get(tag)
-  if (owner === undefined) return undefined
-  if (!owner.modules.some((moduleName) => imported.has(moduleName))) return undefined
+  if (owner === undefined) {
+    return undefined
+  }
+  if (!owner.modules.some((moduleName) => imported.has(moduleName))) {
+    return undefined
+  }
   return owner
 }
 
@@ -108,13 +126,19 @@ export default defineRule({
       tagCandidate: ESTree.Node
     ) {
       const access = getTagAccess(accessCandidate)
-      if (access === undefined) return
+      if (access === undefined) {
+        return
+      }
 
       const tag = getStringValue(tagCandidate)
-      if (tag === undefined) return
+      if (tag === undefined) {
+        return
+      }
 
       const owner = ownerForImportedModules(tag, imported)
-      if (owner === undefined) return
+      if (owner === undefined) {
+        return
+      }
 
       context.report({
         node: access,
@@ -124,11 +148,17 @@ export default defineRule({
 
     return {
       ImportDeclaration(node) {
-        for (const moduleName of importedEffectModules(node)) imported.add(moduleName)
+        for (const moduleName of importedEffectModules(node)) {
+          imported.add(moduleName)
+        }
       },
       BinaryExpression(node) {
-        if (imported.size === 0) return
-        if (!EQUALITY_OPERATORS.has(node.operator)) return
+        if (imported.size === 0) {
+          return
+        }
+        if (!EQUALITY_OPERATORS.has(node.operator)) {
+          return
+        }
 
         reportTagComparison(node.left, node.right)
         reportTagComparison(node.right, node.left)

--- a/packages/oxlint-plugin/src/rules/no-inline-schema-compile.ts
+++ b/packages/oxlint-plugin/src/rules/no-inline-schema-compile.ts
@@ -47,11 +47,17 @@ function getSchemaCompilerMethod(
   callee: ESTree.Node | null | undefined
 ): string | undefined {
   const expression = unwrapExpression(callee)
-  if (expression?.type !== 'MemberExpression') return undefined
-  if (!isIdentifier(unwrapExpression(expression.object), 'Schema')) return undefined
+  if (expression?.type !== 'MemberExpression') {
+    return undefined
+  }
+  if (!isIdentifier(unwrapExpression(expression.object), 'Schema')) {
+    return undefined
+  }
 
   const method = getPropertyName(expression.property)
-  if (method === undefined || !COMPILER_METHODS.has(method)) return undefined
+  if (method === undefined || !COMPILER_METHODS.has(method)) {
+    return undefined
+  }
   return method
 }
 
@@ -62,11 +68,15 @@ function getSchemaCompilerMethod(
  */
 function isStaticSchemaReference(node: ESTree.Node | null | undefined): boolean {
   const expression = unwrapExpression(node)
-  if (expression === undefined) return false
+  if (expression === undefined) {
+    return false
+  }
 
   if (expression.type === 'Identifier') {
     const [firstCharacter] = expression.name
-    if (firstCharacter === undefined) return false
+    if (firstCharacter === undefined) {
+      return false
+    }
     return firstCharacter.toUpperCase() === firstCharacter
   }
 
@@ -76,13 +86,21 @@ function isStaticSchemaReference(node: ESTree.Node | null | undefined): boolean 
 /** An inline `Schema.*(...)` literal, including `Schema.fromJsonString(Static)`. */
 function isNestedStaticSchemaCall(node: ESTree.Node | null | undefined): boolean {
   const expression = unwrapExpression(node)
-  if (expression?.type !== 'CallExpression') return false
+  if (expression?.type !== 'CallExpression') {
+    return false
+  }
 
   const callee = unwrapExpression(expression.callee)
-  if (callee?.type !== 'MemberExpression') return false
-  if (!isIdentifier(unwrapExpression(callee.object), 'Schema')) return false
+  if (callee?.type !== 'MemberExpression') {
+    return false
+  }
+  if (!isIdentifier(unwrapExpression(callee.object), 'Schema')) {
+    return false
+  }
 
-  if (getPropertyName(callee.property) !== 'fromJsonString') return true
+  if (getPropertyName(callee.property) !== 'fromJsonString') {
+    return true
+  }
 
   const [firstArgument] = expression.arguments
   return (
@@ -97,7 +115,9 @@ function isNestedStaticSchemaCall(node: ESTree.Node | null | undefined): boolean
  */
 function isImmediatelyInvoked(node: ESTree.CallExpression): boolean {
   const { parent } = node
-  if (parent.type !== 'CallExpression') return false
+  if (parent.type !== 'CallExpression') {
+    return false
+  }
   return unwrapExpression(parent.callee) === node
 }
 
@@ -141,15 +161,23 @@ export default defineRule({
       ArrowFunctionExpression: enterFunction,
       'ArrowFunctionExpression:exit': exitFunction,
       CallExpression(node) {
-        if (functionDepth === 0) return
+        if (functionDepth === 0) {
+          return
+        }
 
         const method = getSchemaCompilerMethod(node.callee)
-        if (method === undefined) return
-        if (!isImmediatelyInvoked(node)) return
+        if (method === undefined) {
+          return
+        }
+        if (!isImmediatelyInvoked(node)) {
+          return
+        }
 
         const [firstArgument] = node.arguments
         const inlineSchema = isNestedStaticSchemaCall(firstArgument)
-        if (!inlineSchema && !isStaticSchemaReference(firstArgument)) return
+        if (!inlineSchema && !isStaticSchemaReference(firstArgument)) {
+          return
+        }
 
         if (inlineSchema) {
           context.report({ node: node.callee, message: inlineSchemaMessage(method) })

--- a/packages/oxlint-plugin/src/rules/no-interface-merge-outside-dts.ts
+++ b/packages/oxlint-plugin/src/rules/no-interface-merge-outside-dts.ts
@@ -22,17 +22,25 @@ export default defineRule({
     }
   },
   create(context) {
-    if (context.filename.endsWith('.d.ts')) return {}
+    if (context.filename.endsWith('.d.ts')) {
+      return {}
+    }
 
     return {
       TSModuleDeclaration(node) {
         // A module declaration with no block body is `declare module 'x'` with no
         // members, or a nested `declare module a.b`, and merges nothing either way.
-        if (node.body === null) return
-        if (!('body' in node.body)) return
+        if (node.body === null) {
+          return
+        }
+        if (!('body' in node.body)) {
+          return
+        }
 
         for (const statement of node.body.body) {
-          if (statement.type !== 'TSInterfaceDeclaration') continue
+          if (statement.type !== 'TSInterfaceDeclaration') {
+            continue
+          }
           context.report({
             node: statement,
             message:

--- a/packages/oxlint-plugin/src/rules/no-mismatched-augmentation-context.ts
+++ b/packages/oxlint-plugin/src/rules/no-mismatched-augmentation-context.ts
@@ -37,7 +37,9 @@ export default defineRule({
     }
   },
   create(context) {
-    if (!context.filename.endsWith('.d.ts')) return {}
+    if (!context.filename.endsWith('.d.ts')) {
+      return {}
+    }
 
     let isModule = false
 

--- a/packages/oxlint-plugin/src/rules/no-schema-class.ts
+++ b/packages/oxlint-plugin/src/rules/no-schema-class.ts
@@ -17,7 +17,9 @@ import { getPropertyName, isIdentifier, unwrapExpression } from '../internal/ast
 
 function isSchemaClassCall(node: ESTree.Node | null | undefined): boolean {
   const expression = unwrapExpression(node)
-  if (expression?.type !== 'CallExpression') return false
+  if (expression?.type !== 'CallExpression') {
+    return false
+  }
 
   // `Schema.TaggedClass<X>()('X', fields)` nests calls, so walk down to the
   // member access the whole chain hangs off.
@@ -26,8 +28,12 @@ function isSchemaClassCall(node: ESTree.Node | null | undefined): boolean {
     callee = unwrapExpression(callee.callee)
   }
 
-  if (callee?.type !== 'MemberExpression') return false
-  if (!isIdentifier(unwrapExpression(callee.object), 'Schema')) return false
+  if (callee?.type !== 'MemberExpression') {
+    return false
+  }
+  if (!isIdentifier(unwrapExpression(callee.object), 'Schema')) {
+    return false
+  }
 
   const method = getPropertyName(callee.property)
   return method === 'Class' || method === 'TaggedClass'
@@ -36,7 +42,9 @@ function isSchemaClassCall(node: ESTree.Node | null | undefined): boolean {
 /** True for the inner calls of a curried chain, which the outer call reports for. */
 function isCalleeOfEnclosingCall(node: ESTree.CallExpression): boolean {
   const { parent } = node
-  if (parent.type !== 'CallExpression') return false
+  if (parent.type !== 'CallExpression') {
+    return false
+  }
   return unwrapExpression(parent.callee) === node
 }
 
@@ -48,8 +56,12 @@ export default defineRule({
   create(context) {
     return {
       CallExpression(node) {
-        if (isCalleeOfEnclosingCall(node)) return
-        if (!isSchemaClassCall(node)) return
+        if (isCalleeOfEnclosingCall(node)) {
+          return
+        }
+        if (!isSchemaClassCall(node)) {
+          return
+        }
 
         context.report({
           node,

--- a/packages/oxlint-plugin/src/rules/no-unknown-error-message.ts
+++ b/packages/oxlint-plugin/src/rules/no-unknown-error-message.ts
@@ -36,21 +36,31 @@ const DESTRUCTURE_MESSAGE =
 
 function identifierName(node: ESTree.Node | null | undefined): string | undefined {
   const expression = unwrapExpression(node)
-  if (expression === undefined) return undefined
-  if (expression.type !== 'Identifier') return undefined
+  if (expression === undefined) {
+    return undefined
+  }
+  if (expression.type !== 'Identifier') {
+    return undefined
+  }
   return expression.name
 }
 
 function isFailureNamed(node: ESTree.Node | null | undefined): boolean {
   const name = identifierName(node)
-  if (name === undefined) return false
+  if (name === undefined) {
+    return false
+  }
   return FAILURE_NAMES.has(name)
 }
 
 function calleeName(node: ESTree.Node | null | undefined): string | undefined {
   const expression = unwrapExpression(node)
-  if (expression === undefined) return undefined
-  if (expression.type === 'Identifier') return expression.name
+  if (expression === undefined) {
+    return undefined
+  }
+  if (expression.type === 'Identifier') {
+    return expression.name
+  }
   if (expression.type === 'MemberExpression') {
     return getPropertyName(expression.property)
   }
@@ -63,7 +73,9 @@ function calleeName(node: ESTree.Node | null | undefined): string | undefined {
  */
 function isTagHandler(node: ESTree.Node): boolean {
   const parent = parentOf(node)
-  if (parent === undefined) return false
+  if (parent === undefined) {
+    return false
+  }
 
   if (
     parent.type === 'CallExpression' &&
@@ -73,11 +85,17 @@ function isTagHandler(node: ESTree.Node): boolean {
     return true
   }
 
-  if (parent.type !== 'Property') return false
+  if (parent.type !== 'Property') {
+    return false
+  }
   const object = parentOf(parent)
-  if (object?.type !== 'ObjectExpression') return false
+  if (object?.type !== 'ObjectExpression') {
+    return false
+  }
   const call = parentOf(object)
-  if (call?.type !== 'CallExpression') return false
+  if (call?.type !== 'CallExpression') {
+    return false
+  }
   return calleeName(call.callee) === 'catchTags'
 }
 
@@ -87,16 +105,22 @@ function isTagHandler(node: ESTree.Node): boolean {
  */
 function isTagHandlerParameter(node: ESTree.Node | null | undefined): boolean {
   const name = identifierName(node)
-  if (name === undefined) return false
+  if (name === undefined) {
+    return false
+  }
 
-  if (node === null || node === undefined) return false
+  if (node === null || node === undefined) {
+    return false
+  }
   let current = parentOf(node)
   while (current !== undefined) {
     if (
       current.type === 'ArrowFunctionExpression' ||
       current.type === 'FunctionExpression'
     ) {
-      if (!isTagHandler(current)) return false
+      if (!isTagHandler(current)) {
+        return false
+      }
       return isIdentifier(current.params[0], name)
     }
     current = parentOf(current)
@@ -115,23 +139,43 @@ export default defineRule({
   create(context) {
     return {
       CallExpression(node) {
-        if (!isIdentifier(unwrapExpression(node.callee), 'String')) return
-        if (!node.arguments.some((argument) => isFailureNamed(argument))) return
+        if (!isIdentifier(unwrapExpression(node.callee), 'String')) {
+          return
+        }
+        if (!node.arguments.some((argument) => isFailureNamed(argument))) {
+          return
+        }
         context.report({ node, message: STRING_MESSAGE })
       },
       MemberExpression(node) {
-        if (getPropertyName(node.property) !== 'message') return
-        if (!isFailureNamed(node.object)) return
-        if (isTagHandlerParameter(node.object)) return
+        if (getPropertyName(node.property) !== 'message') {
+          return
+        }
+        if (!isFailureNamed(node.object)) {
+          return
+        }
+        if (isTagHandlerParameter(node.object)) {
+          return
+        }
         context.report({ node, message: MEMBER_MESSAGE })
       },
       VariableDeclarator(node) {
-        if (node.id.type !== 'ObjectPattern') return
-        if (!isFailureNamed(node.init)) return
-        if (isTagHandlerParameter(node.init)) return
+        if (node.id.type !== 'ObjectPattern') {
+          return
+        }
+        if (!isFailureNamed(node.init)) {
+          return
+        }
+        if (isTagHandlerParameter(node.init)) {
+          return
+        }
         for (const property of node.id.properties) {
-          if (property.type !== 'Property') continue
-          if (getPropertyName(property.key) !== 'message') continue
+          if (property.type !== 'Property') {
+            continue
+          }
+          if (getPropertyName(property.key) !== 'message') {
+            continue
+          }
           context.report({ node: property, message: DESTRUCTURE_MESSAGE })
         }
       }

--- a/packages/oxlint-plugin/src/rules/no-unsupported-effect-api.ts
+++ b/packages/oxlint-plugin/src/rules/no-unsupported-effect-api.ts
@@ -32,13 +32,19 @@ export default defineRule({
   create(context) {
     return {
       MemberExpression(node) {
-        if (!isIdentifier(node.object, 'Effect')) return
+        if (!isIdentifier(node.object, 'Effect')) {
+          return
+        }
 
         const property = getPropertyName(node.property)
-        if (property === undefined) return
+        if (property === undefined) {
+          return
+        }
 
         const message = REPLACEMENTS.get(property)
-        if (message === undefined) return
+        if (message === undefined) {
+          return
+        }
 
         context.report({ node, message })
       }

--- a/packages/oxlint-plugin/src/rules/prefer-effect-predicate.ts
+++ b/packages/oxlint-plugin/src/rules/prefer-effect-predicate.ts
@@ -20,8 +20,12 @@ const MESSAGE =
 const COMPARISON_OPERATORS = new Set(['!==', '!=', '===', '=='])
 
 function isNullishLiteral(node: ESTree.Node | undefined): boolean {
-  if (node === undefined) return false
-  if (node.type === 'Literal' && node.value === null) return true
+  if (node === undefined) {
+    return false
+  }
+  if (node.type === 'Literal' && node.value === null) {
+    return true
+  }
   return isIdentifier(node, 'undefined')
 }
 
@@ -30,21 +34,31 @@ function isNullishComparison(
   parameterName: string
 ): boolean {
   const expression = unwrapExpression(node)
-  if (expression?.type !== 'BinaryExpression') return false
-  if (!COMPARISON_OPERATORS.has(expression.operator)) return false
+  if (expression?.type !== 'BinaryExpression') {
+    return false
+  }
+  if (!COMPARISON_OPERATORS.has(expression.operator)) {
+    return false
+  }
 
   const left = unwrapExpression(expression.left)
   const right = unwrapExpression(expression.right)
-  if (isIdentifier(left, parameterName) && isNullishLiteral(right)) return true
+  if (isIdentifier(left, parameterName) && isNullishLiteral(right)) {
+    return true
+  }
   return isIdentifier(right, parameterName) && isNullishLiteral(left)
 }
 
 function singleParameterName(
-  params: readonly ESTree.ParamPattern[]
+  params: ReadonlyArray<ESTree.ParamPattern>
 ): string | undefined {
-  if (params.length !== 1) return undefined
+  if (params.length !== 1) {
+    return undefined
+  }
   const [parameter] = params
-  if (parameter?.type !== 'Identifier') return undefined
+  if (parameter?.type !== 'Identifier') {
+    return undefined
+  }
   return parameter.name
 }
 
@@ -57,25 +71,39 @@ function predicateResult(
   body: ESTree.Node | null | undefined
 ): ESTree.Node | undefined {
   const expression = unwrapExpression(body)
-  if (expression === undefined) return undefined
-  if (expression.type !== 'BlockStatement') return expression
-  if (expression.body.length !== 1) return undefined
+  if (expression === undefined) {
+    return undefined
+  }
+  if (expression.type !== 'BlockStatement') {
+    return expression
+  }
+  if (expression.body.length !== 1) {
+    return undefined
+  }
 
   const [statement] = expression.body
-  if (statement?.type !== 'ReturnStatement') return undefined
-  if (statement.argument === null) return undefined
+  if (statement?.type !== 'ReturnStatement') {
+    return undefined
+  }
+  if (statement.argument === null) {
+    return undefined
+  }
   return statement.argument
 }
 
 function isNullishPredicate(node: ESTree.ArrowFunctionExpression | ESTree.Function) {
   const parameterName = singleParameterName(node.params)
-  if (parameterName === undefined) return false
+  if (parameterName === undefined) {
+    return false
+  }
   return isNullishComparison(predicateResult(node.body), parameterName)
 }
 
 function isFilterCall(node: ESTree.CallExpression): boolean {
   const callee = unwrapExpression(node.callee)
-  if (callee?.type !== 'MemberExpression') return false
+  if (callee?.type !== 'MemberExpression') {
+    return false
+  }
   return getPropertyName(callee.property) === 'filter'
 }
 
@@ -91,36 +119,54 @@ export default defineRule({
 
     return {
       ImportDeclaration(node) {
-        if (node.source.value === 'effect') hasEffectImport = true
+        if (node.source.value === 'effect') {
+          hasEffectImport = true
+        }
       },
       VariableDeclarator(node) {
-        if (!hasEffectImport) return
+        if (!hasEffectImport) {
+          return
+        }
 
         const init = unwrapExpression(node.init)
-        if (init?.type !== 'ArrowFunctionExpression') return
-        if (!isNullishPredicate(init)) return
+        if (init?.type !== 'ArrowFunctionExpression') {
+          return
+        }
+        if (!isNullishPredicate(init)) {
+          return
+        }
 
         context.report({ node: init, message: MESSAGE })
       },
       FunctionDeclaration(node) {
-        if (!hasEffectImport) return
-        if (!isNullishPredicate(node)) return
+        if (!hasEffectImport) {
+          return
+        }
+        if (!isNullishPredicate(node)) {
+          return
+        }
 
         context.report({ node, message: MESSAGE })
       },
       CallExpression(node) {
-        if (!hasEffectImport || !isFilterCall(node)) return
+        if (!hasEffectImport || !isFilterCall(node)) {
+          return
+        }
 
         const [firstArgument] = node.arguments
         const predicate = unwrapExpression(firstArgument)
-        if (predicate === undefined) return
+        if (predicate === undefined) {
+          return
+        }
         if (
           predicate.type !== 'ArrowFunctionExpression' &&
           predicate.type !== 'FunctionExpression'
         ) {
           return
         }
-        if (!isNullishPredicate(predicate)) return
+        if (!isNullishPredicate(predicate)) {
+          return
+        }
 
         context.report({ node: predicate, message: MESSAGE })
       }

--- a/packages/oxlint-plugin/test/harness.ts
+++ b/packages/oxlint-plugin/test/harness.ts
@@ -52,8 +52,8 @@ type Case = {
 
 function messagesByCase(
   ruleId: string,
-  cases: readonly Case[]
-): ReadonlyMap<string, readonly string[]> {
+  cases: ReadonlyArray<Case>
+): ReadonlyMap<string, ReadonlyArray<string>> {
   const [pluginName, ruleName] = ruleId.split('/')
   const root = mkdtempSync(join(tmpdir(), 'starter-oxlint-'))
   try {
@@ -81,7 +81,9 @@ function messagesByCase(
       { cwd: root, encoding: 'utf8' }
     )
 
-    if (result.error !== undefined) throw result.error
+    if (result.error !== undefined) {
+      throw result.error
+    }
     if (result.stdout.length === 0) {
       throw new Error(
         `oxlint produced no output for ${ruleId} (exit ${String(result.status)}): ${result.stderr}`
@@ -89,13 +91,17 @@ function messagesByCase(
     }
 
     const expectedCode = `${pluginName}(${ruleName})`
-    const collected = new Map<string, string[]>()
+    const collected = new Map<string, Array<string>>()
     for (const diagnostic of decodeReport(result.stdout).diagnostics) {
-      if (diagnostic.code !== expectedCode) continue
+      if (diagnostic.code !== expectedCode) {
+        continue
+      }
       const owner = cases.find((testCase) =>
         diagnostic.filename.includes(`${testCase.directory}/`)
       )
-      if (owner === undefined) continue
+      if (owner === undefined) {
+        continue
+      }
       const existing = collected.get(owner.directory) ?? []
       existing.push(diagnostic.message)
       collected.set(owner.directory, existing)
@@ -116,14 +122,14 @@ type CaseOptions = {
  * `starter/no-interface-merge-outside-dts`.
  */
 export function createRuleHarness(ruleId: string, defaults: CaseOptions = {}) {
-  const cases: Case[] = []
-  let outcome: ReadonlyMap<string, readonly string[]> | undefined
+  const cases: Array<Case> = []
+  let outcome: ReadonlyMap<string, ReadonlyArray<string>> | undefined
 
   function register(
     name: string,
     code: string,
     options: CaseOptions,
-    check: (messages: readonly string[]) => void
+    check: (messages: ReadonlyArray<string>) => void
   ) {
     const directory = `case-${String(cases.length).padStart(3, '0')}`
     cases.push({

--- a/packages/rate-limit/src/index.test.ts
+++ b/packages/rate-limit/src/index.test.ts
@@ -38,7 +38,7 @@ describe('makeRateLimiter fallback (no Cloudflare bindings)', () => {
       Effect.gen(function* () {
         const limiter = makeRateLimiter(config())
         const key = uniqueKey()
-        const outcomes: boolean[] = []
+        const outcomes: Array<boolean> = []
         for (let i = 0; i < 21; i += 1) {
           outcomes.push(yield* limiter.take({ bucket: 'write', key }))
         }

--- a/packages/rate-limit/src/index.ts
+++ b/packages/rate-limit/src/index.ts
@@ -73,7 +73,9 @@ function takeFromFallback(
 }
 
 function bindingFailureReason(cause: unknown): string {
-  if (cause instanceof Error) return cause.message
+  if (cause instanceof Error) {
+    return cause.message
+  }
   return String(cause)
 }
 
@@ -81,7 +83,9 @@ function bindingFailureReason(cause: unknown): string {
 function fallbackReason(
   binding: CloudflareRateLimit | undefined
 ): 'binding_error' | 'missing_binding' {
-  if (binding === undefined) return 'missing_binding'
+  if (binding === undefined) {
+    return 'missing_binding'
+  }
   return 'binding_error'
 }
 
@@ -140,7 +144,9 @@ export function clientKey(request: Request): string {
   // a D1 read) so unauthenticated floods can't exhaust the database — the
   // token id is not known yet at keying time.
   const ip = request.headers.get('cf-connecting-ip')
-  if (ip) return ip
+  if (ip) {
+    return ip
+  }
   // Without a client IP (local dev) we can't bucket fairly. Use the request
   // URL so a single misconfigured caller can't share the bucket with
   // everyone else.

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -49,9 +49,13 @@ const decodeDriverNumber = Schema.decodeUnknownOption(Schema.Number)
 const decodeDriverString = Schema.decodeUnknownOption(Schema.String)
 
 function quote(value: unknown): string {
-  if (value === null) return 'NULL'
+  if (value === null) {
+    return 'NULL'
+  }
   const asNumber = decodeDriverNumber(value)
-  if (Option.isSome(asNumber)) return String(asNumber.value)
+  if (Option.isSome(asNumber)) {
+    return String(asNumber.value)
+  }
   const asString = decodeDriverString(value)
   if (Option.isNone(asString)) {
     // JSON rather than `String(value)`: an object would stringify to
@@ -72,12 +76,14 @@ function insert<T extends Table>(
   row: { readonly [K in keyof T['_']['columns']]?: unknown }
 ): string {
   const columns = getColumns(table)
-  const entries: [string, string][] = Object.entries(row).map(([key, value]) => {
+  const entries: Array<[string, string]> = Object.entries(row).map(([key, value]) => {
     const column = columns[key]
     if (column === undefined) {
       throw new Error(`seed: unknown column ${key} for table ${getTableName(table)}`)
     }
-    if (value === null || value === undefined) return [column.name, quote(null)]
+    if (value === null || value === undefined) {
+      return [column.name, quote(null)]
+    }
     return [column.name, quote(column.mapToDriverValue(value))]
   })
   return `INSERT OR REPLACE INTO ${getTableName(table)} (${entries.map(([name]) => name).join(', ')}) VALUES (${entries.map(([, value]) => value).join(', ')});`
@@ -118,7 +124,9 @@ type Fixture = Effect.Success<typeof collectFixture>
 // same credential verifies against both the in-memory Seed layer and a seeded
 // local D1 (Seed/Live equivalence).
 function seedTokenValue(token: Fixture['tokens'][number], index: number): string {
-  if (index === 0) return SEED_API_TOKEN
+  if (index === 0) {
+    return SEED_API_TOKEN
+  }
   return `${token.prefix}_token`
 }
 
@@ -134,7 +142,7 @@ function resolveHashes(fixture: Fixture) {
 
 type Hashes = Effect.Success<ReturnType<typeof resolveHashes>>
 
-function workspaceRows(fixture: Fixture): readonly string[] {
+function workspaceRows(fixture: Fixture): ReadonlyArray<string> {
   return [
     insert(workspaces, {
       id: fixture.workspace.id,
@@ -149,7 +157,7 @@ function workspaceRows(fixture: Fixture): readonly string[] {
   ]
 }
 
-function memberRows(fixture: Fixture): readonly string[] {
+function memberRows(fixture: Fixture): ReadonlyArray<string> {
   return fixture.members.flatMap((member) => [
     insert(user, {
       id: member.id,
@@ -175,7 +183,7 @@ function memberRows(fixture: Fixture): readonly string[] {
  * created its user and membership rows). It shares the demo password: the point
  * is to make the role-gated UI reachable by hand, not to model two secrets.
  */
-function demoMemberRows(demoPasswordHash: string): readonly string[] {
+function demoMemberRows(demoPasswordHash: string): ReadonlyArray<string> {
   return [
     insert(account, {
       id: 'acc_member_credential',
@@ -193,7 +201,10 @@ function demoMemberRows(demoPasswordHash: string): readonly string[] {
 
 // Demo sign-in: system admin (`role: 'admin'` — Better Auth admin plugin)
 // and a member of the seed workspace so the membership gate passes.
-function demoUserRows(fixture: Fixture, demoPasswordHash: string): readonly string[] {
+function demoUserRows(
+  fixture: Fixture,
+  demoPasswordHash: string
+): ReadonlyArray<string> {
   return [
     insert(user, {
       id: demoUserIdentity.id,
@@ -227,8 +238,8 @@ function demoUserRows(fixture: Fixture, demoPasswordHash: string): readonly stri
 
 function tokenRows(
   fixture: Fixture,
-  tokenHashes: readonly string[]
-): readonly string[] {
+  tokenHashes: ReadonlyArray<string>
+): ReadonlyArray<string> {
   return fixture.tokens.map((token, index) =>
     insert(apiTokens, {
       id: token.id,
@@ -245,7 +256,7 @@ function tokenRows(
   )
 }
 
-function webhookRows(fixture: Fixture): readonly string[] {
+function webhookRows(fixture: Fixture): ReadonlyArray<string> {
   return fixture.webhooks.map((endpoint) =>
     insert(webhookEndpoints, {
       id: endpoint.id,
@@ -260,7 +271,7 @@ function webhookRows(fixture: Fixture): readonly string[] {
   )
 }
 
-function auditRows(fixture: Fixture): readonly string[] {
+function auditRows(fixture: Fixture): ReadonlyArray<string> {
   return fixture.auditEvents.map((event) =>
     insert(auditEvents, {
       id: event.id,
@@ -276,11 +287,13 @@ function auditRows(fixture: Fixture): readonly string[] {
 }
 
 function readAt(read: boolean): string | null {
-  if (read) return now
+  if (read) {
+    return now
+  }
   return null
 }
 
-function notificationRows(fixture: Fixture): readonly string[] {
+function notificationRows(fixture: Fixture): ReadonlyArray<string> {
   return fixture.notifications.map((notification) =>
     insert(notifications, {
       id: notification.id,


### PR DESCRIPTION
## What

Enables 17 strict oxlint rules and fixes every finding they surface. No rule severities or options were weakened to clear findings, and no `oxlint-disable` comments were added (4 pre-existing `effect/noThrowStatement` directives were repositioned — see below).

## Rules enabled (`error` unless noted)

- `no-throw-literal`
- `no-unexpected-multiline` (was explicitly `"off"`)
- `no-warning-comments` — `["error", { "terms": ["@nocommit"] }]`
- `import/export`
- `react/require-render-return`
- `unicorn/prefer-array-index-of`
- `unicorn/prefer-optional-catch-binding`
- `unicorn/no-hex-escape`
- `unicorn/prefer-single-call`
- `unicorn/prefer-at`
- `unicorn/prefer-string-raw`
- `unicorn/prefer-import-meta-properties`
- `curly` — was `["error", "multi-line"]`, now plain `"error"`
- `@typescript-eslint/array-type` — `["error", { "default": "generic" }]`
- `prefer-arrow-callback` — `["error", { "allowNamedFunctions": true }]`
- `no-unused-vars` — `["error", { "argsIgnorePattern": "^_", "fix": { "imports": "safe-fix", "variables": "off" } }]`

**Skipped rules: none.** All 17 rules exist in the installed oxlint 1.80.0, so no oxlint upgrade was needed. Every entry was verified active: oxlint rejects unknown rule names at config parse time, and a violation probe confirmed each rule reports.

## Config substitutions

The requested `no-unused-vars` option `"variables": "off"` does not exist as a reporting toggle in oxlint (its `vars` option only accepts `"all"` / `"local"`). The closest supported mapping was used and is commented in `.oxlintrc.json`:

- `"variables": "off"` → `fix.variables: "off"` (unused variables are never auto-removed)
- "unused imports only fixable via safe fixes" → `fix.imports: "safe-fix"` (supported by oxlint 1.80.0)

Reporting behavior is unchanged from the previous config (still `vars: "all"`, `argsIgnorePattern: "^_"`), so nothing is weakened.

## Findings fixed: 630 across 168 source files (+ `.oxlintrc.json`)

| Rule | Findings | Fix |
| --- | --- | --- |
| `curly` | 368 | autofix (braces around brace-less bodies) |
| `array-type` | 256 | 249 autofix (`T[]` → `Array<T>`, `readonly T[]` → `ReadonlyArray<T>`); 7 nested types fixed by hand |
| `prefer-at` | 3 | by hand (`events.at(-1)` etc.) |
| `prefer-import-meta-properties` | 2 | by hand (`import.meta.dirname` replaces `dirname(fileURLToPath(import.meta.url))`, now-unused imports removed) |
| `prefer-string-raw` | 1 | by hand (`String.raw` for a literal `\n` needle) |

All remaining 11 rules reported zero findings on this repo.

Side effect worth noting: the `curly` autofix turned single-line `if (x) throw ...` bodies into multi-line blocks, which moved four existing `effect/noThrowStatement` `oxlint-disable-next-line` directives out of range (`reportUnusedDisableDirectives` is `"deny"`). Those four directives were moved back adjacent to their `throw` — repositioned, not added, and their justification comments are unchanged.

## Verification

- `bun run lint` — 0 warnings, 0 errors (type-aware, 870 rules)
- `bun run typecheck` — pass
- `bun run test` — 25/25 turbo tasks pass
- `bun run format:check` — pass
- `bun run check` (full gate incl. fallow dead-code regression check) — pass
