### PR TITLE
feat(api): serve a machine-readable JSON index at /

### DIFF
--- a/apps/api/src/http.ts
+++ b/apps/api/src/http.ts
@@ -2,8 +2,13 @@ import { WideEventLoggerLive } from '@b2b-saas-starter/logger'
 import { selectCapabilitiesLayer } from '@b2b-saas-starter/capabilities/runtime'
 import { StarterApi } from '@b2b-saas-starter/api'
 import { selectAssistantLayer } from '@b2b-saas-starter/ai'
-import { FileSystem, Layer, Path } from 'effect'
-import { Etag, HttpPlatform, HttpRouter } from 'effect/unstable/http'
+import { FileSystem, Layer, Path, Effect } from 'effect'
+import {
+  Etag,
+  HttpPlatform,
+  HttpRouter,
+  HttpServerResponse
+} from 'effect/unstable/http'
 import { HttpApiBuilder, HttpApiScalar } from 'effect/unstable/httpapi'
 import { starterEnv, type ApiEnv } from './env.ts'
 import {
@@ -27,6 +32,25 @@ const PlatformLive = Layer.mergeAll(
   Etag.layer,
   FileSystem.layerNoop({}),
   HttpPlatform.layer.pipe(Layer.provide(FileSystem.layerNoop({})))
+)
+
+// The root index — a tiny machine-readable directory for clients and humans
+// who curl the origin. It rides beside the contract like the MCP protocol
+// route (see mcp.ts): static metadata, not a REST operation, so it never
+// appears in the OpenAPI document or the permission matrix. Paths are
+// relative so the index is correct on any host.
+const rootIndexLayer = HttpRouter.add('GET', '/', () =>
+  Effect.succeed(
+    HttpServerResponse.jsonUnsafe({
+      name: 'b2b-saas-starter-api',
+      description:
+        'Starter REST + MCP API. All routes except /health require an Authorization: Bearer API token.',
+      health: '/health',
+      openapi: '/openapi.json',
+      docs: '/reference',
+      mcp: '/mcp'
+    })
+  )
 )
 
 function makeApiLayer(env: ApiEnv): Layer.Layer<never, never, HttpRouter.HttpRouter> {
@@ -58,6 +82,8 @@ function makeApiLayer(env: ApiEnv): Layer.Layer<never, never, HttpRouter.HttpRou
     // capability layer, but a JSON-RPC wire shape the OpenAPI document must
     // not describe. See `mcp.ts`.
     mcpProtocolLayer(env),
+    // The root directory — see the comment on `rootIndexLayer`.
+    rootIndexLayer,
     HttpApiScalar.layer(StarterApi, { path: '/reference' })
   ).pipe(
     HttpRouter.provideRequest(capabilities),

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -266,6 +266,26 @@ describe('contract-served routes', () => {
       })
     ))
 
+  test('GET / serves the root index', () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const res = yield* send(get('/'))
+        expect(res.status).toBe(200)
+        expect(res.headers.get('content-type')).toContain('application/json')
+        const body = yield* jsonBody(
+          res,
+          Schema.Struct({
+            name: Schema.Literal('b2b-saas-starter-api'),
+            health: Schema.Literal('/health'),
+            openapi: Schema.Literal('/openapi.json'),
+            docs: Schema.Literal('/reference'),
+            mcp: Schema.Literal('/mcp')
+          })
+        )
+        expect(body.docs).toBe('/reference')
+      })
+    ))
+
   test('unknown routes are 404', () =>
     Effect.runPromise(
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- `GET /` on the API worker now returns a tiny JSON directory (`health`, `openapi`, `docs`, `mcp`) instead of a bare 404.
- Rides beside the `StarterApi` contract via `HttpRouter.add` (same pattern as the MCP protocol route), so it stays out of the OpenAPI document and the permission matrix.
- Paths are relative, so the index is correct on any host.

## Test plan
- [x] `pnpm -C apps/api test` — new `GET / serves the root index` test alongside the existing suite (40 passing)