### PR TITLE
fix(deploy): baseline migration bookkeeping so squash renames converge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+      # Migrations are squashed routinely, and a squash renames the surviving
+      # folder. Alchemy tracks applied migrations by that folder name, so the
+      # squashed migration looks pending on a database that already carries
+      # the schema and the deploy dies on `CREATE TABLE` ("table `account`
+      # already exists"). Baseline first: record migrations whose tables ALL
+      # already exist as applied (packages/db/scripts/baseline.ts), so
+      # squashes of already-deployed work converge instead of re-running.
+      - name: Baseline migration bookkeeping
+        run: pnpm run db:baseline:remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - run: pnpm run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Resolve preview URLs
         id: urls
         run: ./.github/scripts/preview-urls.sh
+      # Same squash-rename guard as the production deploy in ci.yml: a
+      # long-lived PR's stage database records pre-squash migration names.
+      # On a fresh stage database this is a no-op.
+      - name: Baseline migration bookkeeping
+        run: pnpm run db:baseline:stage
       # Alchemy applies packages/db/migrations to the stage's D1 as part of
       # the deploy (D1.Database `migrations`), so no separate migrate step.
       - name: Deploy the stage

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -193,7 +193,14 @@ secret, update the value in the `production` environment (or your shell)
 and deploy again — Alchemy ships values as write-only Worker secrets, so
 they are never readable back from Cloudflare. To add a schema change,
 commit the generated migration; the deploy applies it to D1
-automatically.
+automatically. Deploys first run `db:baseline:remote`
+(`packages/db/scripts/baseline.ts`), which records a migration as applied
+only when every table it creates is already present — that is what lets a
+deploy survive the routine migration squashes, since Alchemy tracks
+applied migrations by folder name and every squash renames the folder. A
+squash of work the deployed database never received still fails the
+deploy loudly; the honest repair is a reset: `pnpm run destroy && pnpm
+run deploy`, then reseed.
 
 To tear everything down, run `pnpm run destroy`. This deletes the
 database and its data.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "deploy:stage": "alchemy deploy --yes --stage \"${ALCHEMY_STAGE:?set ALCHEMY_STAGE, e.g. pr-42}\"",
     "destroy:stage": "alchemy destroy --yes --stage \"${ALCHEMY_STAGE:?set ALCHEMY_STAGE, e.g. pr-42}\"",
     "db:seed:stage": "node scripts/seed.ts --remote --database=\"b2b-saas-starter-${ALCHEMY_STAGE:?set ALCHEMY_STAGE, e.g. pr-42}\"",
+    "db:baseline:remote": "node packages/db/scripts/baseline.ts --remote --database=b2b-saas-starter",
+    "db:baseline:stage": "node packages/db/scripts/baseline.ts --remote --database=\"b2b-saas-starter-${ALCHEMY_STAGE:?set ALCHEMY_STAGE, e.g. pr-42}\"",
     "prepare": "command -v vp >/dev/null 2>&1 && vp config --no-agent || true",
     "infra:wrangler": "node infra/write-wrangler.ts && vp fmt --write apps/api/wrangler.jsonc apps/background/wrangler.jsonc apps/web/wrangler.jsonc"
   },

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -16,9 +16,11 @@ Five subpaths, no root export.
 
 ## Usage Patterns
 
-Edit `schema.ts`, run `db:generate`, commit schema and migration together (drizzle-kit folder style). `scripts/migrate.ts` and `./testing` share `migrations-fs.ts` for identical ordering.
+Edit `schema.ts`, run `db:generate`, commit schema and migration together (drizzle-kit folder style). `scripts/migrate.ts`, `scripts/baseline.ts`, and `./testing` share `migrations-fs.ts` for identical ordering.
 
 After a squash a stale local D1 cannot be migrated onto, its `d1_migrations` table naming deleted migrations: delete `packages/db/.wrangler/state/v3/d1`, re-run `db:migrate:local` and `db:seed`, restart `pnpm run dev` (ADR 0049).
+
+Deployed databases converge instead of resetting: both deploy workflows run `scripts/baseline.ts` first, recording a migration in Alchemy's `__alchemy_migrations` bookkeeping as applied only when every table it creates already exists. Alchemy keys appliedness by folder name, so without the baseline every squash rename would re-run the squashed migration and die on `CREATE TABLE`. A squash of work the deployed database never received cannot converge — the deploy fails loudly; the repair is a reset (`pnpm run destroy && pnpm run deploy`, then reseed) or keeping new tables in their own incremental migration.
 
 ## Anti-patterns
 

