### PR TITLE
ci: rebuild update PRs on push to master

### DIFF
--- a/.github/workflows/catalog-update.yml
+++ b/.github/workflows/catalog-update.yml
@@ -5,7 +5,19 @@ name: Catalog Updates
 on:
   schedule:
     - cron: '0 6 * * *' # Every day at 06:00 UTC
+  push:
+    branches:
+      - master
+    paths:
+      - '**/package.json'
+      - '**/bun.lock'
   workflow_dispatch:
+
+# Rebuilds of open update PRs must run one at a time; queued (not cancelled)
+# runs are what let the cascade converge after each merge.
+concurrency:
+  group: catalog-update
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem 1: conflicting update PRs could never be rebuilt

`hasNonBotCommits` skipped any PR containing a commit not authored by `github-actions[bot]`. GitHub's "Update branch" button (and `gh pr update-branch`) adds a merge commit authored by a human, which permanently poisoned the PR — the action would never rebuild it again, so a conflicted update PR stayed conflicted forever.

Commits are now fetched via the REST API (`gh api repos/{owner}/{repo}/pulls/N/commits`) so merge commits (2+ parents) can be identified and ignored. Only human-authored **non-merge** commits trigger the skip. Covered by new unit tests in `test/git.test.ts`.

## Problem 2: waiting until the next day for rebuilds

The workflow only ran on `schedule`/`workflow_dispatch`, so after a merge invalidated the other open update PRs, nothing rebuilt them until the next morning.

Adds a `push` trigger (paths: `**/package.json`, `**/bun.lock`) with a non-cancelling `concurrency` group so open PRs are rebuilt immediately after every merge to master. With auto-merge enabled this cascades: merge → rebuild → CI → merge → … until all groups are up to date, same day. README recipe updated to match.
