### PR TITLE
fix(deps): bump fast-uri override to 3.1.6 to clear pnpm audit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,7 +265,7 @@ catalogs:
 overrides:
   '@hono/node-server@<1.19.10': 1.19.17
   brace-expansion: 5.0.9
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   hono: 4.12.27
   hono@<4.12.34: 4.12.34
   hono@>=3.8.0 <4.12.34: 4.12.34
@@ -7202,8 +7202,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -13963,7 +13963,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -15172,7 +15172,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -111,7 +111,7 @@ catalog:
 overrides:
   '@hono/node-server@<1.19.10': 1.19.17
   brace-expansion: 5.0.9
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   hono: 4.12.27
   'hono@<4.12.34': 4.12.34
   'hono@>=3.8.0 <4.12.34': 4.12.34


### PR DESCRIPTION
Four high-severity fast-uri advisories (GHSA-f65p-4m7j-42xc, GHSA-jqff-g426-hqxp, GHSA-fph4-wmhf-6fwf, GHSA-5jgf-p345-68v8) were published against versions <3.1.6. The repo overrides fast-uri to 3.1.5, so `pnpm audit --audit-level=high` (required `ci` check) now fails on every PR, including master. Bump the override to 3.1.6, the patched release.

Unblocks the open catalog-update PRs.