### PR TITLE
refactor(web): fallow sweep — extract shared require-headers helper from server bindings

### DIFF
--- a/apps/web/src/lib/server/invitation-binding.ts
+++ b/apps/web/src/lib/server/invitation-binding.ts
@@ -1,9 +1,8 @@
 import { Auth } from '@b2b-saas-starter/auth'
 import { type WorkspaceInvitationBinding } from '@b2b-saas-starter/capabilities/governance/workspace-invitations'
-import { Schema } from 'effect'
 import { runAuth } from 'effectful-better-auth'
 import { authRuntime } from '../auth-runtime'
-import { currentRequest } from '../request-context'
+import { requestHeaders } from './require-headers'
 
 /**
  * The web app's adapter onto Better Auth's `organization` invitation endpoints
@@ -24,28 +23,12 @@ import { currentRequest } from '../request-context'
 
 /**
  * A plugin call attempted with no in-flight request to take session headers
- * from. It carries an explicit `message` and, deliberately, no `statusCode`:
- * `classifyBindingFailure` reads the status to tell "the workspace refuses"
- * from "the store is unreachable", and nothing about the invitation is wrong
- * here — so it must land on the unavailable side.
+ * from fails as `MissingRequestHeaders` (see `./require-headers.ts`).
  */
-// oxlint-disable-next-line unicorn/throw-new-error -- Schema.TaggedError is a curried factory call, not an un-new-ed error constructor
-class MissingRequestHeaders extends Schema.TaggedError<MissingRequestHeaders>()(
-  'MissingRequestHeaders',
-  { message: Schema.String }
-) {}
-
-function requireHeaders(headers: Headers | undefined): Headers {
-  if (!headers) {
-    // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the WorkspaceInvitationBinding port returns; there is no Effect error channel on this side of it
-    throw new MissingRequestHeaders({ message: 'no_request_headers' })
-  }
-  return headers
-}
 
 export const webInvitationBinding: WorkspaceInvitationBinding = {
   create: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,
@@ -62,7 +45,7 @@ export const webInvitationBinding: WorkspaceInvitationBinding = {
     })
   },
   cancel: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,
@@ -77,7 +60,7 @@ export const webInvitationBinding: WorkspaceInvitationBinding = {
   // The plugin reads the accepting user from this session and refuses an
   // invitation addressed to anyone else, which is why the port passes no user.
   accept: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,

--- a/apps/web/src/lib/server/member-binding.ts
+++ b/apps/web/src/lib/server/member-binding.ts
@@ -1,9 +1,8 @@
 import { Auth } from '@b2b-saas-starter/auth'
 import { type WorkspaceMemberBinding } from '@b2b-saas-starter/capabilities/governance/workspace-membership'
-import { Schema } from 'effect'
 import { runAuth } from 'effectful-better-auth'
 import { authRuntime } from '../auth-runtime'
-import { currentRequest } from '../request-context'
+import { requestHeaders } from './require-headers'
 
 /**
  * The web app's adapter onto Better Auth's `organization` member endpoints —
@@ -25,24 +24,8 @@ import { currentRequest } from '../request-context'
 
 /**
  * A plugin call attempted with no in-flight request to take session headers
- * from. It carries an explicit `message` and, deliberately, no `statusCode`:
- * `classifyBindingFailure` reads the status to tell "the workspace refuses"
- * from "the store is unreachable", and nothing about the membership is wrong
- * here — so it must land on the unavailable side.
+ * from fails as `MissingRequestHeaders` (see `./require-headers.ts`).
  */
-// oxlint-disable-next-line unicorn/throw-new-error -- Schema.TaggedError is a curried factory call, not an un-new-ed error constructor
-class MissingRequestHeaders extends Schema.TaggedError<MissingRequestHeaders>()(
-  'MissingRequestHeaders',
-  { message: Schema.String }
-) {}
-
-function requireHeaders(headers: Headers | undefined): Headers {
-  if (!headers) {
-    // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the WorkspaceMemberBinding port returns; there is no Effect error channel on this side of it
-    throw new MissingRequestHeaders({ message: 'no_request_headers' })
-  }
-  return headers
-}
 
 export const webMemberBinding: WorkspaceMemberBinding = {
   // The plugin's add-member route is a trusted server-side call (`serverOnly`,
@@ -62,7 +45,7 @@ export const webMemberBinding: WorkspaceMemberBinding = {
     })
   },
   removeMember: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,
@@ -78,7 +61,7 @@ export const webMemberBinding: WorkspaceMemberBinding = {
     })
   },
   changeRole: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,

