### PR TITLE
perf(web): minify the ssr environment so the deployed worker fits the size limit

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -128,6 +128,12 @@ export default defineConfig(({ command, mode }) => {
     }
   }
   return {
+    // The ssr environment does not minify by default in rolldown-vite, and
+    // the deployed web worker bundle is its output verbatim: unminified, the
+    // bundled server tree exceeds the free Workers size limit (3 MiB).
+    // Setting minify at the top level seeds every environment's build, so
+    // the ssr output shrinks below the limit.
+    build: { minify: true },
     server: { port: 3071, host: 'localhost' },
     preview: { port: 3071, host: 'localhost' },
     resolve: {


### PR DESCRIPTION
## Summary

The deploy got past auth, state store, and the worker build (thanks to #212–#214), then failed at the final upload:

```
BadRequest: Your Worker exceeded the size limit of 3 MiB (16.69 MB uploaded)
```

Root cause: rolldown-vite does **not minify the ssr environment by default**, and the deployed web worker bundle is the ssr environment's output verbatim — with the whole server tree bundled unminified, the script overshoots the free plan's 3 MiB limit.

Fix: set `build.minify: true` at the top level of the vite config. Vite seeds every environment's build options from the top level, so the ssr output is now minified. Measured locally: server bundle 4.5 MB raw → **2.9 MB (~0.76 MB gzipped)**; the CI bundle should land around 5–6 MB raw (~1.5 MB gzipped), under the limit.

## Verification

- `vite build` (deploy shape) produces minified ssr output (templates chunk 55k lines → ~2k lines)
- `bun run check` green (25/25)
- Next deploy (this merge or #215's auto-deploy, whichever lands first) should get past the upload and let the smoke test run
