### PR TITLE
fix(web): resolve cloudflare:workers per build target for the deploy build

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,7 +12,7 @@ import rehypeSlug from 'rehype-slug'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig, loadEnv, type PluginOption } from 'vite'
 
 function remarkMermaid() {
   return (tree: { children: Array<Record<string, unknown>> }) => {
@@ -67,6 +67,46 @@ function resolveWorkersShim(command: 'build' | 'serve', mode: string): string | 
   return command === 'serve' && mode !== 'test'
     ? './src/lib/cloudflare-workers-shim-dev.ts'
     : './src/lib/cloudflare-workers-shim.ts'
+}
+
+// Without the shim (alchemy's deploy build), the two build targets need
+// opposite treatment for `cloudflare:workers`: the client bundle must keep
+// a resolvable stand-in (the inert shim evaluates to an all-undefined env
+// bag in the browser), while the server bundle must externalize it so the
+// deployed worker supplies the real `env` bindings — bundling the shim
+// server-side would deploy `env.DB: undefined` and run the whole app
+// provider-light. A `configEnvironment` plugin is used (rather than
+// `environments` config) because it merges after the TanStack Start
+// plugin defines its own environments.
+function cloudflareWorkersDeployPlugin(
+  inertShimPath: string,
+  enabled: boolean
+): PluginOption {
+  return {
+    name: 'b2b-starter:cloudflare-workers-deploy-resolution',
+    // The TanStack Start plugin replaces the ssr environment's
+    // `rolldownOptions` during planning, so `external` cannot be declared
+    // through environment config — resolve per environment here instead.
+    resolveId: {
+      handler(source: string) {
+        if (!enabled || source !== 'cloudflare:workers') {
+          return null
+        }
+        if (this.environment.name === 'ssr') {
+          // Keep the native import: the deployed worker runtime provides
+          // the real module with the live `env` bindings.
+          return { id: source, external: true }
+        }
+        if (this.environment.name === 'client') {
+          // The browser cannot resolve a runtime module: stand in the
+          // inert shim (an all-undefined env bag — the client never reads
+          // a binding).
+          return inertShimPath
+        }
+        return null
+      }
+    }
+  }
 }
 
 export default defineConfig(({ command, mode }) => {
@@ -134,7 +174,11 @@ export default defineConfig(({ command, mode }) => {
       babel({
         exclude: /packages[/\\]email[/\\]/,
         presets: [reactCompilerPreset()]
-      })
+      }),
+      cloudflareWorkersDeployPlugin(
+        resolve(import.meta.dirname, './src/lib/cloudflare-workers-shim.ts'),
+        workersShim === null
+      )
     ],
     test: {
       globals: true,


### PR DESCRIPTION
## Summary

The dispatched deploy got past authentication (the state store now provisions) and failed at the web worker's Vite build:

```
Rolldown failed to resolve import "cloudflare:workers"
```

Alchemy's deploy build runs `vite build` **without** `B2B_STARTER_USE_WORKERS_SHIM=1` (only `bun run build` sets it), and nothing resolves the runtime module in that configuration.

Shipping the dev shim in a deploy would be wrong — it hard-codes `env.DB: undefined`, so the deployed worker would run the entire app provider-light with no D1. The two build targets need opposite treatment:

- **ssr**: externalize `cloudflare:workers` — the deployed worker runtime supplies the real module with the live `env` bindings (the shape `vite.config.ts`'s comment always intended).
- **client**: keep the inert shim — the browser cannot resolve a runtime module, and the client never reads a binding.

Mechanically, a plain `environments` config loses: TanStack Start's planning replaces the ssr environment's `rolldownOptions` wholesale (`{ input }`), clobbering any declared `external`. A plugin-level `resolveId` hook (which runs after planning) is the robust override, so this adds `cloudflareWorkersDeployPlugin` — active only when the shim is off, i.e. exactly alchemy's deploy build. The shim/`bun run build` path is byte-for-byte unchanged.

## Verification

- `vite build` without the shim env now succeeds: client bundle contains the shim chunk and **zero** native `cloudflare:workers` imports; `dist/server/server.js` keeps the native import (externalized for the runtime)
- `vite build` with `B2B_STARTER_USE_WORKERS_SHIM=1` unchanged (no native imports, same output)
- `bun run check` green (25/25)