--- a/apps/web/src/lib/server/require-headers.ts
+++ b/apps/web/src/lib/server/require-headers.ts
@@ -1,0 +1,40 @@
+import { Schema } from 'effect'
+import { currentRequest } from '../request-context'
+
+/**
+ * Shared helper for the server-only `*-binding.ts` adapters (invitation,
+ * member, user-admin, workspace lifecycle), which all need the same
+ * "take session headers from the in-flight request or refuse" behavior.
+ */
+
+/**
+ * A plugin call attempted with no in-flight request to take session headers
+ * from. It carries an explicit `message` and, deliberately, no `statusCode`:
+ * `classifyBindingFailure` reads the status to tell "the workspace refuses"
+ * from "the store is unreachable", and nothing about the binding is wrong
+ * here — so it must land on the unavailable side (the store is not refusing —
+ * there was no store to ask).
+ */
+// oxlint-disable-next-line unicorn/throw-new-error -- Schema.TaggedError is a curried factory call, not an un-new-ed error constructor
+export class MissingRequestHeaders extends Schema.TaggedError<MissingRequestHeaders>()(
+  'MissingRequestHeaders',
+  { message: Schema.String }
+) {}
+
+/**
+ * The headers of the in-flight request, or a thrown `MissingRequestHeaders`.
+ * Throwing raw is deliberate: it rejects the promise the binding port
+ * returns, which has no Effect error channel on this side of it.
+ */
+export function requireHeaders(headers: Headers | undefined): Headers {
+  if (!headers) {
+    // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the binding port returns; there is no Effect error channel on this side of it
+    throw new MissingRequestHeaders({ message: 'no_request_headers' })
+  }
+  return headers
+}
+
+/** Convenience for the near-universal `requireHeaders(currentRequest()?.headers)`. */
+export function requestHeaders(): Headers {
+  return requireHeaders(currentRequest()?.headers)
+}

--- a/apps/web/src/lib/server/user-admin-binding.ts
+++ b/apps/web/src/lib/server/user-admin-binding.ts
@@ -1,9 +1,8 @@
 import { Auth } from '@b2b-saas-starter/auth'
 import { type PlatformUserAdminBinding } from '@b2b-saas-starter/capabilities/governance/platform-user-admin'
-import { Schema } from 'effect'
 import { runAuth } from 'effectful-better-auth'
 import { authRuntime } from '../auth-runtime'
-import { currentRequest } from '../request-context'
+import { requestHeaders } from './require-headers'
 
 /**
  * The web app's adapter onto Better Auth's `admin` endpoints (plus the
@@ -21,26 +20,12 @@ import { currentRequest } from '../request-context'
 
 /**
  * A plugin call attempted with no in-flight request to take session headers
- * from. No `statusCode`, deliberately: the capability classifies it on the
- * unavailable side (the store is not refusing — there was no store to ask).
+ * from fails as `MissingRequestHeaders` (see `./require-headers.ts`).
  */
-// oxlint-disable-next-line unicorn/throw-new-error -- Schema.TaggedError is a curried factory call, not an un-new-ed error constructor
-class MissingRequestHeaders extends Schema.TaggedError<MissingRequestHeaders>()(
-  'MissingRequestHeaders',
-  { message: Schema.String }
-) {}
-
-function requireHeaders(headers: Headers | undefined): Headers {
-  if (!headers) {
-    // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the PlatformUserAdminBinding port returns; there is no Effect error channel on this side of it
-    throw new MissingRequestHeaders({ message: 'no_request_headers' })
-  }
-  return headers
-}
 
 export const webUserAdminBinding: PlatformUserAdminBinding = {
   banUser: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,
@@ -53,7 +38,7 @@ export const webUserAdminBinding: PlatformUserAdminBinding = {
     })
   },
   unbanUser: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,
@@ -66,7 +51,7 @@ export const webUserAdminBinding: PlatformUserAdminBinding = {
     })
   },
   setMemberRole: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,

--- a/apps/web/src/lib/server/workspace-binding.ts
+++ b/apps/web/src/lib/server/workspace-binding.ts
@@ -1,9 +1,8 @@
 import { Auth } from '@b2b-saas-starter/auth'
 import { type WorkspaceLifecycleBinding } from '@b2b-saas-starter/capabilities/governance/workspace-lifecycle'
-import { Schema } from 'effect'
 import { runAuth } from 'effectful-better-auth'
 import { authRuntime } from '../auth-runtime'
-import { currentRequest } from '../request-context'
+import { requestHeaders } from './require-headers'
 
 /**
  * The web app's adapter onto Better Auth's `organization` lifecycle endpoints
@@ -19,19 +18,10 @@ import { currentRequest } from '../request-context'
  * rename and delete demand the session cookie.
  */
 