--- a/packages/db/scripts/alchemy-bookkeeping.ts
+++ b/packages/db/scripts/alchemy-bookkeeping.ts
@@ -1,0 +1,106 @@
+// Alchemy's D1 migration bookkeeping, mirrored for this package's deploy
+// tooling (scripts/baseline.ts). Source of truth: SQL/Migrations/
+// AlchemyFormat.ts in the alchemy package — the table shape, the row format
+// (hash = sha256 of migration.sql, created_at = the folder timestamp in
+// epoch millis, applied_at = now), and the name-keyed applied-detection
+// everything here has to reproduce faithfully.
+//
+// Pure string/SQL helpers plus one JSON decoder: no wrangler spawn, so
+// scripts can share them without inheriting a process.
+import { createHash } from 'node:crypto'
+import { Schema } from 'effect'
+
+// The exact CREATE TABLE alchemy runs on first contact with a database.
+export const ENSURE_BOOKKEEPING_TABLE = `CREATE TABLE IF NOT EXISTS __alchemy_migrations (
+  id INTEGER PRIMARY KEY,
+  hash text NOT NULL,
+  created_at numeric,
+  name text,
+  applied_at TEXT
+);`
+
+export function sqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+// Mirrors alchemy's timestampPrefixMillis: `YYYYMMDDHHMMSS` folder prefix →
+// epoch millis, null when the folder name carries no such prefix.
+export function timestampPrefixMillis(name: string): number | null {
+  const prefix = name.slice(0, 14)
+  if (!/^\d{14}$/.test(prefix)) {
+    return null
+  }
+  return Date.UTC(
+    Number.parseInt(prefix.slice(0, 4), 10),
+    Number.parseInt(prefix.slice(4, 6), 10) - 1,
+    Number.parseInt(prefix.slice(6, 8), 10),
+    Number.parseInt(prefix.slice(8, 10), 10),
+    Number.parseInt(prefix.slice(10, 12), 10),
+    Number.parseInt(prefix.slice(12, 14), 10)
+  )
+}
+
+/** The bookkeeping row alchemy writes for one applied migration. */
+export type BookkeepingRecord = {
+  readonly hash: string
+  readonly createdAtMillis: number | null
+}
+
+export function bookkeepingRecord(name: string, sql: string): BookkeepingRecord {
+  return {
+    hash: createHash('sha256').update(sql).digest('hex'),
+    createdAtMillis: timestampPrefixMillis(name)
+  }
+}
+
+// Mirrors alchemy's sqlite insertSql: one bookkeeping row for an applied
+// migration, values inlined (the D1 HTTP path is raw-SQL-only).
+export function bookkeepingInsertSql(name: string, sql: string): string {
+  const { hash, createdAtMillis } = bookkeepingRecord(name, sql)
+  return `INSERT INTO __alchemy_migrations (hash, created_at, name, applied_at) VALUES (${sqlLiteral(hash)}, ${
+    createdAtMillis === null ? 'NULL' : String(createdAtMillis)
+  }, ${sqlLiteral(name)}, datetime('now'));`
+}
+
+/** The tables and columns a migration's CREATE TABLE statements define. */
+export type TableDdl = {
+  readonly table: string
+  readonly columns: ReadonlyArray<string>
+}
+
+// Parses drizzle's sqlite dialect: backticked table names, tab-indented
+// columns with lowercase type words (constraints start with a keyword, not a
+// type, so they never match). Drives the baseline's existence markers and
+// the rehearsal's post-apply verification.
+export function tablesCreatedBy(sql: string): Array<TableDdl> {
+  const ddl: Array<TableDdl> = []
+  for (const statement of sql.split('--> statement-breakpoint')) {
+    const table = statement.match(/CREATE TABLE (?:IF NOT EXISTS )?`([^`]+)`/)?.[1]
+    if (!table) {
+      continue
+    }
+    const columns = [
+      ...statement.matchAll(/^\s+`([^`]+)`\s+(?:blob|integer|numeric|real|text)\b/gm)
+    ].map((match) => match[1])
+    ddl.push({ table, columns })
+  }
+  return ddl
+}
+
+// Wrangler's `--json` output for a row-returning statement: one batch per
+// statement. Decoding it instead of casting means a wrangler output change
+// fails loudly rather than producing an empty row-set. Extra columns (PRAGMA
+// rows carry more than `name`) are ignored by the struct.
+const NamesJson = Schema.fromJsonString(
+  Schema.Array(
+    Schema.Struct({
+      results: Schema.Array(Schema.Struct({ name: Schema.String }))
+    })
+  )
+)
+
+const decodeNamesJson = Schema.decodeUnknownSync(NamesJson)
+
+export function decodeNames(json: string): Array<string> {
+  return decodeNamesJson(json).flatMap((batch) => batch.results.map((row) => row.name))
+}

