### PR TITLE
ci: enforce circular-dependencies at error

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "rules": {
+    "circular-dependencies": "error"
+  },
   "entry": ["alchemy.run.ts"],
   "ignoreExportsUsedInFile": true,
   "ignoreDependencies": [


### PR DESCRIPTION
Adds `"circular-dependencies": "error"` to the fallow rules so any import cycle fails the PR Gate.

All repos currently measure **0 circular dependencies** (verified in the recent fallow sweeps), so this is a free regression gate — no baseline machinery needed.