-// oxlint-disable-next-line unicorn/throw-new-error -- Schema.TaggedError is a curried factory call, not an un-new-ed error constructor
-class MissingRequestHeaders extends Schema.TaggedError<MissingRequestHeaders>()(
-  'MissingRequestHeaders',
-  { message: Schema.String }
-) {}
-
-function requireHeaders(headers: Headers | undefined): Headers {
-  if (!headers) {
-    // oxlint-disable-next-line effect/noThrowStatement -- rejects the promise the WorkspaceLifecycleBinding port returns; there is no Effect error channel on this side of it
-    throw new MissingRequestHeaders({ message: 'no_request_headers' })
-  }
-  return headers
-}
+/**
+ * A plugin call attempted with no in-flight request to take session headers
+ * from fails as `MissingRequestHeaders` (see `./require-headers.ts`).
+ */
 
 export const webWorkspaceLifecycleBinding: WorkspaceLifecycleBinding = {
   // Create alone is headerless; the plugin takes the creator from the body.
@@ -46,7 +36,7 @@ export const webWorkspaceLifecycleBinding: WorkspaceLifecycleBinding = {
     })
   },
   rename: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,
@@ -62,7 +52,7 @@ export const webWorkspaceLifecycleBinding: WorkspaceLifecycleBinding = {
     })
   },
   remove: async (input) => {
-    const headers = requireHeaders(currentRequest()?.headers)
+    const headers = requestHeaders()
     await runAuth({
       tag: Auth.Tag,
       runtime: authRuntime,


### PR DESCRIPTION
## Fallow quality sweep (dead-code → dupes → health → circular deps → security)

### Verified clean
- **Dead code**: 0 issues, regression gate passes (exit 0).
- **Circular dependencies**: 0 (`dead-code --circular-deps` category in the same run).
- **Hardcoded secrets**: none — all `bsk_live_*` / `Bearer` hits are doc snippets, tests, or the token-prefix template; seed uses a hash.

### Fixed
- **dup:8f632a13** — the four server binding adapters (`invitation-binding.ts`, `member-binding.ts`, `user-admin-binding.ts`, `workspace-binding.ts`) each duplicated an identical `MissingRequestHeaders` `Schema.TaggedError` class + `requireHeaders` guard (64 lines × 4). Extracted into `apps/web/src/lib/server/require-headers.ts` with a `requestHeaders()` convenience for the ubiquitous `requireHeaders(currentRequest()?.headers)`. The `'MissingRequestHeaders'` tag is preserved, so `classifyBindingFailure` and the binding tests (which match on the tag string) are unaffected. Duplication: 1015 → 814 lines.

### Left as reported
- **Dupes (~814 remaining lines, 15 groups)**: auth form email/password fields (sign-in/sign-up/forgot-password), TanStack Form submit-button blocks, api-token-form/webhook-form field clones, email template shells in `packages/email`. All are JSX/form-structure similarity where extraction means designing shared field components — a UI-design decision, not a mechanical cleanup. `routeTree.gen.ts` is generated. Contract-test repetition in `workspace-invitations.contract.ts` is intentional test explicitness.
- **Complexity hotspots** (33 findings, none refactored): top by severity — `packages/env/src/server.ts:186 auditRequiredEnv` (cyc 17/cog 24), `infra/bindings.test.ts:28 stripJsonComments` (cyc 16), `packages/capabilities/src/governance/audit-event-log.ts:195 matched` (cyc 16), `packages/capabilities/src/developer-platform/webhook-url.ts:61 checkIpv6Literal` (cyc 15). All are either parsing/validation ladders (inherent) or test helpers; none are trivial to fix without a real refactor.
- **Security candidates** (verified by reading the code — all safe):
  - `packages/capabilities/src/billing/billing.ts:326` SSRF/medium — the fetch URL is the literal `https://api.stripe.com/v1/checkout/sessions` at the only call site; fallow's taint trace is module-level noise.
  - `packages/capabilities/src/runtime.ts:112` prototype-pollution/medium — false positive: Effect's `Layer.merge` is not a recursive object merge over attacker data.
  - `packages/ai/src/index.ts:149` SSRF/low — `baseUrl` comes from server-side config (env), not request input.
  - `apps/web/src/components/mdx-mermaid.tsx:25` innerHTML/low — mermaid runs with `securityLevel: 'strict'`; chart source is repo-authored MDX.
  - `apps/web/src/components/workspace-billing.tsx:92` open-redirect/low — target is the Stripe checkout session URL returned by the server fn.
  - `apps/web/src/routes/blog.$slug.tsx:76` + `docs.$category.$slug.tsx:100` dangerouslySetInnerHTML/low — `JSON.stringify` of repo-authored MDX frontmatter into a `ld+json` script.

### Checks
- `bun run typecheck` 25/25 · `bun run test` all green (223 web tests) · `bun run lint` 0 warnings · fallow dead-code gate 0/exit 0.
