### PR TITLE
chore(ci): remove duplicate regression key in fallow config

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -41,26 +41,6 @@
   },
   "regression": {
     "baseline": {
-      "totalIssues": 0,
-      "unusedFiles": 0,
-      "unusedExports": 0,
-      "unusedTypes": 0,
-      "unusedDependencies": 0,
-      "unusedDevDependencies": 0,
-      "unusedOptionalDependencies": 0,
-      "unusedEnumMembers": 0,
-      "unusedClassMembers": 0,
-      "unresolvedImports": 0,
-      "unlistedDependencies": 0,
-      "duplicateExports": 0,
-      "circularDependencies": 0,
-      "typeOnlyDependencies": 0,
-      "testOnlyDependencies": 0,
-      "boundaryViolations": 0
-    }
-  },
-  "regression": {
-    "baseline": {
       "analysisIdentity": {
         "mode": "syntactic",
         "semantic_schema_version": 1,


### PR DESCRIPTION
The fallow config carried two `regression` keys: an older, shorter baseline block left behind by a previous `--save-regression-baseline` run, plus the current one. JSON parsing keeps the last key, so behavior is unchanged — this just drops the stale block.