### PR TITLE
ci: retry flaky e2e dev-server startup and fail fast on port drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,28 @@ jobs:
       - run: bun run db:seed
       # Playwright's webServer config (apps/web/playwright.config.ts) starts
       # `bun run dev` on :3071 itself — no separate server step needed.
-      - run: bun run test:e2e
+      # The webServer startup has flaked on CI (Vite never became ready within
+      # its 180s budget, #199's master run and one earlier); that kills the
+      # whole run before any test executes, so Playwright's own per-test
+      # retries never apply. Retry the run once: a second attempt lands on a
+      # warm runner and a fresh server process.
+      - name: Run e2e tests
+        run: |
+          attempts=2
+          for attempt in $(seq 1 "$attempts"); do
+            if bun run test:e2e; then
+              exit 0
+            fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::e2e run failed (attempt $attempt/$attempts) — retrying"
+              # A timed-out webServer can leave the dev server or its workerd
+              # child holding :3071; clear them so the retry starts clean
+              # instead of tripping --strictPort immediately.
+              pkill -f 'vite dev' 2>/dev/null || true
+              pkill -f workerd 2>/dev/null || true
+            fi
+          done
+          exit 1
 
   deploy:
     if: github.event_name == 'workflow_dispatch'

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
     trace: 'on-first-retry'
   },
   webServer: {
-    command: 'bun run dev',
+    // --strictPort: without it Vite silently serves on 3072 when :3071 is
+    // taken, and the readiness probe below polls :3071 until the webServer
+    // timeout — a three-minute hang whose only symptom is a missing banner.
+    // Fail fast instead so the cause is visible.
+    command: 'bun run dev -- --strictPort',
     url: 'http://localhost:3071',
     // Locally a dev server on :3071 is usually already running and reusing it
     // saves a cold start. CI always starts its own: a process still holding


### PR DESCRIPTION
## Problem

Master CI run [`33322031066`](https://github.com/brandhaug/b2b-saas-starter/actions/runs/33322031066) (for #199) failed in the `e2e` job:

```
Error: Timed out waiting 180000ms from config.webServer.
```

Vite's dev server started (TanStack Router codegen warnings printed at 16:19:03) but never emitted its ready banner, and Playwright polled `http://localhost:3071` until the 180s webServer timeout. The same timeout already occurred on the Aug 24 master run (`32724742420`), so this is a recurring cold-start flake, not a regression from #199.

Two things made it maximally painful:

1. **Per-test retries can't help.** The webServer dies before any test executes, so the config's `retries: 1` (which exists exactly for dev-server variance) never applies — the whole run fails.
2. **A port conflict would hang silently.** Without `--strictPort`, Vite serves on 3072 if :3071 is taken, and the readiness probe polls :3071 until timeout — a three-minute hang whose only symptom is a missing banner.

## Changes

- **`.github/workflows/ci.yml`** — retry the `bun run test:e2e` step once (workflow-level), clearing any leaked `vite dev` / `workerd` process between attempts so the retry starts clean. A failed first attempt emits a `::warning` annotation. A second attempt lands on a warm runner with a fresh server process.
- **`apps/web/playwright.config.ts`** — start the webServer as `bun run dev -- --strictPort`: if :3071 is occupied, Vite exits with a visible error instead of drifting to another port while the probe waits.

## Verification

- `bun run dev -- --strictPort` boots, binds :3071, and answers 200 (ready in ~2s locally).
- Retry-loop logic exercised for both paths (pass-on-retry → exit 0; both fail → exit 1).
- `oxfmt` / `oxlint` clean; pre-commit typecheck passed.