--- a/packages/db/scripts/baseline.ts
+++ b/packages/db/scripts/baseline.ts
@@ -1,0 +1,120 @@
+// Records migrations as applied in Alchemy's bookkeeping table
+// (`__alchemy_migrations`) on a deployed D1 — without executing them.
+//
+// Why: Alchemy's D1.Database `migrations` prop detects applied migrations by
+// folder NAME. This repo squashes its migrations (packages/db/AGENTS.md), and
+// a squash renames the one surviving folder, so the squashed migration looks
+// pending on every database that already carries the schema — and the deploy
+// dies on its first `CREATE TABLE` (`table \`account\` already exists`).
+// Local dev resets its D1 after a squash; a deployed database cannot be reset
+// that casually, so both deploy workflows run this script first.
+//
+// A migration is recorded ONLY when every table it creates already exists:
+// "recorded as applied" then means "this migration has no work left to do".
+// A squash that also adds tables the deployed database never received (a
+// squash stacked on a red deploy chain) is deliberately left pending —
+// recording it would silently skip the new tables — so the deploy fails
+// loudly instead, and the honest repair is a reset (packages/db/AGENTS.md).
+// Squashing already-deployed work, the routine case, is a pure rename and
+// converges here.
+//
+// The row format mirrors Alchemy's own sqlite bookkeeping insert (see
+// scripts/alchemy-bookkeeping.ts). A migration that creates no tables (pure
+// ALTERs) is never baselined — a fresh database still needs Alchemy to run it.
+//
+// Usage: node scripts/baseline.ts [--local] | --remote --database=<d1 name>
+//   (root scripts: `db:baseline:remote` for prod, `db:baseline:stage` for a
+//    `pr-<number>` stage — mirroring `db:seed:stage`. Local mode exists to
+//    rehearse against `packages/db/.wrangler/state`; day-to-day local D1 is
+//    reset after a squash instead, per packages/db/AGENTS.md.)
+//
+// Like scripts/migrate.ts, this is a Node CLI entry point, not application
+// code: no Effect runtime exists here, only argv, wrangler, and an exit code.
+import {
+  ENSURE_BOOKKEEPING_TABLE,
+  bookkeepingRecord,
+  decodeNames,
+  sqlLiteral,
+  tablesCreatedBy
+} from './alchemy-bookkeeping.ts'
+import { listMigrations } from '../src/migrations-fs.ts'
+import { wranglerD1Execute, type Target } from './wrangler-d1.ts'
+
+/**
+ * Baselines the committed migrations against one D1: records each unrecorded
+ * migration whose tables all already exist. Returns the names it recorded.
+ */
+export async function runBaseline(target: Target): Promise<Array<string>> {
+  function execute(args: ReadonlyArray<string>, captureJson: boolean): Promise<string> {
+    return wranglerD1Execute(target.database, [target.flag, ...args], captureJson)
+  }
+
+  await execute([`--command=${ENSURE_BOOKKEEPING_TABLE}`], true)
+
+  function selectRecorded(): Promise<Array<string>> {
+    return execute(['--command=SELECT name FROM __alchemy_migrations'], true).then(
+      decodeNames
+    )
+  }
+  const recorded = new Set(await selectRecorded())
+
+  for (const { name, sql } of listMigrations()) {
+    if (recorded.has(name)) {
+      continue
+    }
+    const tables = tablesCreatedBy(sql).map(({ table }) => table)
+    if (tables.length === 0) {
+      continue
+    }
+    // All tables must exist: each contributes its own EXISTS marker, so a
+    // migration that still has tables to create stays pending.
+    const { hash, createdAtMillis } = bookkeepingRecord(name, sql)
+    const guards = tables
+      .map(
+        (table) =>
+          `EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ${sqlLiteral(table)})`
+      )
+      .join(' AND ')
+    const command = `INSERT INTO __alchemy_migrations (hash, created_at, name, applied_at)
+SELECT ${sqlLiteral(hash)}, ${
+      createdAtMillis === null ? 'NULL' : String(createdAtMillis)
+    }, ${sqlLiteral(name)}, datetime('now')
+WHERE NOT EXISTS (SELECT 1 FROM __alchemy_migrations WHERE name = ${sqlLiteral(name)})
+  AND ${guards};`
+    await execute([`--command=${command}`], true)
+  }
+
+  // Which inserts landed: re-read the bookkeeping and diff against the
+  // pre-baseline set, rather than decoding wrangler's INSERT output shape.
+  const after = await selectRecorded()
+  return after.filter((name) => !recorded.has(name))
+}
+
+if (import.meta.main) {
+  // Mirrors scripts/seed.ts's target parsing: local by default; remote needs
+  // both flags because the database is then addressed by name, not by the
+  // package's local wrangler config.
+  const remote = process.argv.includes('--remote')
+  const remoteDatabase = process.argv
+    .find((arg) => arg.startsWith('--database='))
+    ?.slice('--database='.length)
+  if (remote && !remoteDatabase) {
+    console.error(
+      'baseline: remote baselining needs both --remote and --database=<d1 name> (e.g. b2b-saas-starter-pr-42)'
+    )
+    process.exit(1)
+  }
+  const database = remoteDatabase ?? 'b2b-saas-starter'
+  const flag = remote ? '--remote' : '--local'
+
+  const baselined = await runBaseline({ database, flag })
+  if (baselined.length === 0) {
+    console.log(
+      `No baselining needed on ${database}: every committed migration is either recorded or still has work to do.`
+    )
+  } else {
+    console.log(
+      `Baselined ${baselined.length} migration(s) into __alchemy_migrations on ${database}: ${baselined.join(', ')}.`
+    )
+  }
+}

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -12,18 +12,13 @@
 // runtime, its whole job is to spawn `wrangler` and shuttle files, and its exit
 // code is the contract with the `db:migrate:*` package scripts. There is no
 // Effect runtime to read Config/Stdio/FileSystem/Command from here.
