### PR TITLE
ci(deploy): smoke test the deployed workers after release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,16 @@ jobs:
           BETTER_AUTH_TRUSTED_ORIGINS: ${{ secrets.BETTER_AUTH_TRUSTED_ORIGINS }}
           # Optional — the SendEmail binding is skipped when unset (alchemy.run.ts).
           CLOUDFLARE_EMAIL_FROM: ${{ secrets.CLOUDFLARE_EMAIL_FROM }}
+      # A green deploy only proves the upload succeeded; the deploy job fails
+      # unless the uploaded workers actually serve. Probes the health route on
+      # the API worker and the web app root. `--retry` rides out propagation
+      # lag right after the upload; `-f --retry-all-errors` makes any HTTP
+      # failure (not just transport errors) retry, then fail the job.
+      - name: Smoke test the deployment
+        run: |
+          for url in \
+            https://b2b-saas-starter-api.brandhaug.workers.dev/health \
+            https://b2b-saas-starter-web.brandhaug.workers.dev/; do
+            echo "Probing $url"
+            curl -fsS --retry 5 --retry-delay 3 --retry-all-errors "$url" > /dev/null
+          done


### PR DESCRIPTION
## Summary
- The deploy job now fails unless the freshly uploaded workers actually serve: it probes `/health` on the API worker and `/` on the web worker on the `workers.dev` subdomains.
- `curl -f --retry 5 --retry-delay 3 --retry-all-errors` rides out post-upload propagation lag, then turns any HTTP failure into a red job — today's `D1DatabaseNotFound` incident shipped green despite a broken deployment, and this closes that gap at the deploy gate.

## Test plan
- [ ] Merge and confirm the next master CI run's deploy job shows both probes passing