### PR TITLE
fix(deploy): pass D1 migrations via the migrations prop

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -124,7 +124,10 @@ export const Stack = Alchemy.Stack(
   Effect.gen(function* () {
     const db = yield* Cloudflare.D1.Database('b2b-saas-starter-db', {
       name: 'b2b-saas-starter',
-      migrationsDir: './packages/db/migrations'
+      // Alchemy 2.0 takes the migrations input as `migrations` ({ dir, table? });
+      // a `migrationsDir` prop is silently dropped and the database deploys with
+      // no schema applied.
+      migrations: { dir: './packages/db/migrations' }
     })
 
     const webhookDeadLetterQueue = yield* Cloudflare.Queues.Queue('webhook-queue-dlq', {


### PR DESCRIPTION
## Summary
- alchemy 2.0.0-beta.74's `D1.Database` takes `migrations: { dir, table? }`; the `migrationsDir` prop is silently ignored, so the prod database was created with no schema applied and subsequent deploys reused it as a noop.
- Also cleared the stale `prod` state left by the partial deploys (the state store recorded a D1 database and queues that did not exist in the account, which made the deploy fail with `D1DatabaseNotFound`). The deploy now succeeds as of run 33532202888.

## Test plan
- [x] `pnpm run typecheck`
- [ ] CI + deploy to prod; verify `b2b-saas-starter` D1 has the schema applied