-import { spawn } from 'node:child_process'
 import { mkdtempSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Schema } from 'effect'
 import { listMigrations } from '../src/migrations-fs.ts'
-
-const packageDir = join(import.meta.dirname, '..')
-// The wrangler bin of this package's own node_modules (pnpm writes every direct
-// dependency's bin there), so the spawn never reaches for a global install.
-const wranglerBin = join(packageDir, 'node_modules', '.bin', 'wrangler')
+import { wranglerD1Execute } from './wrangler-d1.ts'
 
 function resolveTarget(argv: ReadonlyArray<string>): '--remote' | '--local' {
   if (argv.includes('--remote')) {
@@ -34,54 +29,11 @@ function resolveTarget(argv: ReadonlyArray<string>): '--remote' | '--local' {
 
 const target = resolveTarget(process.argv)
 
-function jsonFlags(captureJson: boolean): Array<string> {
-  if (captureJson) {
-    return ['--json']
-  }
-  return []
-}
-
 function wranglerExecute(
   args: ReadonlyArray<string>,
   captureJson: boolean
 ): Promise<string> {
-  // Plain Node CLI entry, not Effect code (see the header) — the child-process
-  // wait is an ordinary Promise, which is why effect/noNewPromise is waived.
-  // oxlint-disable-next-line effect/noNewPromise -- see above
-  return new Promise((resolve) => {
-    const child = spawn(
-      wranglerBin,
-      [
-        'd1',
-        'execute',
-        'b2b-saas-starter',
-        target,
-        `--config=${join(packageDir, 'wrangler.jsonc')}`,
-        ...args,
-        ...jsonFlags(captureJson)
-      ],
-      // Wrangler's stderr always streams through; stdout is piped only when the
-      // caller needs to decode the `--json` output.
-      { stdio: ['ignore', captureJson ? 'pipe' : 'inherit', 'inherit'] }
-    )
-    let stdoutText = ''
-    if (captureJson && child.stdout) {
-      child.stdout.setEncoding('utf8')
-      child.stdout.on('data', (chunk: string) => {
-        stdoutText += chunk
-      })
-    }
-    child.on('exit', (code) => {
-      if (code !== 0) {
-        process.exit(code ?? 1)
-      }
-      resolve(stdoutText)
-    })
-    child.on('error', (error) => {
-      console.error(error)
-      process.exit(1)
-    })
-  })
+  return wranglerD1Execute('b2b-saas-starter', [target, ...args], captureJson)
 }
 
 // Wrangler's `--json` output for a SELECT: one batch per statement. Decoding it

--- a/packages/db/scripts/wrangler-d1.ts
+++ b/packages/db/scripts/wrangler-d1.ts
@@ -1,0 +1,68 @@
+// Shared `wrangler d1 execute` spawn for the package's CLI scripts
+// (scripts/migrate.ts, scripts/baseline.ts).
+//
+// Like those scripts, this is a Node CLI helper, not application code: it
+// runs outside any Effect runtime, so the child-process wait is an ordinary
+// Promise — the one place `new Promise` appears, carrying the
+// effect/noNewPromise waiver for every caller (see migrate.ts's header).
+import { spawn } from 'node:child_process'
+import { join } from 'node:path'
+
+const packageDir = join(import.meta.dirname, '..')
+// The wrangler bin of this package's own node_modules (pnpm writes every direct
+// dependency's bin there), so the spawn never reaches for a global install.
+const wranglerBin = join(packageDir, 'node_modules', '.bin', 'wrangler')
+
+/** One D1 a script targets, and how: by name, locally or remote. */
+export type Target = {
+  readonly database: string
+  readonly flag: '--local' | '--remote'
+}
+
+/**
+ * Executes SQL against a D1 database by name. `args` carries the target
+ * (`--local` / `--remote`) and the payload (`--command=…` / `--file=…`).
+ * Wrangler's stderr always streams through; stdout is piped only when the
+ * caller needs to decode the `--json` output.
+ */
+export function wranglerD1Execute(
+  database: string,
+  args: ReadonlyArray<string>,
+  captureJson: boolean
+): Promise<string> {
+  // Plain Node CLI helper, not Effect code (see the header) — the
+  // child-process wait is an ordinary Promise, which is why
+  // effect/noNewPromise is waived.
+  // oxlint-disable-next-line effect/noNewPromise -- see above
+  return new Promise((resolve) => {
+    const child = spawn(
+      wranglerBin,
+      [
+        'd1',
+        'execute',
+        database,
+        `--config=${join(packageDir, 'wrangler.jsonc')}`,
+        ...args,
+        ...(captureJson ? ['--json'] : [])
+      ],
+      { stdio: ['ignore', captureJson ? 'pipe' : 'inherit', 'inherit'] }
+    )
+    let stdoutText = ''
+    if (captureJson && child.stdout) {
+      child.stdout.setEncoding('utf8')
+      child.stdout.on('data', (chunk: string) => {
+        stdoutText += chunk
+      })
+    }
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        process.exit(code ?? 1)
+      }
+      resolve(stdoutText)
+    })
+    child.on('error', (error) => {
+      console.error(error)
+      process.exit(1)
+    })
+  })
+}


