### PR TITLE
fix(deploy): omit unset optional provider env keys instead of forwarding null

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -90,14 +90,19 @@ const BETTER_AUTH_TRUSTED_ORIGINS =
 const CLOUDFLARE_EMAIL_FROM = readEnv('CLOUDFLARE_EMAIL_FROM')
 
 // Optional provider env, forwarded to the web, API, and background workers so
-// a deployed worker receives its provider configuration. Unset values leave
-// the relevant provider inactive instead of failing the deploy. The key lists(and
-// the secret-vs-plain split) live in `packages/env/src/server.ts` next to the
-// schema — adding a var there is the ONE place to edit.
+// a deployed worker receives its provider configuration. Unset values are
+// omitted entirely — a worker env key that is present but `null` leaks into
+// every consumer (e.g. the telemetry config's string guards) and violates
+// the provider-light rule, which treats an absent key as inactive. The key
+// lists (and the secret-vs-plain split) live in `packages/env/src/server.ts`
+// next to the schema — adding a var there is the ONE place to edit.
 const optionalProviderEnv = {
   ...Object.fromEntries(presentSecretEntries(optionalModuleEnvSecretKeys)),
   ...Object.fromEntries(
-    optionalModuleEnvPlainKeys.map((key) => [key, readEnv(key) ?? null])
+    optionalModuleEnvPlainKeys.flatMap((key) => {
+      const value = readEnv(key)
+      return value !== undefined && value !== '' ? [[key, value]] : []
+    })
   )
 }
 

--- a/apps/web/src/lib/server/telemetry-config.ts
+++ b/apps/web/src/lib/server/telemetry-config.ts
@@ -12,9 +12,11 @@ export type ClientTelemetryConfig = {
   readonly posthogHost: string | undefined
 }
 
-/** Absent and empty both count as unset — no empty-string DSNs reach an SDK. */
-function nonEmptyEnvValue(value: string | undefined): string | undefined {
-  if (value === undefined) {
+/** Absent, null, and empty all count as unset — no empty-string DSNs reach an
+ * SDK. (Worker env keys for unset optional providers arrive as `null` from
+ * deploys that forward them explicitly, so `undefined` alone is not enough.) */
+function nonEmptyEnvValue(value: string | null | undefined): string | undefined {
+  if (value === undefined || value === null) {
     return undefined
   }
   if (value.length === 0) {


### PR DESCRIPTION
## Summary

The deployed web worker returned **500 on every page render**:

```
TypeError: Cannot read properties of null (reading 'length')
```

Root cause: `alchemy.run.ts` forwarded unset **optional plain env keys** (`SENTRY_DSN`, `POSTHOG_KEY`, …) as explicit `null` values into the workers' env, and the telemetry config's `nonEmptyEnvValue` guard only checked `undefined` — `null.length` threw on the root loader of every request.

Fix:

- `alchemy.run.ts` omits unset (and empty) optional plain env keys entirely — an absent key is "inactive", which is what the provider-light rule already promises, and consumers treat `undefined` correctly everywhere else.
- `nonEmptyEnvValue` treats `null` as unset defensively.

## Verification

- `bun run check` green
- Next auto-deploy (this merge) followed by a smoke test: landing page 200, `/health` on the API worker, sign-in origin behavior