### PR DESCRIPTION
## Why

Every production deploy since #234's migration squash fails with:

```
MigrationError: D1 migration batch failed: BadRequest: table `account` already exists at offset 13: SQLITE_ERROR
```

Alchemy applies `packages/db/migrations` as part of the deploy and tracks applied migrations **by folder name** in `__alchemy_migrations`. This repo squashes migrations routinely, and every squash renames the surviving folder — so the squashed migration looks pending on any database that already carries the schema, and the deploy re-runs it from the first `CREATE TABLE`.

## What

One small script, run by both deploy workflows before `alchemy deploy`:

- **`packages/db/scripts/baseline.ts`** — records a migration as applied in Alchemy's exact row format (sha256 of `migration.sql`, folder-timestamp millis), **only when every table it creates already exists**. A squash of already-deployed work — the routine case — is then a pure rename and converges instead of re-running. A recorded row always means "no work left to do", so a squash containing tables the deployed database never received stays pending and fails loudly rather than silently skipping DDL.
- Shared plumbing: `wrangler-d1.ts` (the wrangler spawn; `migrate.ts` refactored onto it) and `alchemy-bookkeeping.ts` (the mirrored table/row format).
- Docs: `packages/db/AGENTS.md`, `docs/deploying.md` (including the loud-failure repair: reset, or keep new tables incremental).

No new CI jobs. Two related checks already exist and stay the safety net for their cases: `infra/bindings.test.ts` pins that stages never share a physical database/queue/worker, and each PR's preview database persists across pushes, so a squash mid-PR already fails that PR's preview redeploy.

## One-time action for production

Prod predates the squash: it carries the 18-table schema and never received #234's OAuth tables (deploys were red), so `jazzy_hellcat` is pending *and* partially present — the baseline correctly refuses to paper over that. Reset once:

```bash
pnpm run destroy && pnpm run deploy   # with the production env vars
node scripts/seed.ts --remote --database=b2b-saas-starter
```

Fresh databases (including all preview stages) are unaffected.