### PR TITLE
test: migrate Effect.runPromise tests to it.effect

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
+    "@effect/vitest": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plus": "catalog:",

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,7 +1,7 @@
 import { SEED_API_TOKEN } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
 import { signWorkspaceExportDownload } from '@b2b-saas-starter/capabilities/governance/workspace-export'
 import { seedWorkspaceExportFixture } from '@b2b-saas-starter/capabilities/seed-fixture'
-import { describe, expect, test, vi } from 'vite-plus/test'
+import { describe, expect, it, vi } from '@effect/vitest'
 import { DateTime, Effect, Schema } from 'effect'
 import { type ApiEnv } from './env.ts'
 import { buildWebHandler } from './http.ts'
@@ -105,275 +105,255 @@ function send(request: Request, env: ApiEnv = {}): Effect.Effect<Response> {
   return Effect.promise(() => handlerFor(env)(request))
 }
 
-function jsonBody<S extends Schema.Top>(
-  response: Response,
-  schema: S
-): Effect.Effect<S['Type'], never, S['DecodingServices']> {
+function jsonBody<S extends Schema.Top>(response: Response, schema: S) {
   return Effect.promise(() => response.json()).pipe(
-    Effect.flatMap((body) => Schema.decodeUnknownEffect(schema)(body)),
-    Effect.orDie
+    Effect.flatMap((body) => Schema.decodeUnknownEffect(schema)(body))
   )
 }
 
 describe('contract-served routes', () => {
-  test('GET /health is public and returns ok', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/health'))
-        expect(res.status).toBe(200)
-        expect(yield* jsonBody(res, HealthBody)).toEqual({ status: 'ok' })
-      })
-    ))
+  it.effect('GET /health is public and returns ok', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/health'))
+      expect(res.status).toBe(200)
+      expect(yield* jsonBody(res, HealthBody)).toEqual({ status: 'ok' })
+    })
+  )
 
-  test('GET /openapi.json is generated from the contract', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/openapi.json'))
-        expect(res.status).toBe(200)
-        const doc = yield* jsonBody(res, OpenApiBody)
-        expect(doc.openapi).toBeDefined()
-        expect(doc.paths['/workspaces/{slug}/overview']).toBeDefined()
-        expect(doc.paths['/workspaces/{slug}/webhooks']).toBeDefined()
-        expect(doc.paths['/health']).toBeDefined()
-        // The published contract must not advertise a surface the worker cannot
-        // serve. See the 404 test below and issue #64.
-        expect(doc.paths['/workspaces/{slug}/invitations']).toBeUndefined()
-      })
-    ))
+  it.effect('GET /openapi.json is generated from the contract', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/openapi.json'))
+      expect(res.status).toBe(200)
+      const doc = yield* jsonBody(res, OpenApiBody)
+      expect(doc.openapi).toBeDefined()
+      expect(doc.paths['/workspaces/{slug}/overview']).toBeDefined()
+      expect(doc.paths['/workspaces/{slug}/webhooks']).toBeDefined()
+      expect(doc.paths['/health']).toBeDefined()
+      // The published contract must not advertise a surface the worker cannot
+      // serve. See the 404 test below and issue #64.
+      expect(doc.paths['/workspaces/{slug}/invitations']).toBeUndefined()
+    })
+  )
 
-  test('GET /reference serves the Scalar UI', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/reference'))
-        expect(res.status).toBe(200)
-        expect(res.headers.get('content-type')).toContain('text/html')
-      })
-    ))
+  it.effect('GET /reference serves the Scalar UI', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/reference'))
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toContain('text/html')
+    })
+  )
 
-  test('protected routes require a bearer token', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/workspaces/starter-lab/overview'))
-        expect(res.status).toBe(401)
-        expect((yield* jsonBody(res, ErrorBody))._tag).toBe('Unauthorized')
-      })
-    ))
+  it.effect('protected routes require a bearer token', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/workspaces/starter-lab/overview'))
+      expect(res.status).toBe(401)
+      expect((yield* jsonBody(res, ErrorBody))._tag).toBe('Unauthorized')
+    })
+  )
 
-  test('unknown bearer tokens are authentication failures', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          get('/workspaces/starter-lab/overview', {
-            authorization: 'Bearer bsk_live_bogus'
-          })
-        )
-        expect(res.status).toBe(401)
-      })
-    ))
+  it.effect('unknown bearer tokens are authentication failures', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        get('/workspaces/starter-lab/overview', {
+          authorization: 'Bearer bsk_live_bogus'
+        })
+      )
+      expect(res.status).toBe(401)
+    })
+  )
 
-  test('workspace tokens cannot cross workspace slugs', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/workspaces/does-not-exist/overview', bearer))
-        expect(res.status).toBe(403)
-        expect((yield* jsonBody(res, ErrorBody))._tag).toBe('AuthorizationDenied')
-      })
-    ))
+  it.effect('workspace tokens cannot cross workspace slugs', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/workspaces/does-not-exist/overview', bearer))
+      expect(res.status).toBe(403)
+      expect((yield* jsonBody(res, ErrorBody))._tag).toBe('AuthorizationDenied')
+    })
+  )
 
   // The read-only token's whole route table lives in `permission-matrix.test.ts`,
   // which asserts every gated operation the contract advertises. Keeping one
   // permitted read and two denials here as well only duplicated three of its rows.
 
-  test('GET workspace overview returns the DTO for the seed token', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/workspaces/starter-lab/overview', bearer))
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, OverviewBody)
-        expect(body.workspace.slug).toBe('starter-lab')
-        expect(Array.isArray(body.notifications)).toBe(true)
-      })
-    ))
+  it.effect('GET workspace overview returns the DTO for the seed token', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/workspaces/starter-lab/overview', bearer))
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, OverviewBody)
+      expect(body.workspace.slug).toBe('starter-lab')
+      expect(Array.isArray(body.notifications)).toBe(true)
+    })
+  )
 
-  test('POST create api token returns 201 with the created token', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          post(
-            '/workspaces/starter-lab/api-tokens',
-            { name: 'CI token', scopes: ['read'] },
-            bearer
-          )
+  it.effect('POST create api token returns 201 with the created token', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        post(
+          '/workspaces/starter-lab/api-tokens',
+          { name: 'CI token', scopes: ['read'] },
+          bearer
         )
-        expect(res.status).toBe(201)
-        const body = yield* jsonBody(res, CreatedTokenBody)
-        expect(body.token).toBeTruthy()
-        expect(body.scopes).toEqual(['read'])
-      })
-    ))
+      )
+      expect(res.status).toBe(201)
+      const body = yield* jsonBody(res, CreatedTokenBody)
+      expect(body.token).toBeTruthy()
+      expect(body.scopes).toEqual(['read'])
+    })
+  )
 
-  test('POST create webhook rejects invalid destinations', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          post(
-            '/workspaces/starter-lab/webhooks',
-            { url: 'http://insecure.example.com/hook', events: ['api_token.created'] },
-            bearer
-          )
+  it.effect('POST create webhook rejects invalid destinations', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        post(
+          '/workspaces/starter-lab/webhooks',
+          { url: 'http://insecure.example.com/hook', events: ['api_token.created'] },
+          bearer
         )
-        expect(res.status).toBe(400)
-        expect((yield* jsonBody(res, ErrorBody))._tag).toBe('InvalidWebhookUrl')
-      })
-    ))
+      )
+      expect(res.status).toBe(400)
+      expect((yield* jsonBody(res, ErrorBody))._tag).toBe('InvalidWebhookUrl')
+    })
+  )
 
-  test('POST create webhook accepts https destinations', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          post(
-            '/workspaces/starter-lab/webhooks',
-            { url: 'https://example.com/hook', events: ['api_token.created'] },
-            bearer
-          )
+  it.effect('POST create webhook accepts https destinations', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        post(
+          '/workspaces/starter-lab/webhooks',
+          { url: 'https://example.com/hook', events: ['api_token.created'] },
+          bearer
         )
-        expect(res.status).toBe(201)
-        const body = yield* jsonBody(res, CreatedWebhookBody)
-        expect(body.url).toBe('https://example.com/hook')
-        expect(body.enabled).toBe(true)
-      })
-    ))
+      )
+      expect(res.status).toBe(201)
+      const body = yield* jsonBody(res, CreatedWebhookBody)
+      expect(body.url).toBe('https://example.com/hook')
+      expect(body.enabled).toBe(true)
+    })
+  )
 
-  test('PATCH webhook endpoint updates the provided fields', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        function patch(payload: typeof Schema.Json.Type) {
-          return send(
-            new Request('https://api.test/workspaces/starter-lab/webhooks/wh_release', {
+  it.effect('PATCH webhook endpoint updates the provided fields', () =>
+    Effect.gen(function* () {
+      function patch(payload: typeof Schema.Json.Type) {
+        return send(
+          new Request('https://api.test/workspaces/starter-lab/webhooks/wh_release', {
+            method: 'PATCH',
+            headers: { 'content-type': 'application/json', ...bearer },
+            body: encodeJsonBody(payload)
+          })
+        )
+      }
+      const res = yield* patch({ enabled: false })
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, UpdatedWebhookBody)
+      // Only the provided field changed; URL and subscriptions are intact.
+      expect(body.enabled).toBe(false)
+      expect(body.url).toBe('https://example.com/webhooks/starter')
+      expect(body.events).toEqual(['api_token.created'])
+      // Put the endpoint back: later tests dispatch to it.
+      const reEnabled = yield* patch({ enabled: true })
+      expect((yield* jsonBody(reEnabled, UpdatedWebhookBody)).enabled).toBe(true)
+    })
+  )
+
+  it.effect('PATCH webhook endpoint re-validates the URL and 404s unknown ids', () =>
+    Effect.gen(function* () {
+      function patch(endpointId: string, payload: typeof Schema.Json.Type) {
+        return send(
+          new Request(
+            `https://api.test/workspaces/starter-lab/webhooks/${endpointId}`,
+            {
               method: 'PATCH',
               headers: { 'content-type': 'application/json', ...bearer },
               body: encodeJsonBody(payload)
-            })
-          )
-        }
-        const res = yield* patch({ enabled: false })
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, UpdatedWebhookBody)
-        // Only the provided field changed; URL and subscriptions are intact.
-        expect(body.enabled).toBe(false)
-        expect(body.url).toBe('https://example.com/webhooks/starter')
-        expect(body.events).toEqual(['api_token.created'])
-        // Put the endpoint back: later tests dispatch to it.
-        const reEnabled = yield* patch({ enabled: true })
-        expect((yield* jsonBody(reEnabled, UpdatedWebhookBody)).enabled).toBe(true)
-      })
-    ))
-
-  test('PATCH webhook endpoint re-validates the URL and 404s unknown ids', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        function patch(endpointId: string, payload: typeof Schema.Json.Type) {
-          return send(
-            new Request(
-              `https://api.test/workspaces/starter-lab/webhooks/${endpointId}`,
-              {
-                method: 'PATCH',
-                headers: { 'content-type': 'application/json', ...bearer },
-                body: encodeJsonBody(payload)
-              }
-            )
-          )
-        }
-        const invalid = yield* patch('wh_release', { url: 'http://localhost/hook' })
-        expect(invalid.status).toBe(400)
-        expect((yield* jsonBody(invalid, ErrorBody))._tag).toBe('InvalidWebhookUrl')
-        const missing = yield* patch('wh_missing', { enabled: true })
-        expect(missing.status).toBe(404)
-        expect((yield* jsonBody(missing, ErrorBody))._tag).toBe(
-          'WebhookEndpointNotFound'
-        )
-      })
-    ))
-
-  test('DELETE webhook endpoint removes it and 404s when nothing matches', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        // Create a throwaway endpoint so the seed fixture stays intact for the
-        // other tests in this file.
-        const created = yield* send(
-          post(
-            '/workspaces/starter-lab/webhooks',
-            { url: 'https://example.com/doomed', events: ['api_token.revoked'] },
-            bearer
-          )
-        )
-        const createdBody = yield* jsonBody(created, CreatedEndpointIdBody)
-        const res = yield* send(
-          new Request(
-            `https://api.test/workspaces/starter-lab/webhooks/${createdBody.id}`,
-            {
-              method: 'DELETE',
-              headers: bearer
             }
           )
         )
-        expect(res.status).toBe(200)
-        expect(yield* jsonBody(res, DeletedBody)).toEqual({ status: 'deleted' })
-        const again = yield* send(
-          new Request(
-            `https://api.test/workspaces/starter-lab/webhooks/${createdBody.id}`,
-            {
-              method: 'DELETE',
-              headers: bearer
-            }
-          )
-        )
-        expect(again.status).toBe(404)
-      })
-    ))
+      }
+      const invalid = yield* patch('wh_release', { url: 'http://localhost/hook' })
+      expect(invalid.status).toBe(400)
+      expect((yield* jsonBody(invalid, ErrorBody))._tag).toBe('InvalidWebhookUrl')
+      const missing = yield* patch('wh_missing', { enabled: true })
+      expect(missing.status).toBe(404)
+      expect((yield* jsonBody(missing, ErrorBody))._tag).toBe('WebhookEndpointNotFound')
+    })
+  )
 
-  test('POST rotate-secret returns the new secret once', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          post('/workspaces/starter-lab/webhooks/wh_release/rotate-secret', {}, bearer)
+  it.effect('DELETE webhook endpoint removes it and 404s when nothing matches', () =>
+    Effect.gen(function* () {
+      // Create a throwaway endpoint so the seed fixture stays intact for the
+      // other tests in this file.
+      const created = yield* send(
+        post(
+          '/workspaces/starter-lab/webhooks',
+          { url: 'https://example.com/doomed', events: ['api_token.revoked'] },
+          bearer
         )
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, RotatedSecretBody)
-        expect(body.signingSecret).toMatch(/^whsec_/)
-        const missing = yield* send(
-          post('/workspaces/starter-lab/webhooks/wh_missing/rotate-secret', {}, bearer)
+      )
+      const createdBody = yield* jsonBody(created, CreatedEndpointIdBody)
+      const res = yield* send(
+        new Request(
+          `https://api.test/workspaces/starter-lab/webhooks/${createdBody.id}`,
+          {
+            method: 'DELETE',
+            headers: bearer
+          }
         )
-        expect(missing.status).toBe(404)
-      })
-    ))
+      )
+      expect(res.status).toBe(200)
+      expect(yield* jsonBody(res, DeletedBody)).toEqual({ status: 'deleted' })
+      const again = yield* send(
+        new Request(
+          `https://api.test/workspaces/starter-lab/webhooks/${createdBody.id}`,
+          {
+            method: 'DELETE',
+            headers: bearer
+          }
+        )
+      )
+      expect(again.status).toBe(404)
+    })
+  )
 
-  test('POST test-event queues a synthetic webhook.test_event delivery', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          post('/workspaces/starter-lab/webhooks/wh_release/test-event', {}, bearer)
-        )
-        expect(res.status).toBe(201)
-        const body = yield* jsonBody(res, QueuedDeliveryBody)
-        expect(body.status).toBe('queued')
-        expect(body.deliveryId).toBeTruthy()
-        // The pending delivery lists back through the read surface.
-        const deliveries = yield* send(
-          get('/workspaces/starter-lab/webhooks/wh_release/deliveries', bearer)
-        )
-        const rows = yield* jsonBody(deliveries, DeliveriesBody)
-        const pending = rows.find((row) => row.id === body.deliveryId)
-        expect(pending).toMatchObject({
-          status: 'pending',
-          attempts: 0,
-          eventType: 'webhook.test_event'
-        })
-      })
-    ))
+  it.effect('POST rotate-secret returns the new secret once', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        post('/workspaces/starter-lab/webhooks/wh_release/rotate-secret', {}, bearer)
+      )
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, RotatedSecretBody)
+      expect(body.signingSecret).toMatch(/^whsec_/)
+      const missing = yield* send(
+        post('/workspaces/starter-lab/webhooks/wh_missing/rotate-secret', {}, bearer)
+      )
+      expect(missing.status).toBe(404)
+    })
+  )
 
-  test('POST replay-delivery re-enqueues a failed delivery as a pending copy', () =>
-    Effect.runPromise(
+  it.effect('POST test-event queues a synthetic webhook.test_event delivery', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        post('/workspaces/starter-lab/webhooks/wh_release/test-event', {}, bearer)
+      )
+      expect(res.status).toBe(201)
+      const body = yield* jsonBody(res, QueuedDeliveryBody)
+      expect(body.status).toBe('queued')
+      expect(body.deliveryId).toBeTruthy()
+      // The pending delivery lists back through the read surface.
+      const deliveries = yield* send(
+        get('/workspaces/starter-lab/webhooks/wh_release/deliveries', bearer)
+      )
+      const rows = yield* jsonBody(deliveries, DeliveriesBody)
+      const pending = rows.find((row) => row.id === body.deliveryId)
+      expect(pending).toMatchObject({
+        status: 'pending',
+        attempts: 0,
+        eventType: 'webhook.test_event'
+      })
+    })
+  )
+
+  it.effect(
+    'POST replay-delivery re-enqueues a failed delivery as a pending copy',
+    () =>
       Effect.gen(function* () {
         const res = yield* send(
           post(
@@ -420,49 +400,46 @@ describe('contract-served routes', () => {
         )
         expect(missing.status).toBe(404)
       })
-    ))
+  )
 
-  test('GET webhook deliveries lists recorded evidence for one endpoint', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          get('/workspaces/starter-lab/webhooks/wh_release/deliveries', bearer)
-        )
-        expect(res.status).toBe(200)
-        const rows = yield* jsonBody(res, DeliveriesBody)
-        const failed = rows.find((row) => row.id === 'whd_seed_failed')
-        expect(failed).toMatchObject({
-          status: 'failed',
-          responseStatus: 500,
-          replayedFrom: null
-        })
-        expect(failed?.requestHeaders?.['x-b2b-starter-event']).toBe(
-          'api_token.created'
-        )
-        expect(failed?.responseBody).toContain('upstream')
+  it.effect('GET webhook deliveries lists recorded evidence for one endpoint', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        get('/workspaces/starter-lab/webhooks/wh_release/deliveries', bearer)
+      )
+      expect(res.status).toBe(200)
+      const rows = yield* jsonBody(res, DeliveriesBody)
+      const failed = rows.find((row) => row.id === 'whd_seed_failed')
+      expect(failed).toMatchObject({
+        status: 'failed',
+        responseStatus: 500,
+        replayedFrom: null
       })
-    ))
+      expect(failed?.requestHeaders?.['x-b2b-starter-event']).toBe('api_token.created')
+      expect(failed?.responseBody).toContain('upstream')
+    })
+  )
 
   // Issue #64: the worker has no session to offer Better Auth's organization
   // plugin, so it cannot persist an invitation. The endpoint used to email a
   // link carrying no invitation id, which no recipient could ever accept, so
   // the route is gone rather than left emailing a dead link.
-  test('POST invitations is not served: the worker cannot persist one', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          post(
-            '/workspaces/starter-lab/invitations',
-            { to: 'invitee@example.com' },
-            bearer
-          )
+  it.effect('POST invitations is not served: the worker cannot persist one', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        post(
+          '/workspaces/starter-lab/invitations',
+          { to: 'invitee@example.com' },
+          bearer
         )
-        expect(res.status).toBe(404)
-      })
-    ))
+      )
+      expect(res.status).toBe(404)
+    })
+  )
 
-  test('POST assistant answer returns a mock reply when authorized and unconfigured', () =>
-    Effect.runPromise(
+  it.effect(
+    'POST assistant answer returns a mock reply when authorized and unconfigured',
+    () =>
       Effect.gen(function* () {
         const res = yield* send(
           post(
@@ -476,65 +453,59 @@ describe('contract-served routes', () => {
         expect(body.provider).toBe('mock')
         expect(body.assistantConfigured).toBe(false)
       })
-    ))
+  )
 
-  test('GET /mcp/discovery returns the discovery document when authorized', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/mcp/discovery', bearer))
-        expect(res.status).toBe(200)
-        expect((yield* jsonBody(res, McpDiscoveryBody)).name).toBe(
-          'b2b-saas-starter-mcp'
-        )
-      })
-    ))
+  it.effect('GET /mcp/discovery returns the discovery document when authorized', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/mcp/discovery', bearer))
+      expect(res.status).toBe(200)
+      expect((yield* jsonBody(res, McpDiscoveryBody)).name).toBe('b2b-saas-starter-mcp')
+    })
+  )
 
-  test('a denying rate-limit binding short-circuits with 429', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const denyAssistant: ApiEnv = {
-          RATE_LIMITER_ASSISTANT: { limit: () => Promise.resolve({ success: false }) }
-        }
-        const res = yield* send(
-          post('/assistant/answer', {
-            workspaceSlug: 'starter-lab',
-            question: 'Hi'
-          }),
-          denyAssistant
-        )
-        expect(res.status).toBe(429)
-        expect((yield* jsonBody(res, ErrorBody))._tag).toBe('RateLimited')
-      })
-    ))
+  it.effect('a denying rate-limit binding short-circuits with 429', () =>
+    Effect.gen(function* () {
+      const denyAssistant: ApiEnv = {
+        RATE_LIMITER_ASSISTANT: { limit: () => Promise.resolve({ success: false }) }
+      }
+      const res = yield* send(
+        post('/assistant/answer', {
+          workspaceSlug: 'starter-lab',
+          question: 'Hi'
+        }),
+        denyAssistant
+      )
+      expect(res.status).toBe(429)
+      expect((yield* jsonBody(res, ErrorBody))._tag).toBe('RateLimited')
+    })
+  )
 
-  test('GET / serves the root index', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/'))
-        expect(res.status).toBe(200)
-        expect(res.headers.get('content-type')).toContain('application/json')
-        const body = yield* jsonBody(
-          res,
-          Schema.Struct({
-            name: Schema.Literal('b2b-saas-starter-api'),
-            health: Schema.Literal('/health'),
-            openapi: Schema.Literal('/openapi.json'),
-            docs: Schema.Literal('/reference'),
-            mcp: Schema.Literal('/mcp'),
-            mcpDiscovery: Schema.Literal('/mcp/discovery')
-          })
-        )
-        expect(body.docs).toBe('/reference')
-      })
-    ))
+  it.effect('GET / serves the root index', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/'))
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toContain('application/json')
+      const body = yield* jsonBody(
+        res,
+        Schema.Struct({
+          name: Schema.Literal('b2b-saas-starter-api'),
+          health: Schema.Literal('/health'),
+          openapi: Schema.Literal('/openapi.json'),
+          docs: Schema.Literal('/reference'),
+          mcp: Schema.Literal('/mcp'),
+          mcpDiscovery: Schema.Literal('/mcp/discovery')
+        })
+      )
+      expect(body.docs).toBe('/reference')
+    })
+  )
 
-  test('unknown routes are 404', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/nope'))
-        expect(res.status).toBe(404)
-      })
-    ))
+  it.effect('unknown routes are 404', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/nope'))
+      expect(res.status).toBe(404)
+    })
+  )
 })
 
 /**
@@ -551,7 +522,7 @@ const decodeWideEventLine = Schema.decodeUnknownSync(
 )
 
 describe('request observability', () => {
-  test('the wide event carries the Cloudflare colo the request arrived at', () => {
+  it.effect('the wide event carries the Cloudflare colo the request arrived at', () => {
     const lines: Array<typeof WideEventLine.Type> = []
     const captureLine = vi
       .spyOn(console, 'log')
@@ -564,29 +535,28 @@ describe('request observability', () => {
     // attached here the way the runtime would.
     Object.defineProperty(request, 'cf', { value: { colo: 'ARN' } })
 
-    return Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(request)
-        expect(res.status).toBe(200)
+    return Effect.gen(function* () {
+      const res = yield* send(request)
+      expect(res.status).toBe(200)
 
-        const events = lines.filter((line) => line.message === 'request.health')
-        // Exactly one event per request, and it names the colo as its region.
-        expect(events).toHaveLength(1)
-        expect(events[0]?.annotations).toMatchObject({
-          service: 'api',
-          status: 'ok',
-          pathname: '/health',
-          method: 'GET',
-          region: 'ARN'
-        })
-      }).pipe(Effect.ensuring(Effect.sync(() => captureLine.mockRestore())))
-    )
+      const events = lines.filter((line) => line.message === 'request.health')
+      // Exactly one event per request, and it names the colo as its region.
+      expect(events).toHaveLength(1)
+      expect(events[0]?.annotations).toMatchObject({
+        service: 'api',
+        status: 'ok',
+        pathname: '/health',
+        method: 'GET',
+        region: 'ARN'
+      })
+    }).pipe(Effect.ensuring(Effect.sync(() => captureLine.mockRestore())))
   })
 })
 
 describe('workspace exports (ADR 0055)', () => {
-  test('POST /workspaces/:slug/exports requests an export with the owner-set token', () =>
-    Effect.runPromise(
+  it.effect(
+    'POST /workspaces/:slug/exports requests an export with the owner-set token',
+    () =>
       Effect.gen(function* () {
         const res = yield* send(post('/workspaces/starter-lab/exports', {}, bearer))
         expect(res.status).toBe(202)
@@ -594,41 +564,39 @@ describe('workspace exports (ADR 0055)', () => {
         // The Seed adapter has no queue: the row lands ready inline.
         expect(body.status).toBe('ready')
       })
-    ))
+  )
 
-  test('POST …/exports/:exportId/download-link mints a link on this origin', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          post(
-            `/workspaces/starter-lab/exports/${seedWorkspaceExportFixture.id}/download-link`,
-            {},
-            bearer
-          )
+  it.effect('POST …/exports/:exportId/download-link mints a link on this origin', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        post(
+          `/workspaces/starter-lab/exports/${seedWorkspaceExportFixture.id}/download-link`,
+          {},
+          bearer
         )
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, DownloadLinkBody)
-        expect(body.url).toMatch(
-          /^https:\/\/api\.test\/exports\/exp_seed_ready\/download\?expires=\d+&signature=[0-9a-f]{64}$/
-        )
-        // The minted link is honoured by the public route, on a fresh handler
-        // whose Seed adapter shares nothing but the fixture secret.
-        const download = yield* send(new Request(body.url))
-        expect(download.status).toBe(200)
-        expect(download.headers.get('content-type')).toContain('application/gzip')
-        expect(download.headers.get('content-disposition')).toContain(
-          'starter-lab-export-exp_seed_ready.json.gz'
-        )
-        const bytes = new Uint8Array(
-          yield* Effect.promise(() => download.arrayBuffer())
-        )
-        // Gzip magic bytes: 0x1f 0x8b.
-        expect([...bytes.subarray(0, 2)]).toEqual([0x1f, 0x8b])
-      })
-    ))
+      )
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, DownloadLinkBody)
+      expect(body.url).toMatch(
+        /^https:\/\/api\.test\/exports\/exp_seed_ready\/download\?expires=\d+&signature=[0-9a-f]{64}$/
+      )
+      // The minted link is honoured by the public route, on a fresh handler
+      // whose Seed adapter shares nothing but the fixture secret.
+      const download = yield* send(new Request(body.url))
+      expect(download.status).toBe(200)
+      expect(download.headers.get('content-type')).toContain('application/gzip')
+      expect(download.headers.get('content-disposition')).toContain(
+        'starter-lab-export-exp_seed_ready.json.gz'
+      )
+      const bytes = new Uint8Array(yield* Effect.promise(() => download.arrayBuffer()))
+      // Gzip magic bytes: 0x1f 0x8b.
+      expect([...bytes.subarray(0, 2)]).toEqual([0x1f, 0x8b])
+    })
+  )
 
-  test('download-link answers 404 for an export this workspace cannot hand out', () =>
-    Effect.runPromise(
+  it.effect(
+    'download-link answers 404 for an export this workspace cannot hand out',
+    () =>
       Effect.gen(function* () {
         const res = yield* send(
           post('/workspaces/starter-lab/exports/exp_nope/download-link', {}, bearer)
@@ -638,10 +606,14 @@ describe('workspace exports (ADR 0055)', () => {
           'WorkspaceExportNotDownloadable'
         )
       })
-    ))
+  )
 
-  test('GET /exports/:id/download is public but refuses a bad or missing signature', () =>
-    Effect.runPromise(
+  // `it.live`, not `it.effect`: the test mints the link against `DateTime.now`
+  // and the handler validates it against the real clock, so the TestClock's
+  // epoch-zero time would read as an already-expired signature.
+  it.live(
+    'GET /exports/:id/download is public but refuses a bad or missing signature',
+    () =>
       Effect.gen(function* () {
         const now = yield* DateTime.now
         const expires = Math.floor(DateTime.toEpochMillis(now) / 1000) + 600
@@ -672,15 +644,14 @@ describe('workspace exports (ADR 0055)', () => {
         )
         expect(unknown.status).toBe(404)
       })
-    ))
+  )
 
-  test('the signed download route is not advertised by the contract', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(get('/openapi.json'))
-        const doc = yield* jsonBody(res, OpenApiBody)
-        expect(doc.paths['/exports/{exportId}/download']).toBeUndefined()
-        expect(doc.paths['/workspaces/{slug}/exports']).toBeDefined()
-      })
-    ))
+  it.effect('the signed download route is not advertised by the contract', () =>
+    Effect.gen(function* () {
+      const res = yield* send(get('/openapi.json'))
+      const doc = yield* jsonBody(res, OpenApiBody)
+      expect(doc.paths['/exports/{exportId}/download']).toBeUndefined()
+      expect(doc.paths['/workspaces/{slug}/exports']).toBeDefined()
+    })
+  )
 })

--- a/apps/api/src/mcp-oauth.test.ts
+++ b/apps/api/src/mcp-oauth.test.ts
@@ -4,7 +4,7 @@ import {
   MCP_WORKSPACE_SLUG_CLAIM
 } from '@b2b-saas-starter/authz/mcp-access-token'
 import { SEED_API_TOKEN } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
-import { afterEach, describe, expect, test, vi } from 'vite-plus/test'
+import { afterEach, describe, expect, it, vi } from '@effect/vitest'
 import { Effect, Schema } from 'effect'
 import {
   exportJWK,
@@ -45,15 +45,11 @@ type TestAuthority = {
  */
 let authority: Promise<TestAuthority> | undefined
 function theAuthority(): Promise<TestAuthority> {
-  authority ??= Effect.runPromise(
-    Effect.gen(function* () {
-      const pair = yield* Effect.promise(() => generateKeyPair('EdDSA'))
-      const jwk = yield* Effect.promise(() => exportJWK(pair.publicKey))
-      return {
-        privateKey: pair.privateKey,
-        jwks: { keys: [{ ...jwk, kid: 'k1', alg: 'EdDSA' }] }
-      }
-    })
+  authority ??= generateKeyPair('EdDSA').then(({ publicKey, privateKey }) =>
+    exportJWK(publicKey).then((jwk) => ({
+      privateKey,
+      jwks: { keys: [{ ...jwk, kid: 'k1', alg: 'EdDSA' }] }
+    }))
   )
   return authority
 }
@@ -138,73 +134,72 @@ const ProtectedResourceBody = Schema.Struct({
 })
 
 describe('POST /mcp with an OAuth access token', () => {
-  test('a token for workspace A reads workspace A', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { privateKey, jwks } = yield* Effect.promise(theAuthority)
-        stubJwksFetch(jwks)
-        const handler = buildWebHandler(env).handler
-        const token = yield* Effect.promise(() => accessToken(privateKey))
-        const res = yield* Effect.promise(() =>
-          callTool(handler, `Bearer ${token}`, 'get_workspace_overview')
-        )
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, CallToolBody)
-        expect(body.result.isError).toBeUndefined()
-        expect(body.result.content[0]?.text).toContain('"slug": "starter-lab"')
-      })
-    ))
+  it.effect('a token for workspace A reads workspace A', () =>
+    Effect.gen(function* () {
+      const { privateKey, jwks } = yield* Effect.promise(theAuthority)
+      stubJwksFetch(jwks)
+      const handler = buildWebHandler(env).handler
+      const token = yield* Effect.promise(() => accessToken(privateKey))
+      const res = yield* Effect.promise(() =>
+        callTool(handler, `Bearer ${token}`, 'get_workspace_overview')
+      )
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, CallToolBody)
+      expect(body.result.isError).toBeUndefined()
+      expect(body.result.content[0]?.text).toContain('"slug": "starter-lab"')
+    })
+  )
 
-  test('a token for workspace A cannot read workspace B', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { privateKey, jwks } = yield* Effect.promise(theAuthority)
-        stubJwksFetch(jwks)
-        // Same user, same signature, but the consent named another workspace:
-        // the workspace layer resolves the slug in the claims and nothing else.
-        const handler = buildWebHandler(env).handler
-        const token = yield* Effect.promise(() =>
-          accessToken(privateKey, {
-            [MCP_WORKSPACE_ID_CLAIM]: 'wrk_other',
-            [MCP_WORKSPACE_SLUG_CLAIM]: 'other-workspace'
+  it.effect('a token for workspace A cannot read workspace B', () =>
+    Effect.gen(function* () {
+      const { privateKey, jwks } = yield* Effect.promise(theAuthority)
+      stubJwksFetch(jwks)
+      // Same user, same signature, but the consent named another workspace:
+      // the workspace layer resolves the slug in the claims and nothing else.
+      const handler = buildWebHandler(env).handler
+      const token = yield* Effect.promise(() =>
+        accessToken(privateKey, {
+          [MCP_WORKSPACE_ID_CLAIM]: 'wrk_other',
+          [MCP_WORKSPACE_SLUG_CLAIM]: 'other-workspace'
+        })
+      )
+      const res = yield* Effect.promise(() =>
+        callTool(handler, `Bearer ${token}`, 'get_workspace_overview')
+      )
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, CallToolBody)
+      expect(body.result.isError).toBe(true)
+      expect(body.result.content[0]?.text).toBe('workspace not found')
+
+      // The resource channel answers the same resolution failure with a
+      // JSON-RPC error instead of an `isError` result — pinned end to end
+      // because Effect's `registerResource` re-wraps the message through
+      // `catchCause`, so the surfaced text is worth asserting, not assuming.
+      const session = mcpClient(handler, `Bearer ${token}`)
+      const read = yield* Effect.promise(() =>
+        session
+          .initialize()
+          .then(() => session.rpc('resources/read', { uri: 'workspace://overview' }))
+      )
+      expect(read.status).toBe(200)
+      const readBody = yield* jsonBody(
+        read,
+        Schema.Struct({
+          jsonrpc: Schema.Literal('2.0'),
+          id: Schema.Unknown,
+          error: Schema.Struct({
+            code: Schema.Number,
+            message: Schema.String
           })
-        )
-        const res = yield* Effect.promise(() =>
-          callTool(handler, `Bearer ${token}`, 'get_workspace_overview')
-        )
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, CallToolBody)
-        expect(body.result.isError).toBe(true)
-        expect(body.result.content[0]?.text).toBe('workspace not found')
+        })
+      )
+      expect(readBody.error.message).toContain('workspace not found')
+    })
+  )
 
-        // The resource channel answers the same resolution failure with a
-        // JSON-RPC error instead of an `isError` result — pinned end to end
-        // because Effect's `registerResource` re-wraps the message through
-        // `catchCause`, so the surfaced text is worth asserting, not assuming.
-        const session = mcpClient(handler, `Bearer ${token}`)
-        const read = yield* Effect.promise(() =>
-          session
-            .initialize()
-            .then(() => session.rpc('resources/read', { uri: 'workspace://overview' }))
-        )
-        expect(read.status).toBe(200)
-        const readBody = yield* jsonBody(
-          read,
-          Schema.Struct({
-            jsonrpc: Schema.Literal('2.0'),
-            id: Schema.Unknown,
-            error: Schema.Struct({
-              code: Schema.Number,
-              message: Schema.String
-            })
-          })
-        )
-        expect(readBody.error.message).toContain('workspace not found')
-      })
-    ))
-
-  test('a token for a user who is not a member reads nothing, non-disclosingly', () =>
-    Effect.runPromise(
+  it.effect(
+    'a token for a user who is not a member reads nothing, non-disclosingly',
+    () =>
       Effect.gen(function* () {
         const { privateKey, jwks } = yield* Effect.promise(theAuthority)
         stubJwksFetch(jwks)
@@ -219,158 +214,146 @@ describe('POST /mcp with an OAuth access token', () => {
         expect(body.result.isError).toBe(true)
         expect(body.result.content[0]?.text).toBe('workspace not found')
       })
-    ))
+  )
 
-  test('a member authorizes as their role, not as the token claim', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { privateKey, jwks } = yield* Effect.promise(theAuthority)
-        stubJwksFetch(jwks)
-        const handler = buildWebHandler(env).handler
-        // `usr_dev` is a plain member of the seed workspace; a member cannot
-        // read the audit log even if the token claims otherwise.
-        const token = yield* Effect.promise(() =>
-          accessToken(privateKey, {
-            sub: 'usr_dev',
-            [MCP_WORKSPACE_ROLE_CLAIM]: 'owner'
-          })
-        )
-        const res = yield* Effect.promise(() =>
-          callTool(handler, `Bearer ${token}`, 'list_audit_events')
-        )
-        const body = yield* jsonBody(res, CallToolBody)
-        expect(body.result.isError).toBe(true)
-        expect(body.result.content[0]?.text).toContain('denied:')
+  it.effect('a member authorizes as their role, not as the token claim', () =>
+    Effect.gen(function* () {
+      const { privateKey, jwks } = yield* Effect.promise(theAuthority)
+      stubJwksFetch(jwks)
+      const handler = buildWebHandler(env).handler
+      // `usr_dev` is a plain member of the seed workspace; a member cannot
+      // read the audit log even if the token claims otherwise.
+      const token = yield* Effect.promise(() =>
+        accessToken(privateKey, {
+          sub: 'usr_dev',
+          [MCP_WORKSPACE_ROLE_CLAIM]: 'owner'
+        })
+      )
+      const res = yield* Effect.promise(() =>
+        callTool(handler, `Bearer ${token}`, 'list_audit_events')
+      )
+      const body = yield* jsonBody(res, CallToolBody)
+      expect(body.result.isError).toBe(true)
+      expect(body.result.content[0]?.text).toContain('denied:')
 
-        const allowed = yield* Effect.promise(() =>
-          callTool(handler, `Bearer ${token}`, 'list_notifications')
-        )
-        expect((yield* jsonBody(allowed, CallToolBody)).result.isError).toBeUndefined()
-      })
-    ))
+      const allowed = yield* Effect.promise(() =>
+        callTool(handler, `Bearer ${token}`, 'list_notifications')
+      )
+      expect((yield* jsonBody(allowed, CallToolBody)).result.isError).toBeUndefined()
+    })
+  )
 
-  test('the key set is fetched once across requests', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { privateKey, jwks } = yield* Effect.promise(theAuthority)
-        const fetchJwks = stubJwksFetch(jwks)
-        const handler = buildWebHandler(env).handler
-        const token = yield* Effect.promise(() => accessToken(privateKey))
-        yield* Effect.promise(() =>
-          callTool(handler, `Bearer ${token}`, 'list_members')
-        )
-        yield* Effect.promise(() =>
-          callTool(handler, `Bearer ${token}`, 'list_members')
-        )
-        expect(fetchJwks).toHaveBeenCalledTimes(1)
-      })
-    ))
+  it.effect('the key set is fetched once across requests', () =>
+    Effect.gen(function* () {
+      const { privateKey, jwks } = yield* Effect.promise(theAuthority)
+      const fetchJwks = stubJwksFetch(jwks)
+      const handler = buildWebHandler(env).handler
+      const token = yield* Effect.promise(() => accessToken(privateKey))
+      yield* Effect.promise(() => callTool(handler, `Bearer ${token}`, 'list_members'))
+      yield* Effect.promise(() => callTool(handler, `Bearer ${token}`, 'list_members'))
+      expect(fetchJwks).toHaveBeenCalledTimes(1)
+    })
+  )
 
-  test('a JWT is refused when OAuth is not configured', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { privateKey, jwks } = yield* Effect.promise(theAuthority)
-        const fetchJwks = stubJwksFetch(jwks)
-        const handler = buildWebHandler({}).handler
-        const token = yield* Effect.promise(() => accessToken(privateKey))
-        // Not `callTool`: the refusal lands on the initialize exchange itself.
-        const session = mcpClient(handler, `Bearer ${token}`)
-        const res = yield* Effect.promise(() =>
-          session.rpc('initialize', {
-            protocolVersion: '2025-11-25',
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' }
-          })
-        )
-        expect(res.status).toBe(401)
-        expect((yield* jsonBody(res, ErrorBody)).message).toBe('oauth_not_configured')
-        expect(res.headers.get('www-authenticate')).toBeNull()
-        expect(fetchJwks).not.toHaveBeenCalled()
-      })
-    ))
+  it.effect('a JWT is refused when OAuth is not configured', () =>
+    Effect.gen(function* () {
+      const { privateKey, jwks } = yield* Effect.promise(theAuthority)
+      const fetchJwks = stubJwksFetch(jwks)
+      const handler = buildWebHandler({}).handler
+      const token = yield* Effect.promise(() => accessToken(privateKey))
+      // Not `callTool`: the refusal lands on the initialize exchange itself.
+      const session = mcpClient(handler, `Bearer ${token}`)
+      const res = yield* Effect.promise(() =>
+        session.rpc('initialize', {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' }
+        })
+      )
+      expect(res.status).toBe(401)
+      expect((yield* jsonBody(res, ErrorBody)).message).toBe('oauth_not_configured')
+      expect(res.headers.get('www-authenticate')).toBeNull()
+      expect(fetchJwks).not.toHaveBeenCalled()
+    })
+  )
 
-  test('a 401 points OAuth clients at the protected-resource metadata', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          new Request('https://api.test/mcp', {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-              accept: 'application/json, text/event-stream'
-            },
-            body: encodeJsonBody({ jsonrpc: '2.0', id: 1, method: 'initialize' })
-          })
-        )
-        expect(res.status).toBe(401)
-        expect(res.headers.get('www-authenticate')).toBe(
-          'Bearer resource_metadata="https://api.test/.well-known/oauth-protected-resource/mcp"'
-        )
-      })
-    ))
+  it.effect('a 401 points OAuth clients at the protected-resource metadata', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        new Request('https://api.test/mcp', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+          },
+          body: encodeJsonBody({ jsonrpc: '2.0', id: 1, method: 'initialize' })
+        })
+      )
+      expect(res.status).toBe(401)
+      expect(res.headers.get('www-authenticate')).toBe(
+        'Bearer resource_metadata="https://api.test/.well-known/oauth-protected-resource/mcp"'
+      )
+    })
+  )
 })
 
 describe('the two credentials stay separate', () => {
-  test('REST routes do not accept an OAuth access token', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { privateKey, jwks } = yield* Effect.promise(theAuthority)
-        stubJwksFetch(jwks)
-        const token = yield* Effect.promise(() => accessToken(privateKey))
-        const res = yield* send(
-          new Request('https://api.test/workspaces/starter-lab/overview', {
-            headers: { authorization: `Bearer ${token}` }
-          })
-        )
-        expect(res.status).toBe(401)
-        expect((yield* jsonBody(res, ErrorBody))._tag).toBe('Unauthorized')
-      })
-    ))
+  it.effect('REST routes do not accept an OAuth access token', () =>
+    Effect.gen(function* () {
+      const { privateKey, jwks } = yield* Effect.promise(theAuthority)
+      stubJwksFetch(jwks)
+      const token = yield* Effect.promise(() => accessToken(privateKey))
+      const res = yield* send(
+        new Request('https://api.test/workspaces/starter-lab/overview', {
+          headers: { authorization: `Bearer ${token}` }
+        })
+      )
+      expect(res.status).toBe(401)
+      expect((yield* jsonBody(res, ErrorBody))._tag).toBe('Unauthorized')
+    })
+  )
 
-  test('an API Token still opens POST /mcp with OAuth configured', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { jwks } = yield* Effect.promise(theAuthority)
-        const fetchJwks = stubJwksFetch(jwks)
-        const handler = buildWebHandler(env).handler
-        const res = yield* Effect.promise(() =>
-          callTool(handler, `Bearer ${SEED_API_TOKEN}`, 'get_workspace_overview')
-        )
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, CallToolBody)
-        expect(body.result.content[0]?.text).toContain('"slug": "starter-lab"')
-        // The token path never touches the key set.
-        expect(fetchJwks).not.toHaveBeenCalled()
-      })
-    ))
+  it.effect('an API Token still opens POST /mcp with OAuth configured', () =>
+    Effect.gen(function* () {
+      const { jwks } = yield* Effect.promise(theAuthority)
+      const fetchJwks = stubJwksFetch(jwks)
+      const handler = buildWebHandler(env).handler
+      const res = yield* Effect.promise(() =>
+        callTool(handler, `Bearer ${SEED_API_TOKEN}`, 'get_workspace_overview')
+      )
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, CallToolBody)
+      expect(body.result.content[0]?.text).toContain('"slug": "starter-lab"')
+      // The token path never touches the key set.
+      expect(fetchJwks).not.toHaveBeenCalled()
+    })
+  )
 })
 
 describe('protected-resource metadata', () => {
-  test('is served at the well-known root and the /mcp alias', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        for (const path of [
-          '/.well-known/oauth-protected-resource',
-          '/.well-known/oauth-protected-resource/mcp'
-        ]) {
-          const res = yield* send(new Request(`https://api.test${path}`))
-          expect(res.status).toBe(200)
-          const body = yield* jsonBody(res, ProtectedResourceBody)
-          expect(body.resource).toBe(RESOURCE)
-          expect(body.authorization_servers).toEqual([ISSUER])
-          expect(body.scopes_supported).toContain('mcp:read')
-        }
-      })
-    ))
+  it.effect('is served at the well-known root and the /mcp alias', () =>
+    Effect.gen(function* () {
+      for (const path of [
+        '/.well-known/oauth-protected-resource',
+        '/.well-known/oauth-protected-resource/mcp'
+      ]) {
+        const res = yield* send(new Request(`https://api.test${path}`))
+        expect(res.status).toBe(200)
+        const body = yield* jsonBody(res, ProtectedResourceBody)
+        expect(body.resource).toBe(RESOURCE)
+        expect(body.authorization_servers).toEqual([ISSUER])
+        expect(body.scopes_supported).toContain('mcp:read')
+      }
+    })
+  )
 
-  test('is 404 while OAuth is unconfigured', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          new Request('https://api.test/.well-known/oauth-protected-resource/mcp'),
-          {}
-        )
-        expect(res.status).toBe(404)
-      })
-    ))
+  it.effect('is 404 while OAuth is unconfigured', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        new Request('https://api.test/.well-known/oauth-protected-resource/mcp'),
+        {}
+      )
+      expect(res.status).toBe(404)
+    })
+  )
 })

--- a/apps/api/src/mcp.test.ts
+++ b/apps/api/src/mcp.test.ts
@@ -1,5 +1,5 @@
 import { SEED_API_TOKEN } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
-import { describe, expect, test } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 import { Effect, Schema } from 'effect'
 import { buildWebHandler } from './http.ts'
 import { PAGED_TOOL_INPUT, mcpDiscoveryDocument } from './mcp.ts'
@@ -14,13 +14,13 @@ import { jsonBody, mcpClient } from './test-utils.ts'
  * which would resurrect a surface REST never advertised, has nowhere to hide.
  */
 describe('mcp ↔ rest operation mirror', () => {
-  test('discovery advertises exactly the shared read operations, in order', () => {
+  it('discovery advertises exactly the shared read operations, in order', () => {
     expect(mcpDiscoveryDocument().tools.map((tool) => tool.name)).toEqual(
       readOperations().map((op) => op.toolName)
     )
   })
 
-  test('every advertised tool names the REST operation it mirrors', () => {
+  it('every advertised tool names the REST operation it mirrors', () => {
     for (const [index, operation] of readOperations().entries()) {
       const tool = mcpDiscoveryDocument().tools[index]
       expect(tool?.description).toContain(
@@ -29,7 +29,7 @@ describe('mcp ↔ rest operation mirror', () => {
     }
   })
 
-  test('list tools advertise the paging input; non-list tools take none', () => {
+  it('list tools advertise the paging input; non-list tools take none', () => {
     const AdvertisedInput = Schema.Struct({
       properties: Schema.Record(Schema.String, Schema.Unknown)
     })
@@ -60,7 +60,7 @@ describe('mcp ↔ rest operation mirror', () => {
     }
   })
 
-  test('the paged tool input names the same paging vocabulary as the REST query', () => {
+  it('the paged tool input names the same paging vocabulary as the REST query', () => {
     // `ListPageQuery` (packages/api) owns this vocabulary for REST — optional
     // `cursor` string, optional `limit` number (ADR 0057). Pinning the Effect
     // schema's advertised shape here keeps the two surfaces from drifting on
@@ -138,186 +138,175 @@ const GuardFailureBody = Schema.Struct({
 })
 
 describe('POST /mcp protocol', () => {
-  test('a session-initialized client lists tools and calls them', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const client = mcpClient(handler, bearer.authorization)
-        yield* Effect.promise(() => client.initialize())
+  it.effect('a session-initialized client lists tools and calls them', () =>
+    Effect.gen(function* () {
+      const client = mcpClient(handler, bearer.authorization)
+      yield* Effect.promise(() => client.initialize())
 
-        const listed = yield* Effect.promise(() => client.rpc('tools/list', {}))
-        expect(listed.status).toBe(200)
-        const body = yield* jsonBody(listed, Ok(ToolListResult))
-        // `tools/list` and the discovery document are both projected from the
-        // shared operation table, so both surfaces answer with one list.
-        expect(body.result.tools.map((tool) => tool.name)).toEqual(
-          readOperations().map((op) => op.toolName)
-        )
-        expect(mcpDiscoveryDocument().tools).toHaveLength(readOperations().length)
+      const listed = yield* Effect.promise(() => client.rpc('tools/list', {}))
+      expect(listed.status).toBe(200)
+      const body = yield* jsonBody(listed, Ok(ToolListResult))
+      // `tools/list` and the discovery document are both projected from the
+      // shared operation table, so both surfaces answer with one list.
+      expect(body.result.tools.map((tool) => tool.name)).toEqual(
+        readOperations().map((op) => op.toolName)
+      )
+      expect(mcpDiscoveryDocument().tools).toHaveLength(readOperations().length)
 
-        const called = yield* Effect.promise(() =>
-          client.rpc('tools/call', {
-            name: 'list_notifications',
-            arguments: {}
-          })
-        )
-        expect(called.status).toBe(200)
-        const result = yield* jsonBody(called, Ok(CallToolResult))
-        expect(result.result.isError).not.toBe(true)
-        expect(result.result.content[0]?.text).toContain('not_email')
-      })
-    ))
+      const called = yield* Effect.promise(() =>
+        client.rpc('tools/call', {
+          name: 'list_notifications',
+          arguments: {}
+        })
+      )
+      expect(called.status).toBe(200)
+      const result = yield* jsonBody(called, Ok(CallToolResult))
+      expect(result.result.isError).not.toBe(true)
+      expect(result.result.content[0]?.text).toContain('not_email')
+    })
+  )
 
-  test('initialize answers an unknown offered revision with the served one', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const client = mcpClient(handler, bearer.authorization)
-        const res = yield* Effect.promise(() =>
-          client.rpc('initialize', {
-            protocolVersion: '2026-07-28',
-            capabilities: {},
-            clientInfo: { name: 'client-from-the-future', version: '1.0.0' }
-          })
-        )
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, Ok(InitializeResult))
-        expect(body.result.serverInfo.name).toBe('b2b-saas-starter-mcp')
-      })
-    ))
+  it.effect('initialize answers an unknown offered revision with the served one', () =>
+    Effect.gen(function* () {
+      const client = mcpClient(handler, bearer.authorization)
+      const res = yield* Effect.promise(() =>
+        client.rpc('initialize', {
+          protocolVersion: '2026-07-28',
+          capabilities: {},
+          clientInfo: { name: 'client-from-the-future', version: '1.0.0' }
+        })
+      )
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, Ok(InitializeResult))
+      expect(body.result.serverInfo.name).toBe('b2b-saas-starter-mcp')
+    })
+  )
 
-  test('a request without a session is refused, not served statelessly', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          new Request('https://api.test/mcp', {
-            method: 'POST',
-            headers: bearer,
-            body: encodeJsonBody({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
-          })
-        )
-        // The transport is sessionful: only initialize opens a session, and
-        // everything else must carry the one it minted.
-        expect(res.status).toBe(400)
-      })
-    ))
+  it.effect('a request without a session is refused, not served statelessly', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        new Request('https://api.test/mcp', {
+          method: 'POST',
+          headers: bearer,
+          body: encodeJsonBody({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
+        })
+      )
+      // The transport is sessionful: only initialize opens a session, and
+      // everything else must carry the one it minted.
+      expect(res.status).toBe(400)
+    })
+  )
 
-  test('tools/call list_notifications honors the paging input like REST', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const client = mcpClient(handler, bearer.authorization)
-        yield* Effect.promise(() => client.initialize())
-        const res = yield* Effect.promise(() =>
-          client.rpc('tools/call', {
-            name: 'list_notifications',
-            arguments: { limit: 2, cursor: 'not-a-cursor' }
-          })
-        )
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, Ok(CallToolResult))
-        expect(body.result.isError).not.toBe(true)
-        // An undecodable cursor addresses no position — the empty page the
-        // REST route serves for the same input.
-        expect(body.result.content[0]?.text).toContain('[]')
-      })
-    ))
+  it.effect('tools/call list_notifications honors the paging input like REST', () =>
+    Effect.gen(function* () {
+      const client = mcpClient(handler, bearer.authorization)
+      yield* Effect.promise(() => client.initialize())
+      const res = yield* Effect.promise(() =>
+        client.rpc('tools/call', {
+          name: 'list_notifications',
+          arguments: { limit: 2, cursor: 'not-a-cursor' }
+        })
+      )
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, Ok(CallToolResult))
+      expect(body.result.isError).not.toBe(true)
+      // An undecodable cursor addresses no position — the empty page the
+      // REST route serves for the same input.
+      expect(body.result.content[0]?.text).toContain('[]')
+    })
+  )
 
-  test('resources/read serves the workspace overview resource', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const client = mcpClient(handler, bearer.authorization)
-        yield* Effect.promise(() => client.initialize())
-        const res = yield* Effect.promise(() =>
-          client.rpc('resources/read', { uri: 'workspace://overview' })
-        )
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(res, Ok(ResourceReadResult))
-        expect(body.result.contents[0]?.uri).toBe('workspace://overview')
-        expect(body.result.contents[0]?.text).toContain('starter-lab')
-      })
-    ))
+  it.effect('resources/read serves the workspace overview resource', () =>
+    Effect.gen(function* () {
+      const client = mcpClient(handler, bearer.authorization)
+      yield* Effect.promise(() => client.initialize())
+      const res = yield* Effect.promise(() =>
+        client.rpc('resources/read', { uri: 'workspace://overview' })
+      )
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(res, Ok(ResourceReadResult))
+      expect(body.result.contents[0]?.uri).toBe('workspace://overview')
+      expect(body.result.contents[0]?.text).toContain('starter-lab')
+    })
+  )
 
-  test('POST /mcp requires a bearer token, and rejects it the way REST does', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          new Request('https://api.test/mcp', {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-              accept: 'application/json, text/event-stream'
-            },
-            body: encodeJsonBody({ jsonrpc: '2.0', id: 1, method: 'initialize' })
-          })
-        )
-        expect(res.status).toBe(401)
-        // A guard failure is not a JSON-RPC failure: the request never reached
-        // the protocol. It is encoded from the contract's own error schemas —
-        // status from the tag table (pinned to each schema's `httpApiStatus`
-        // by `packages/api`'s errors test), body from the schema — so this
-        // route answers a rejected request exactly as a REST route does.
-        // Asserted against the REST answer rather than a literal, so the
-        // two cannot drift apart silently.
-        const rest = yield* send(
-          new Request('https://api.test/workspaces/acme/members')
-        )
-        expect(rest.status).toBe(res.status)
-        expect(yield* jsonBody(res, GuardFailureBody)).toEqual(
-          yield* jsonBody(rest, GuardFailureBody)
-        )
-      })
-    ))
+  it.effect('POST /mcp requires a bearer token, and rejects it the way REST does', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        new Request('https://api.test/mcp', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+          },
+          body: encodeJsonBody({ jsonrpc: '2.0', id: 1, method: 'initialize' })
+        })
+      )
+      expect(res.status).toBe(401)
+      // A guard failure is not a JSON-RPC failure: the request never reached
+      // the protocol. It is encoded from the contract's own error schemas —
+      // status from the tag table (pinned to each schema's `httpApiStatus`
+      // by `packages/api`'s errors test), body from the schema — so this
+      // route answers a rejected request exactly as a REST route does.
+      // Asserted against the REST answer rather than a literal, so the
+      // two cannot drift apart silently.
+      const rest = yield* send(new Request('https://api.test/workspaces/acme/members'))
+      expect(rest.status).toBe(res.status)
+      expect(yield* jsonBody(res, GuardFailureBody)).toEqual(
+        yield* jsonBody(rest, GuardFailureBody)
+      )
+    })
+  )
 
-  test('an unknown token is an authentication failure, not a denial', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          new Request('https://api.test/mcp', {
-            method: 'POST',
-            headers: {
-              authorization: 'Bearer bsk_live_bogus',
-              'content-type': 'application/json',
-              accept: 'application/json, text/event-stream'
-            },
-            body: encodeJsonBody({ jsonrpc: '2.0', id: 1, method: 'initialize' })
-          })
-        )
-        expect(res.status).toBe(401)
-      })
-    ))
+  it.effect('an unknown token is an authentication failure, not a denial', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        new Request('https://api.test/mcp', {
+          method: 'POST',
+          headers: {
+            authorization: 'Bearer bsk_live_bogus',
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+          },
+          body: encodeJsonBody({ jsonrpc: '2.0', id: 1, method: 'initialize' })
+        })
+      )
+      expect(res.status).toBe(401)
+    })
+  )
 
-  test('malformed JSON is a JSON-RPC parse error, not a crash', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(
-          new Request('https://api.test/mcp', {
-            method: 'POST',
-            headers: bearer,
-            body: '{not json'
-          })
-        )
-        // The transport carries the protocol error in a well-formed JSON-RPC
-        // body rather than an HTTP error status.
-        expect(res.status).toBe(200)
-        const body = yield* jsonBody(
-          res,
-          Schema.Struct({
-            jsonrpc: Schema.Literal('2.0'),
-            id: Schema.NullOr(Schema.Unknown),
-            error: Schema.Struct({ code: Schema.Number })
-          })
-        )
-        expect(body.error.code).toBe(-32_700)
-      })
-    ))
+  it.effect('malformed JSON is a JSON-RPC parse error, not a crash', () =>
+    Effect.gen(function* () {
+      const res = yield* send(
+        new Request('https://api.test/mcp', {
+          method: 'POST',
+          headers: bearer,
+          body: '{not json'
+        })
+      )
+      // The transport carries the protocol error in a well-formed JSON-RPC
+      // body rather than an HTTP error status.
+      expect(res.status).toBe(200)
+      const body = yield* jsonBody(
+        res,
+        Schema.Struct({
+          jsonrpc: Schema.Literal('2.0'),
+          id: Schema.NullOr(Schema.Unknown),
+          error: Schema.Struct({ code: Schema.Number })
+        })
+      )
+      expect(body.error.code).toBe(-32_700)
+    })
+  )
 
-  test('a notification is accepted with no reply body', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const client = mcpClient(handler, bearer.authorization)
-        yield* Effect.promise(() => client.initialize())
-        const res = yield* Effect.promise(() =>
-          client.notify('notifications/initialized')
-        )
-        expect(res.status).toBe(202)
-      })
-    ))
+  it.effect('a notification is accepted with no reply body', () =>
+    Effect.gen(function* () {
+      const client = mcpClient(handler, bearer.authorization)
+      yield* Effect.promise(() => client.initialize())
+      const res = yield* Effect.promise(() =>
+        client.notify('notifications/initialized')
+      )
+      expect(res.status).toBe(202)
+    })
+  )
 })

--- a/apps/api/src/oauth-access-token.test.ts
+++ b/apps/api/src/oauth-access-token.test.ts
@@ -4,7 +4,7 @@ import {
   MCP_WORKSPACE_SLUG_CLAIM,
   mcpAccessTokenPrincipal
 } from '@b2b-saas-starter/authz/mcp-access-token'
-import { describe, expect, test, vi } from 'vite-plus/test'
+import { describe, expect, it, vi } from '@effect/vitest'
 import { Effect, Exit, Result } from 'effect'
 import {
   createLocalJWKSet,
@@ -79,11 +79,11 @@ function verifyWith(signer: Signer, token: string) {
     { issuer: ISSUER, audience: AUDIENCE },
     createLocalJWKSet(signer.jwks)
   )
-  return Effect.runPromise(Effect.result(verifier.verify(token).pipe(Effect.scoped)))
+  return Effect.result(verifier.verify(token))
 }
 
 describe('claim → principal mapping', () => {
-  test('maps the starter claims onto the workspace principal', () => {
+  it('maps the starter claims onto the workspace principal', () => {
     const outcome = mcpAccessTokenPrincipal(goodPayload)
     expect(outcome).toEqual({
       ok: true,
@@ -97,14 +97,14 @@ describe('claim → principal mapping', () => {
     })
   })
 
-  test('refuses a token without the mcp:read scope', () => {
+  it('refuses a token without the mcp:read scope', () => {
     expect(mcpAccessTokenPrincipal({ ...goodPayload, scope: 'openid' })).toEqual({
       ok: false,
       reason: 'missing_mcp_scope'
     })
   })
 
-  test('refuses a token missing a workspace claim or naming an unknown role', () => {
+  it('refuses a token missing a workspace claim or naming an unknown role', () => {
     // A payload with no slug claim at all.
     const withoutSlug: JWTPayload = {
       sub: 'usr_demo',
@@ -124,7 +124,7 @@ describe('claim → principal mapping', () => {
     ).toEqual({ ok: false, reason: 'malformed_claims' })
   })
 
-  test('refuses a DPoP-bound token presented as a bare bearer', () => {
+  it('refuses a DPoP-bound token presented as a bare bearer', () => {
     expect(mcpAccessTokenPrincipal({ ...goodPayload, cnf: { jkt: 'thumb' } })).toEqual({
       ok: false,
       reason: 'dpop_bound_token'
@@ -133,22 +133,22 @@ describe('claim → principal mapping', () => {
 })
 
 describe('JWKS verification', () => {
-  test('accepts a token signed by the issuer for this resource', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const signer = yield* makeSigner()
-        const token = yield* Effect.promise(() => signer.sign(goodPayload))
-        const outcome = yield* Effect.promise(() => verifyWith(signer, token))
-        expect(Result.isSuccess(outcome)).toBe(true)
-        if (Result.isSuccess(outcome)) {
-          expect(outcome.success.workspaceSlug).toBe('starter-lab')
-          expect(outcome.success.userId).toBe('usr_demo')
-        }
-      })
-    ))
+  it.effect('accepts a token signed by the issuer for this resource', () =>
+    Effect.gen(function* () {
+      const signer = yield* makeSigner()
+      const token = yield* Effect.promise(() => signer.sign(goodPayload))
+      const outcome = yield* verifyWith(signer, token)
+      expect(Result.isSuccess(outcome)).toBe(true)
+      if (Result.isSuccess(outcome)) {
+        expect(outcome.success.workspaceSlug).toBe('starter-lab')
+        expect(outcome.success.userId).toBe('usr_demo')
+      }
+    })
+  )
 
-  test('rejects a wrong issuer, a wrong audience, an expired token, and a foreign key', () =>
-    Effect.runPromise(
+  it.effect(
+    'rejects a wrong issuer, a wrong audience, an expired token, and a foreign key',
+    () =>
       Effect.gen(function* () {
         const signer = yield* makeSigner()
         const cases = yield* Effect.promise(() =>
@@ -160,7 +160,7 @@ describe('JWKS verification', () => {
         )
         const reasons: Array<string> = []
         for (const token of cases) {
-          const outcome = yield* Effect.promise(() => verifyWith(signer, token))
+          const outcome = yield* verifyWith(signer, token)
           expect(Result.isFailure(outcome)).toBe(true)
           if (Result.isFailure(outcome)) {
             reasons.push(outcome.failure.message)
@@ -175,51 +175,48 @@ describe('JWKS verification', () => {
         // A token signed by a key the issuer never published.
         const stranger = yield* makeSigner()
         const forged = yield* Effect.promise(() => stranger.sign(goodPayload))
-        const outcome = yield* Effect.promise(() => verifyWith(signer, forged))
+        const outcome = yield* verifyWith(signer, forged)
         expect(Result.isFailure(outcome)).toBe(true)
         if (Result.isFailure(outcome)) {
           expect(outcome.failure.message).toBe('invalid_access_token')
         }
       })
-    ))
+  )
 
-  test('fetches the remote key set once and reuses the cached keys', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const signer = yield* makeSigner()
-        const fetchJwks = vi.fn(() =>
-          Promise.resolve(
-            // oxlint-disable-next-line effect/noGlobals -- the fixture JWK set is the wire body jose's custom fetch receives
-            new Response(JSON.stringify(signer.jwks), {
-              headers: { 'content-type': 'application/json' }
-            })
-          )
+  it.effect('fetches the remote key set once and reuses the cached keys', () =>
+    Effect.gen(function* () {
+      const signer = yield* makeSigner()
+      const fetchJwks = vi.fn(() =>
+        Promise.resolve(
+          // oxlint-disable-next-line effect/noGlobals -- the fixture JWK set is the wire body jose's custom fetch receives
+          new Response(JSON.stringify(signer.jwks), {
+            headers: { 'content-type': 'application/json' }
+          })
         )
-        const keySet = createRemoteJWKSet(new URL(`${ISSUER}/jwks`), {
-          [customFetch]: fetchJwks
-        })
-        const verifier = makeOAuthTokenVerifier(
-          { issuer: ISSUER, audience: AUDIENCE },
-          keySet
-        )
-        const first = yield* Effect.promise(() => signer.sign(goodPayload))
-        const second = yield* Effect.promise(() =>
-          signer.sign({ ...goodPayload, sub: 'usr_dev' })
-        )
-        const exits = yield* Effect.promise(() =>
-          Promise.all([
-            Effect.runPromiseExit(verifier.verify(first).pipe(Effect.scoped)),
-            Effect.runPromiseExit(verifier.verify(second).pipe(Effect.scoped))
-          ])
-        )
-        expect(exits.every(Exit.isSuccess)).toBe(true)
-        expect(fetchJwks).toHaveBeenCalledTimes(1)
+      )
+      const keySet = createRemoteJWKSet(new URL(`${ISSUER}/jwks`), {
+        [customFetch]: fetchJwks
       })
-    ))
+      const verifier = makeOAuthTokenVerifier(
+        { issuer: ISSUER, audience: AUDIENCE },
+        keySet
+      )
+      const first = yield* Effect.promise(() => signer.sign(goodPayload))
+      const second = yield* Effect.promise(() =>
+        signer.sign({ ...goodPayload, sub: 'usr_dev' })
+      )
+      const exits = yield* Effect.all([
+        Effect.exit(verifier.verify(first)),
+        Effect.exit(verifier.verify(second))
+      ])
+      expect(exits.every(Exit.isSuccess)).toBe(true)
+      expect(fetchJwks).toHaveBeenCalledTimes(1)
+    })
+  )
 })
 
 describe('resource configuration', () => {
-  test('is inactive until both the issuer and the resource URL are set', () => {
+  it('is inactive until both the issuer and the resource URL are set', () => {
     expect(oauthResourceConfig({})).toBeUndefined()
     expect(oauthResourceConfig({ MCP_OAUTH_ISSUER: ISSUER })).toBeUndefined()
     expect(oauthResourceConfig({ MCP_RESOURCE_URL: AUDIENCE })).toBeUndefined()
@@ -231,7 +228,7 @@ describe('resource configuration', () => {
     ).toEqual({ issuer: ISSUER, audience: AUDIENCE, jwksUrl: `${ISSUER}/jwks` })
   })
 
-  test('advertises the resource, its authorization server and the MCP scopes', () => {
+  it('advertises the resource, its authorization server and the MCP scopes', () => {
     expect(
       protectedResourceMetadata({ issuer: ISSUER, audience: AUDIENCE, jwksUrl: '' })
     ).toEqual({
@@ -243,7 +240,7 @@ describe('resource configuration', () => {
     })
   })
 
-  test('tells a JWT from an API Token by shape', () => {
+  it('tells a JWT from an API Token by shape', () => {
     expect(looksLikeJwt('bsk_seed_0000000000000000')).toBe(false)
     expect(looksLikeJwt('aaa.bbb.ccc')).toBe(true)
   })

--- a/apps/api/src/pagination.test.ts
+++ b/apps/api/src/pagination.test.ts
@@ -1,6 +1,6 @@
 import { SEED_API_TOKEN } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
 import { walkKeysetPages } from '@b2b-saas-starter/capabilities/internal/keyset-cursor'
-import { describe, expect, test } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 import { Effect, Schema } from 'effect'
 import { buildWebHandler } from './http.ts'
 
@@ -27,13 +27,9 @@ function send(request: Request): Effect.Effect<Response> {
   return Effect.promise(() => buildWebHandler({}).handler(request))
 }
 
-function jsonBody<S extends Schema.Top>(
-  response: Response,
-  schema: S
-): Effect.Effect<S['Type'], never, S['DecodingServices']> {
+function jsonBody<S extends Schema.Top>(response: Response, schema: S) {
   return Effect.promise(() => response.json()).pipe(
-    Effect.flatMap((body) => Schema.decodeUnknownEffect(schema)(body)),
-    Effect.orDie
+    Effect.flatMap((body) => Schema.decodeUnknownEffect(schema)(body))
   )
 }
 
@@ -69,119 +65,108 @@ function walk(path: string) {
 }
 
 describe('REST list paging', () => {
-  test('every list endpoint answers the Page shape with no params', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        for (const path of [
-          '/workspaces/starter-lab/members',
-          '/workspaces/starter-lab/notifications',
-          '/workspaces/starter-lab/api-tokens',
-          '/workspaces/starter-lab/webhooks'
-        ]) {
-          const response = yield* send(get(path))
-          expect(response.status).toBe(200)
-          const page = yield* jsonBody(response, PageBody)
-          expect(page.items.length).toBeGreaterThan(0)
-          // The seed collections are smaller than the default page, so the
-          // first page is the last one.
-          expect(page.nextCursor).toBe(null)
-        }
-      })
-    ))
-
-  test('limit narrows the page and the cursor resumes exactly after it', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const response = yield* send(
-          get('/workspaces/starter-lab/notifications?limit=2')
-        )
+  it.effect('every list endpoint answers the Page shape with no params', () =>
+    Effect.gen(function* () {
+      for (const path of [
+        '/workspaces/starter-lab/members',
+        '/workspaces/starter-lab/notifications',
+        '/workspaces/starter-lab/api-tokens',
+        '/workspaces/starter-lab/webhooks'
+      ]) {
+        const response = yield* send(get(path))
+        expect(response.status).toBe(200)
         const page = yield* jsonBody(response, PageBody)
-        expect(page.items).toHaveLength(2)
-        expect(page.items.map((item) => item.id)).toEqual(['not_email', 'not_export'])
-        expect(page.nextCursor).not.toBe(null)
+        expect(page.items.length).toBeGreaterThan(0)
+        // The seed collections are smaller than the default page, so the
+        // first page is the last one.
+        expect(page.nextCursor).toBe(null)
+      }
+    })
+  )
 
-        const resumed = yield* send(
-          get(
-            `/workspaces/starter-lab/notifications?limit=2&cursor=${encodeURIComponent(page.nextCursor ?? '')}`
-          )
+  it.effect('limit narrows the page and the cursor resumes exactly after it', () =>
+    Effect.gen(function* () {
+      const response = yield* send(get('/workspaces/starter-lab/notifications?limit=2'))
+      const page = yield* jsonBody(response, PageBody)
+      expect(page.items).toHaveLength(2)
+      expect(page.items.map((item) => item.id)).toEqual(['not_email', 'not_export'])
+      expect(page.nextCursor).not.toBe(null)
+
+      const resumed = yield* send(
+        get(
+          `/workspaces/starter-lab/notifications?limit=2&cursor=${encodeURIComponent(page.nextCursor ?? '')}`
         )
-        const nextPage = yield* jsonBody(resumed, PageBody)
-        expect(nextPage.items.map((item) => item.id)).toEqual([
-          'not_webhook',
-          'not_token'
-        ])
-      })
-    ))
+      )
+      const nextPage = yield* jsonBody(resumed, PageBody)
+      expect(nextPage.items.map((item) => item.id)).toEqual([
+        'not_webhook',
+        'not_token'
+      ])
+    })
+  )
 
-  test('a walk with a small limit covers the collection once, newest first', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const ids = yield* walk('/workspaces/starter-lab/notifications?limit=2')
-        expect(ids).toEqual([
-          'not_email',
-          'not_export',
-          'not_webhook',
-          'not_token',
-          'not_token_call',
-          'not_billing',
-          'not_rotation',
-          'not_invite'
-        ])
-      })
-    ))
+  it.effect('a walk with a small limit covers the collection once, newest first', () =>
+    Effect.gen(function* () {
+      const ids = yield* walk('/workspaces/starter-lab/notifications?limit=2')
+      expect(ids).toEqual([
+        'not_email',
+        'not_export',
+        'not_webhook',
+        'not_token',
+        'not_token_call',
+        'not_billing',
+        'not_rotation',
+        'not_invite'
+      ])
+    })
+  )
 
-  test('audit events honor limit', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
+  it.effect('audit events honor limit', () =>
+    Effect.gen(function* () {
+      const response = yield* send(get('/workspaces/starter-lab/audit-events?limit=1'))
+      const page = yield* jsonBody(response, PageBody)
+      // The seed fixture holds two workspace-scoped audit events, so the
+      // newest-first first page holds one and names the next.
+      expect(page.items).toHaveLength(1)
+      expect(page.items[0]?.id).toBe('aud_export')
+      expect(page.nextCursor).not.toBe(null)
+    })
+  )
+
+  it.effect('an undecodable cursor addresses no position instead of failing', () =>
+    Effect.gen(function* () {
+      const response = yield* send(
+        get('/workspaces/starter-lab/notifications?cursor=not-a-cursor')
+      )
+      expect(response.status).toBe(200)
+      const page = yield* jsonBody(response, PageBody)
+      expect(page.items).toHaveLength(0)
+      expect(page.nextCursor).toBe(null)
+    })
+  )
+
+  it.effect('an out-of-range limit clamps instead of failing', () =>
+    Effect.gen(function* () {
+      for (const limit of ['0', '-5', '999999']) {
         const response = yield* send(
-          get('/workspaces/starter-lab/audit-events?limit=1')
-        )
-        const page = yield* jsonBody(response, PageBody)
-        // The seed fixture holds two workspace-scoped audit events, so the
-        // newest-first first page holds one and names the next.
-        expect(page.items).toHaveLength(1)
-        expect(page.items[0]?.id).toBe('aud_export')
-        expect(page.nextCursor).not.toBe(null)
-      })
-    ))
-
-  test('an undecodable cursor addresses no position instead of failing', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const response = yield* send(
-          get('/workspaces/starter-lab/notifications?cursor=not-a-cursor')
+          get(`/workspaces/starter-lab/notifications?limit=${limit}`)
         )
         expect(response.status).toBe(200)
         const page = yield* jsonBody(response, PageBody)
-        expect(page.items).toHaveLength(0)
-        expect(page.nextCursor).toBe(null)
-      })
-    ))
+        expect(page.items.length).toBeGreaterThan(0)
+      }
+    })
+  )
 
-  test('an out-of-range limit clamps instead of failing', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        for (const limit of ['0', '-5', '999999']) {
-          const response = yield* send(
-            get(`/workspaces/starter-lab/notifications?limit=${limit}`)
-          )
-          expect(response.status).toBe(200)
-          const page = yield* jsonBody(response, PageBody)
-          expect(page.items.length).toBeGreaterThan(0)
-        }
-      })
-    ))
-
-  test('an unusable limit falls back to the default page instead of failing', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const response = yield* send(
-          get('/workspaces/starter-lab/notifications?limit=abc')
-        )
-        expect(response.status).toBe(200)
-        const page = yield* jsonBody(response, PageBody)
-        expect(page.items).toHaveLength(8)
-        expect(page.nextCursor).toBe(null)
-      })
-    ))
+  it.effect('an unusable limit falls back to the default page instead of failing', () =>
+    Effect.gen(function* () {
+      const response = yield* send(
+        get('/workspaces/starter-lab/notifications?limit=abc')
+      )
+      expect(response.status).toBe(200)
+      const page = yield* jsonBody(response, PageBody)
+      expect(page.items).toHaveLength(8)
+      expect(page.nextCursor).toBe(null)
+    })
+  )
 })

--- a/apps/api/src/permission-matrix.test.ts
+++ b/apps/api/src/permission-matrix.test.ts
@@ -274,17 +274,15 @@ describe('permission matrix', () => {
     expect(gated).not.toContain('health')
   })
 
-  it.effect.each(MATRIX)(
-    'a read-only token gets $expected from $operation ($permission)',
-    (entry) =>
+  describe.each(MATRIX)('$operation ($permission)', (entry) => {
+    it.effect('answers a read-only token with the expected status', () =>
       Effect.gen(function* () {
         const res = yield* send(entry.request)
-        // oxlint-disable-next-line vitest/no-standalone-expect -- it.effect.each's double call hides the test block from the rule
         expect(res.status).toBe(entry.expected)
         if (entry.expected === 403) {
-          // oxlint-disable-next-line vitest/no-standalone-expect -- same as above
           expect((yield* jsonBody(res, ErrorBody))._tag).toBe('AuthorizationDenied')
         }
       })
-  )
+    )
+  })
 })

--- a/apps/api/src/permission-matrix.test.ts
+++ b/apps/api/src/permission-matrix.test.ts
@@ -1,6 +1,6 @@
 import { SEED_READONLY_API_TOKEN } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
 import { BearerAuth, rateLimitBucketFor, StarterApi } from '@b2b-saas-starter/api'
-import { describe, expect, test } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 import { Effect, Schema } from 'effect'
 import { buildWebHandler } from './http.ts'
 import { mirroredRestPath, permissionLabel, readOperations } from './operations.ts'
@@ -57,13 +57,9 @@ function send(request: Request): Effect.Effect<Response> {
   return Effect.promise(() => buildWebHandler({}).handler(request))
 }
 
-function jsonBody<S extends Schema.Top>(
-  response: Response,
-  schema: S
-): Effect.Effect<S['Type'], never, S['DecodingServices']> {
+function jsonBody<S extends Schema.Top>(response: Response, schema: S) {
   return Effect.promise(() => response.json()).pipe(
-    Effect.flatMap((body) => Schema.decodeUnknownEffect(schema)(body)),
-    Effect.orDie
+    Effect.flatMap((body) => Schema.decodeUnknownEffect(schema)(body))
   )
 }
 
@@ -213,23 +209,22 @@ const HTTP_METHODS = new Set([
 ])
 
 describe('permission matrix', () => {
-  test('covers every gated operation the served contract advertises', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(new Request('https://api.test/openapi.json'))
-        const doc = yield* jsonBody(res, OpenApiBody)
-        const served = Object.entries(doc.paths)
-          .flatMap(([path, item]) =>
-            Object.keys(item)
-              .filter((key) => HTTP_METHODS.has(key))
-              .map((method) => `${method.toUpperCase()} ${path}`)
-          )
-          .filter((operation) => !PUBLIC_OPERATIONS.has(operation))
-        expect(served.toSorted()).toEqual(
-          MATRIX.map((entry) => entry.operation).toSorted()
+  it.effect('covers every gated operation the served contract advertises', () =>
+    Effect.gen(function* () {
+      const res = yield* send(new Request('https://api.test/openapi.json'))
+      const doc = yield* jsonBody(res, OpenApiBody)
+      const served = Object.entries(doc.paths)
+        .flatMap(([path, item]) =>
+          Object.keys(item)
+            .filter((key) => HTTP_METHODS.has(key))
+            .map((method) => `${method.toUpperCase()} ${path}`)
         )
-      })
-    ))
+        .filter((operation) => !PUBLIC_OPERATIONS.has(operation))
+      expect(served.toSorted()).toEqual(
+        MATRIX.map((entry) => entry.operation).toSorted()
+      )
+    })
+  )
 
   /**
    * The gate is declared on the contract (`BearerAuth`), not hand-composed in
@@ -238,33 +233,32 @@ describe('permission matrix', () => {
    * operation with no security requirement rather than as a handler someone has
    * to notice is missing three lines.
    */
-  test('the served document secures exactly the gated operations', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const res = yield* send(new Request('https://api.test/openapi.json'))
-        const doc = yield* jsonBody(res, OpenApiBody)
-        expect(doc.components.securitySchemes['bearer']).toEqual({
-          type: 'http',
-          scheme: 'Bearer'
-        })
-        const secured = Object.entries(doc.paths).flatMap(([path, item]) =>
-          Object.entries(item)
-            .filter(([method]) => HTTP_METHODS.has(method))
-            .filter(([, operation]) => (operation.security?.length ?? 0) > 0)
-            .map(([method]) => `${method.toUpperCase()} ${path}`)
-        )
-        expect(secured.toSorted()).toEqual(
-          MATRIX.map((entry) => entry.operation).toSorted()
-        )
+  it.effect('the served document secures exactly the gated operations', () =>
+    Effect.gen(function* () {
+      const res = yield* send(new Request('https://api.test/openapi.json'))
+      const doc = yield* jsonBody(res, OpenApiBody)
+      expect(doc.components.securitySchemes['bearer']).toEqual({
+        type: 'http',
+        scheme: 'Bearer'
       })
-    ))
+      const secured = Object.entries(doc.paths).flatMap(([path, item]) =>
+        Object.entries(item)
+          .filter(([method]) => HTTP_METHODS.has(method))
+          .filter(([, operation]) => (operation.security?.length ?? 0) > 0)
+          .map(([method]) => `${method.toUpperCase()} ${path}`)
+      )
+      expect(secured.toSorted()).toEqual(
+        MATRIX.map((entry) => entry.operation).toSorted()
+      )
+    })
+  )
 
   /**
    * The bucket a group draws from is a row in the contract's table; the
    * middleware dies on a group without one, so assert the table covers every
    * group that carries the gate.
    */
-  test('every group behind the gate names a rate-limit bucket', () => {
+  it('every group behind the gate names a rate-limit bucket', () => {
     const gated = Object.values(StarterApi.groups)
       .filter((group) =>
         Object.values(group.endpoints).some((endpoint) =>
@@ -280,17 +274,17 @@ describe('permission matrix', () => {
     expect(gated).not.toContain('health')
   })
 
-  test.each(MATRIX)(
+  it.effect.each(MATRIX)(
     'a read-only token gets $expected from $operation ($permission)',
     (entry) =>
-      Effect.runPromise(
-        Effect.gen(function* () {
-          const res = yield* send(entry.request)
-          expect(res.status).toBe(entry.expected)
-          if (entry.expected === 403) {
-            expect((yield* jsonBody(res, ErrorBody))._tag).toBe('AuthorizationDenied')
-          }
-        })
-      )
+      Effect.gen(function* () {
+        const res = yield* send(entry.request)
+        // oxlint-disable-next-line vitest/no-standalone-expect -- it.effect.each's double call hides the test block from the rule
+        expect(res.status).toBe(entry.expected)
+        if (entry.expected === 403) {
+          // oxlint-disable-next-line vitest/no-standalone-expect -- same as above
+          expect((yield* jsonBody(res, ErrorBody))._tag).toBe('AuthorizationDenied')
+        }
+      })
   )
 })

--- a/apps/background/src/export-consumer.test.ts
+++ b/apps/background/src/export-consumer.test.ts
@@ -20,7 +20,7 @@ import {
   testWorkspaceContext,
   WorkspaceContext
 } from '@b2b-saas-starter/capabilities/workspace-context'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 import { Effect, Layer } from 'effect'
 
 import {
@@ -157,68 +157,61 @@ function run(
   } = {}
 ) {
   const recorded: Recorded = { completed: [], failed: [] }
-  // The stubs never fail, so the error channel is eliminated with orDie
-  // instead of a cast — the same shape the webhook consumer tests use.
-  return Effect.scoped(
-    Effect.orDie(
-      processWorkspaceExportMessage(
-        readDelivery(WorkspaceExportQueueMessage, {
-          id: 'qmsg_export',
-          body,
-          attempts: options.attempts ?? 1
-        }),
-        options.resolve ?? resolveLab
-      ).pipe(
-        Effect.provide(
-          Layer.mergeAll(stubExports(recorded), stubReads(options.failing ?? false))
-        )
-      )
-    )
-  ).pipe(Effect.map((outcome) => ({ outcome, recorded })))
+  return processWorkspaceExportMessage(
+    readDelivery(WorkspaceExportQueueMessage, {
+      id: 'qmsg_export',
+      body,
+      attempts: options.attempts ?? 1
+    }),
+    options.resolve ?? resolveLab
+  ).pipe(
+    Effect.provide(
+      Layer.mergeAll(stubExports(recorded), stubReads(options.failing ?? false))
+    ),
+    Effect.map((outcome) => ({ outcome, recorded }))
+  )
 }
 
 describe('processWorkspaceExportMessage', () => {
-  it('builds the archive and completes the export', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded } = yield* run(message)
-        expect(outcome).toBe('ack')
-        expect(recorded.failed).toHaveLength(0)
-        expect(recorded.completed).toHaveLength(1)
-        const completed = recorded.completed[0]
-        expect(completed).toMatchObject({ exportId: 'exp_1', workspaceId: 'wrk_1' })
-        // A real gzip container: magic bytes first.
-        expect([...(completed?.archive.subarray(0, 2) ?? [])]).toEqual([0x1f, 0x8b])
-        expect(completed?.archive.length).toBeGreaterThan(22)
-      })
-    ))
+  it.effect('builds the archive and completes the export', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded } = yield* run(message)
+      expect(outcome).toBe('ack')
+      expect(recorded.failed).toHaveLength(0)
+      expect(recorded.completed).toHaveLength(1)
+      const completed = recorded.completed[0]
+      expect(completed).toMatchObject({ exportId: 'exp_1', workspaceId: 'wrk_1' })
+      // A real gzip container: magic bytes first.
+      expect([...(completed?.archive.subarray(0, 2) ?? [])]).toEqual([0x1f, 0x8b])
+      expect(completed?.archive.length).toBeGreaterThan(22)
+    })
+  )
 
-  it('acks a malformed message without touching any row', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded } = yield* run({ exportId: 42 })
-        expect(outcome).toBe('ack')
-        expect(recorded.completed).toHaveLength(0)
-        expect(recorded.failed).toHaveLength(0)
-      })
-    ))
+  it.effect('acks a malformed message without touching any row', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded } = yield* run({ exportId: 42 })
+      expect(outcome).toBe('ack')
+      expect(recorded.completed).toHaveLength(0)
+      expect(recorded.failed).toHaveLength(0)
+    })
+  )
 
-  it('marks the export failed when the slug no longer resolves', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded } = yield* run({ ...message, workspaceSlug: 'gone' })
-        expect(outcome).toBe('ack')
-        expect(recorded.completed).toHaveLength(0)
-        expect(recorded.failed[0]).toMatchObject({
-          exportId: 'exp_1',
-          workspaceId: 'wrk_1',
-          reason: 'workspace_not_found'
-        })
+  it.effect('marks the export failed when the slug no longer resolves', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded } = yield* run({ ...message, workspaceSlug: 'gone' })
+      expect(outcome).toBe('ack')
+      expect(recorded.completed).toHaveLength(0)
+      expect(recorded.failed[0]).toMatchObject({
+        exportId: 'exp_1',
+        workspaceId: 'wrk_1',
+        reason: 'workspace_not_found'
       })
-    ))
+    })
+  )
 
-  it('marks the export failed when the slug resolves to a different workspace', () =>
-    Effect.runPromise(
+  it.effect(
+    'marks the export failed when the slug resolves to a different workspace',
+    () =>
       Effect.gen(function* () {
         const { outcome, recorded } = yield* run({ ...message, workspaceId: 'wrk_old' })
         expect(outcome).toBe('ack')
@@ -228,23 +221,23 @@ describe('processWorkspaceExportMessage', () => {
           reason: 'workspace_mismatch'
         })
       })
-    ))
+  )
 
-  it('retries a store outage while attempts remain', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded } = yield* run(message, {
-          failing: true,
-          attempts: 1
-        })
-        expect(outcome).toBe('retry')
-        expect(recorded.failed).toHaveLength(0)
-        expect(recorded.completed).toHaveLength(0)
+  it.effect('retries a store outage while attempts remain', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded } = yield* run(message, {
+        failing: true,
+        attempts: 1
       })
-    ))
+      expect(outcome).toBe('retry')
+      expect(recorded.failed).toHaveLength(0)
+      expect(recorded.completed).toHaveLength(0)
+    })
+  )
 
-  it('marks the export failed on the last attempt instead of retrying forever', () =>
-    Effect.runPromise(
+  it.effect(
+    'marks the export failed on the last attempt instead of retrying forever',
+    () =>
       Effect.gen(function* () {
         const { outcome, recorded } = yield* run(message, {
           failing: true,
@@ -253,7 +246,7 @@ describe('processWorkspaceExportMessage', () => {
         expect(outcome).toBe('ack')
         expect(recorded.failed[0]?.reason).toMatch(/^unavailable: /)
       })
-    ))
+  )
 })
 
 describe('readDelivery', () => {

--- a/apps/background/src/index.test.ts
+++ b/apps/background/src/index.test.ts
@@ -1,13 +1,12 @@
 import { type WebhookDeliveryAttemptInput } from '@b2b-saas-starter/capabilities/developer-platform/webhook-delivery-plan'
 import { WebhookEndpoints } from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
 import { WebhookQueueMessage } from '@b2b-saas-starter/capabilities/developer-platform/webhook-publisher'
-import { type CapabilityUnavailable } from '@b2b-saas-starter/capabilities/errors'
 import {
   NotificationFeed,
   type CreateNotificationInput
 } from '@b2b-saas-starter/capabilities/notifications/notification-feed'
-import { describe, expect, it } from 'vite-plus/test'
-import { Effect, Layer, type Scope } from 'effect'
+import { describe, expect, it } from '@effect/vitest'
+import { Effect, Layer } from 'effect'
 import {
   HttpClient,
   HttpClientResponse,
@@ -25,40 +24,38 @@ import { readDelivery } from './queue-consumer.ts'
 // this file owns is the worker's orchestration around them.
 
 describe('webhook signature', () => {
-  it('matches the fixed HMAC-SHA256 vector over "<timestamp>.<body>"', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const secret = 'whsec_test'
-        const timestamp = 1_700_000_000
-        const body =
-          '{"deliveryId":"whd_test","eventType":"demo.event","payload":{"hello":"world"}}'
-        const signature = yield* computeWebhookSignature(secret, timestamp, body)
-        expect(signature).toBe(
-          '869b9de1fa743616d6143977e0a770f55f7cfd874cba33d935c1bfb5b481f9b2'
-        )
-        expect(signatureHeaderValue(timestamp, [signature])).toBe(
-          't=1700000000,sha256=869b9de1fa743616d6143977e0a770f55f7cfd874cba33d935c1bfb5b481f9b2'
-        )
-      })
-    ))
+  it.effect('matches the fixed HMAC-SHA256 vector over "<timestamp>.<body>"', () =>
+    Effect.gen(function* () {
+      const secret = 'whsec_test'
+      const timestamp = 1_700_000_000
+      const body =
+        '{"deliveryId":"whd_test","eventType":"demo.event","payload":{"hello":"world"}}'
+      const signature = yield* computeWebhookSignature(secret, timestamp, body)
+      expect(signature).toBe(
+        '869b9de1fa743616d6143977e0a770f55f7cfd874cba33d935c1bfb5b481f9b2'
+      )
+      expect(signatureHeaderValue(timestamp, [signature])).toBe(
+        't=1700000000,sha256=869b9de1fa743616d6143977e0a770f55f7cfd874cba33d935c1bfb5b481f9b2'
+      )
+    })
+  )
 
-  it('lists one sha256 entry per active signing secret on the header', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const timestamp = 1_700_000_000
-        const body = '{"hello":"world"}'
-        const signatures = [
-          yield* computeWebhookSignature('whsec_new', timestamp, body),
-          yield* computeWebhookSignature('whsec_old', timestamp, body)
-        ]
-        // The rotation-grace shape: `t=` first, then one sha256 per secret, in
-        // signing order (current secret first).
-        const header = signatureHeaderValue(timestamp, signatures)
-        expect(header).toMatch(/^t=1700000000,sha256=[0-9a-f]{64},sha256=[0-9a-f]{64}$/)
-        expect(header).toContain(signatures[1])
-        expect(signatures[0]).not.toBe(signatures[1])
-      })
-    ))
+  it.effect('lists one sha256 entry per active signing secret on the header', () =>
+    Effect.gen(function* () {
+      const timestamp = 1_700_000_000
+      const body = '{"hello":"world"}'
+      const signatures = [
+        yield* computeWebhookSignature('whsec_new', timestamp, body),
+        yield* computeWebhookSignature('whsec_old', timestamp, body)
+      ]
+      // The rotation-grace shape: `t=` first, then one sha256 per secret, in
+      // signing order (current secret first).
+      const header = signatureHeaderValue(timestamp, signatures)
+      expect(header).toMatch(/^t=1700000000,sha256=[0-9a-f]{64},sha256=[0-9a-f]{64}$/)
+      expect(header).toContain(signatures[1])
+      expect(signatures[0]).not.toBe(signatures[1])
+    })
+  )
 })
 
 const message: WebhookQueueMessage = {
@@ -168,14 +165,6 @@ function stubFeed(
  */
 type CapturedRequest = { request?: HttpClientRequest.HttpClientRequest }
 
-// Both consumers surface D1 outages as CapabilityUnavailable; the stubs never
-// fail, so the error channel is eliminated with orDie instead of a cast.
-function runScoped<A>(
-  effect: Effect.Effect<A, CapabilityUnavailable, Scope.Scope>
-): Effect.Effect<A> {
-  return Effect.scoped(Effect.orDie(effect))
-}
-
 describe('processWebhookMessage', () => {
   function stubHttp(
     status: number,
@@ -191,6 +180,9 @@ describe('processWebhookMessage', () => {
     )
   }
 
+  // Both consumers surface D1 outages as CapabilityUnavailable, which now
+  // simply fails the test under `it.effect` — the stubs never fail, so a
+  // failure here is a real signal, not noise.
   function run(
     dispatchTarget: typeof target | null,
     status: number,
@@ -201,132 +193,125 @@ describe('processWebhookMessage', () => {
     const recorded: Array<WebhookDeliveryAttemptInput> = []
     const created: Array<CreateNotificationInput> = []
     const captured: CapturedRequest = {}
-    return runScoped(
-      processWebhookMessage(
-        readDelivery(WebhookQueueMessage, { id: messageId, body: input, attempts }),
-        'trace-test'
-      ).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            stubEndpoints(dispatchTarget, recorded),
-            stubFeed(created),
-            stubHttp(status, captured)
-          )
+    return processWebhookMessage(
+      readDelivery(WebhookQueueMessage, { id: messageId, body: input, attempts }),
+      'trace-test'
+    ).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          stubEndpoints(dispatchTarget, recorded),
+          stubFeed(created),
+          stubHttp(status, captured)
         )
-      )
-    ).pipe(Effect.map((outcome) => ({ outcome, recorded, created, captured })))
+      ),
+      Effect.map((outcome) => ({ outcome, recorded, created, captured }))
+    )
   }
 
-  it('delivers on 2xx, signs the request, and persists a delivered row', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded, captured } = yield* run(target, 200)
-        expect(outcome).toBe('ack')
-        expect(recorded).toHaveLength(1)
-        expect(recorded[0]).toMatchObject({
-          endpointId: 'wh_1',
-          eventType: 'api_token.created',
-          status: 'delivered',
-          responseStatus: 200,
-          nextAttemptAt: null,
-          // Operator evidence: what was sent...
-          payload: { hello: 'world' },
-          requestHeaders: {
-            'x-b2b-starter-event': 'api_token.created'
-          }
-        })
-        const headers: Record<string, string | undefined> =
-          captured.request?.headers ?? {}
-        expect(headers['x-b2b-starter-event']).toBe('api_token.created')
-        expect(headers['x-b2b-starter-signature']).toMatch(
-          /^t=\d+,sha256=[0-9a-f]{64}$/
-        )
-        expect(headers['x-trace-id']).toBe('trace-test')
-        // The exact header block the consumer recorded is the one it posted.
-        expect(recorded[0]?.requestHeaders?.['x-b2b-starter-signature']).toBe(
-          headers['x-b2b-starter-signature']
-        )
-        // A null response body records the empty string, not a fabricated one.
-        expect(recorded[0]?.responseBody).toBe('')
-      })
-    ))
-
-  it('dual-signs while a rotated secret is inside its grace window', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded, captured } = yield* run(rotatingTarget, 200)
-        expect(outcome).toBe('ack')
-        const headers: Record<string, string | undefined> =
-          captured.request?.headers ?? {}
-        const header = headers['x-b2b-starter-signature'] ?? ''
-        // Two entries: the current secret signs first, the replaced one second.
-        const entries = header.split(',').filter((part) => part.startsWith('sha256='))
-        expect(entries).toHaveLength(2)
-        // Recompute both signatures over the exact bytes the request carried.
-        const requestBody = captured.request?.body
-        expect(requestBody?._tag).toBe('Uint8Array')
-        let bodyText = ''
-        if (requestBody?._tag === 'Uint8Array') {
-          bodyText = new TextDecoder().decode(requestBody.body)
+  it.effect('delivers on 2xx, signs the request, and persists a delivered row', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded, captured } = yield* run(target, 200)
+      expect(outcome).toBe('ack')
+      expect(recorded).toHaveLength(1)
+      expect(recorded[0]).toMatchObject({
+        endpointId: 'wh_1',
+        eventType: 'api_token.created',
+        status: 'delivered',
+        responseStatus: 200,
+        nextAttemptAt: null,
+        // Operator evidence: what was sent...
+        payload: { hello: 'world' },
+        requestHeaders: {
+          'x-b2b-starter-event': 'api_token.created'
         }
-        const timestamp = Number(header.match(/^t=(\d+)/)?.[1])
-        const expectedFirst = yield* computeWebhookSignature(
-          'whsec_new',
-          timestamp,
-          bodyText
-        )
-        const expectedSecond = yield* computeWebhookSignature(
-          'whsec_old',
-          timestamp,
-          bodyText
-        )
-        expect(entries[0]).toBe(`sha256=${expectedFirst}`)
-        expect(entries[1]).toBe(`sha256=${expectedSecond}`)
-        // The recorded evidence carries the same dual-signature header.
-        expect(recorded[0]?.requestHeaders?.['x-b2b-starter-signature']).toBe(header)
       })
-    ))
+      const headers: Record<string, string | undefined> =
+        captured.request?.headers ?? {}
+      expect(headers['x-b2b-starter-event']).toBe('api_token.created')
+      expect(headers['x-b2b-starter-signature']).toMatch(/^t=\d+,sha256=[0-9a-f]{64}$/)
+      expect(headers['x-trace-id']).toBe('trace-test')
+      // The exact header block the consumer recorded is the one it posted.
+      expect(recorded[0]?.requestHeaders?.['x-b2b-starter-signature']).toBe(
+        headers['x-b2b-starter-signature']
+      )
+      // A null response body records the empty string, not a fabricated one.
+      expect(recorded[0]?.responseBody).toBe('')
+    })
+  )
 
-  it('retries on 5xx and persists the backoff-aligned next attempt', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded } = yield* run(target, 500, 2)
-        expect(outcome).toBe('retry')
-        expect(recorded[0]).toMatchObject({ status: 'failed', responseStatus: 500 })
-        expect(recorded[0]?.nextAttemptAt).toBeTruthy()
-      })
-    ))
+  it.effect('dual-signs while a rotated secret is inside its grace window', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded, captured } = yield* run(rotatingTarget, 200)
+      expect(outcome).toBe('ack')
+      const headers: Record<string, string | undefined> =
+        captured.request?.headers ?? {}
+      const header = headers['x-b2b-starter-signature'] ?? ''
+      // Two entries: the current secret signs first, the replaced one second.
+      const entries = header.split(',').filter((part) => part.startsWith('sha256='))
+      expect(entries).toHaveLength(2)
+      // Recompute both signatures over the exact bytes the request carried.
+      const requestBody = captured.request?.body
+      expect(requestBody?._tag).toBe('Uint8Array')
+      let bodyText = ''
+      if (requestBody?._tag === 'Uint8Array') {
+        bodyText = new TextDecoder().decode(requestBody.body)
+      }
+      const timestamp = Number(header.match(/^t=(\d+)/)?.[1])
+      const expectedFirst = yield* computeWebhookSignature(
+        'whsec_new',
+        timestamp,
+        bodyText
+      )
+      const expectedSecond = yield* computeWebhookSignature(
+        'whsec_old',
+        timestamp,
+        bodyText
+      )
+      expect(entries[0]).toBe(`sha256=${expectedFirst}`)
+      expect(entries[1]).toBe(`sha256=${expectedSecond}`)
+      // The recorded evidence carries the same dual-signature header.
+      expect(recorded[0]?.requestHeaders?.['x-b2b-starter-signature']).toBe(header)
+    })
+  )
 
-  it('derives one stable deliveryId per queue message across redeliveries', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        // Two independent runs stand in for attempt 1 and its redelivery: the
-        // envelope id is the identity, so both must persist — and sign — the
-        // same deliveryId even though each run is a fresh invocation.
-        const firstAttempt = yield* run(target, 500, 1, message, 'qmsg_1')
-        const redelivery = yield* run(target, 200, 2, message, 'qmsg_1')
-        expect(firstAttempt.recorded[0]?.id).toBe('whd_qmsg_1')
-        expect(redelivery.recorded[0]?.id).toBe('whd_qmsg_1')
-        // The signed body carries the same id it persists (same variable in
-        // processWebhookMessage), so receiver dedup on the body's deliveryId
-        // collapses both attempts.
-      })
-    ))
+  it.effect('retries on 5xx and persists the backoff-aligned next attempt', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded } = yield* run(target, 500, 2)
+      expect(outcome).toBe('retry')
+      expect(recorded[0]).toMatchObject({ status: 'failed', responseStatus: 500 })
+      expect(recorded[0]?.nextAttemptAt).toBeTruthy()
+    })
+  )
 
-  it('prefers the deliveryId an operator dispatch stamped on the message', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        // A replay's pending row exists before the message is enqueued; the
-        // consumer must resolve that row, not mint a queue-derived one.
-        const replayedMessage = { ...message, deliveryId: 'whd_replayed_row' }
-        const { recorded } = yield* run(target, 200, 1, replayedMessage, 'qmsg_9')
-        expect(recorded[0]?.id).toBe('whd_replayed_row')
-        expect(recorded[0]?.status).toBe('delivered')
-      })
-    ))
+  it.effect('derives one stable deliveryId per queue message across redeliveries', () =>
+    Effect.gen(function* () {
+      // Two independent runs stand in for attempt 1 and its redelivery: the
+      // envelope id is the identity, so both must persist — and sign — the
+      // same deliveryId even though each run is a fresh invocation.
+      const firstAttempt = yield* run(target, 500, 1, message, 'qmsg_1')
+      const redelivery = yield* run(target, 200, 2, message, 'qmsg_1')
+      expect(firstAttempt.recorded[0]?.id).toBe('whd_qmsg_1')
+      expect(redelivery.recorded[0]?.id).toBe('whd_qmsg_1')
+      // The signed body carries the same id it persists (same variable in
+      // processWebhookMessage), so receiver dedup on the body's deliveryId
+      // collapses both attempts.
+    })
+  )
 
-  it('acks a non-retryable 4xx as failed_permanent with the audit workspace id', () =>
-    Effect.runPromise(
+  it.effect('prefers the deliveryId an operator dispatch stamped on the message', () =>
+    Effect.gen(function* () {
+      // A replay's pending row exists before the message is enqueued; the
+      // consumer must resolve that row, not mint a queue-derived one.
+      const replayedMessage = { ...message, deliveryId: 'whd_replayed_row' }
+      const { recorded } = yield* run(target, 200, 1, replayedMessage, 'qmsg_9')
+      expect(recorded[0]?.id).toBe('whd_replayed_row')
+      expect(recorded[0]?.status).toBe('delivered')
+    })
+  )
+
+  it.effect(
+    'acks a non-retryable 4xx as failed_permanent with the audit workspace id',
+    () =>
       Effect.gen(function* () {
         const { outcome, recorded, created } = yield* run(target, 404)
         expect(outcome).toBe('ack')
@@ -346,43 +331,41 @@ describe('processWebhookMessage', () => {
         })
         expect(created[0]?.message).toContain('https://example.com/hook')
       })
-    ))
+  )
 
-  it('creates no notification for a delivered or retried attempt', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const delivered = yield* run(target, 200)
-        const retried = yield* run(target, 500)
-        expect(delivered.created).toHaveLength(0)
-        expect(retried.created).toHaveLength(0)
+  it.effect('creates no notification for a delivered or retried attempt', () =>
+    Effect.gen(function* () {
+      const delivered = yield* run(target, 200)
+      const retried = yield* run(target, 500)
+      expect(delivered.created).toHaveLength(0)
+      expect(retried.created).toHaveLength(0)
+    })
+  )
+
+  it.effect('acks a disabled endpoint without recording an attempt', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded, captured } = yield* run(null, 200)
+      expect(outcome).toBe('ack')
+      expect(recorded).toHaveLength(0)
+      expect(captured.request).toBeUndefined()
+    })
+  )
+
+  it.effect('acks a malformed queue message without dispatching or recording', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded, captured } = yield* run(target, 200, 1, {
+        endpointId: 42,
+        payload: {}
       })
-    ))
+      expect(outcome).toBe('ack')
+      expect(recorded).toHaveLength(0)
+      expect(captured.request).toBeUndefined()
+    })
+  )
 
-  it('acks a disabled endpoint without recording an attempt', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded, captured } = yield* run(null, 200)
-        expect(outcome).toBe('ack')
-        expect(recorded).toHaveLength(0)
-        expect(captured.request).toBeUndefined()
-      })
-    ))
-
-  it('acks a malformed queue message without dispatching or recording', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded, captured } = yield* run(target, 200, 1, {
-          endpointId: 42,
-          payload: {}
-        })
-        expect(outcome).toBe('ack')
-        expect(recorded).toHaveLength(0)
-        expect(captured.request).toBeUndefined()
-      })
-    ))
-
-  it('treats a message without a workspaceId as malformed (legacy in-flight shape)', () =>
-    Effect.runPromise(
+  it.effect(
+    'treats a message without a workspaceId as malformed (legacy in-flight shape)',
+    () =>
       Effect.gen(function* () {
         const { outcome, recorded, captured } = yield* run(target, 200, 1, {
           endpointId: 'wh_1',
@@ -393,74 +376,68 @@ describe('processWebhookMessage', () => {
         expect(recorded).toHaveLength(0)
         expect(captured.request).toBeUndefined()
       })
-    ))
+  )
 
-  it('acks a cross-workspace message without releasing the signing secret', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded, captured } = yield* run(target, 200, 1, {
-          ...message,
-          workspaceId: 'ws_other'
-        })
-        expect(outcome).toBe('ack')
-        expect(recorded).toHaveLength(0)
-        expect(captured.request).toBeUndefined()
+  it.effect('acks a cross-workspace message without releasing the signing secret', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded, captured } = yield* run(target, 200, 1, {
+        ...message,
+        workspaceId: 'ws_other'
       })
-    ))
+      expect(outcome).toBe('ack')
+      expect(recorded).toHaveLength(0)
+      expect(captured.request).toBeUndefined()
+    })
+  )
 
-  it('acks an SSRF-invalid target as failed_permanent without dispatching', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, recorded, captured } = yield* run(
-          { ...target, url: 'https://127.0.0.1/hook' },
-          200
-        )
-        expect(outcome).toBe('ack')
-        expect(recorded[0]).toMatchObject({
-          status: 'failed_permanent',
-          responseStatus: null,
-          workspaceId: 'ws_1'
-        })
-        expect(captured.request).toBeUndefined()
+  it.effect('acks an SSRF-invalid target as failed_permanent without dispatching', () =>
+    Effect.gen(function* () {
+      const { outcome, recorded, captured } = yield* run(
+        { ...target, url: 'https://127.0.0.1/hook' },
+        200
+      )
+      expect(outcome).toBe('ack')
+      expect(recorded[0]).toMatchObject({
+        status: 'failed_permanent',
+        responseStatus: null,
+        workspaceId: 'ws_1'
       })
-    ))
+      expect(captured.request).toBeUndefined()
+    })
+  )
 })
 
 describe('processDeadLetterMessage', () => {
-  function runDeadLetter(
-    input: unknown,
-    attempts = 4
-  ): Effect.Effect<Array<WebhookDeliveryAttemptInput>> {
+  function runDeadLetter(input: unknown, attempts = 4) {
     const recorded: Array<WebhookDeliveryAttemptInput> = []
-    return runScoped(
-      processDeadLetterMessage(
-        readDelivery(WebhookQueueMessage, { id: 'qmsg_dead', body: input, attempts })
-      ).pipe(Effect.provide(Layer.merge(stubEndpoints(target, recorded), stubFeed([]))))
-    ).pipe(Effect.map(() => recorded))
+    return processDeadLetterMessage(
+      readDelivery(WebhookQueueMessage, { id: 'qmsg_dead', body: input, attempts })
+    ).pipe(
+      Effect.provide(Layer.merge(stubEndpoints(target, recorded), stubFeed([]))),
+      Effect.map(() => recorded)
+    )
   }
 
-  it('records a dead_lettered row carrying the audit workspace id', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const recorded = yield* runDeadLetter(message)
-        expect(recorded).toHaveLength(1)
-        expect(recorded[0]).toMatchObject({
-          endpointId: 'wh_1',
-          workspaceId: 'ws_1',
-          eventType: 'api_token.created',
-          status: 'dead_lettered',
-          attempts: 4,
-          responseStatus: null,
-          nextAttemptAt: null
-        })
+  it.effect('records a dead_lettered row carrying the audit workspace id', () =>
+    Effect.gen(function* () {
+      const recorded = yield* runDeadLetter(message)
+      expect(recorded).toHaveLength(1)
+      expect(recorded[0]).toMatchObject({
+        endpointId: 'wh_1',
+        workspaceId: 'ws_1',
+        eventType: 'api_token.created',
+        status: 'dead_lettered',
+        attempts: 4,
+        responseStatus: null,
+        nextAttemptAt: null
       })
-    ))
+    })
+  )
 
-  it('acks a malformed dead letter without recording', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const recorded = yield* runDeadLetter({ endpointId: 42 })
-        expect(recorded).toHaveLength(0)
-      })
-    ))
+  it.effect('acks a malformed dead letter without recording', () =>
+    Effect.gen(function* () {
+      const recorded = yield* runDeadLetter({ endpointId: 42 })
+      expect(recorded).toHaveLength(0)
+    })
+  )
 })

--- a/apps/background/src/notification-email-consumer.test.ts
+++ b/apps/background/src/notification-email-consumer.test.ts
@@ -14,7 +14,7 @@ import {
   type EmailMessage
 } from '@b2b-saas-starter/email'
 import { render } from '@react-email/render'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 import { Effect, Layer } from 'effect'
 
 import { processNotificationEmailMessage } from './notification-email-consumer.ts'
@@ -93,79 +93,73 @@ function run(
     })
   }
   const preferences = SeedNotificationPreferences(stored).pipe(Layer.provide(audit))
-  return Effect.scoped(
-    processNotificationEmailMessage(
-      readDelivery(NotificationEmailQueueMessage, {
-        id: 'q1',
-        body,
-        attempts: 1
-      }),
-      'https://app.test'
-    ).pipe(
-      Effect.provide(
-        Layer.mergeAll(stubFeed(found), preferences, stubDispatcher(sent, options.fail))
-      )
-    )
-  ).pipe(Effect.map((outcome) => ({ outcome, sent })))
+  return processNotificationEmailMessage(
+    readDelivery(NotificationEmailQueueMessage, {
+      id: 'q1',
+      body,
+      attempts: 1
+    }),
+    'https://app.test'
+  ).pipe(
+    Effect.provide(
+      Layer.mergeAll(stubFeed(found), preferences, stubDispatcher(sent, options.fail))
+    ),
+    Effect.map((outcome) => ({ outcome, sent }))
+  )
 }
 
 const message = { notificationId: 'not_1', recipientUserId: 'usr_owner' }
 
 describe('processNotificationEmailMessage', () => {
-  it('renders the kind template and sends it to the recipient', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, sent } = yield* run(context, message)
-        expect(outcome).toBe('ack')
-        expect(sent).toHaveLength(1)
-        expect(sent[0]?.to).toBe('owner@example.com')
-        expect(sent[0]?.subject).toBe(
-          '[B2B SaaS Starter] API token created: API token created'
-        )
-        const html = yield* Effect.promise(() => render(sent[0]!.element))
-        expect(html).toContain('Ops Lead minted')
-        expect(html).toContain('https://app.test/workspaces/starter-lab/api-tokens')
-        expect(html).toContain(
-          'https://app.test/account/notifications?kind=api_token.created'
-        )
-      })
-    ))
+  it.effect('renders the kind template and sends it to the recipient', () =>
+    Effect.gen(function* () {
+      const { outcome, sent } = yield* run(context, message)
+      expect(outcome).toBe('ack')
+      expect(sent).toHaveLength(1)
+      expect(sent[0]?.to).toBe('owner@example.com')
+      expect(sent[0]?.subject).toBe(
+        '[B2B SaaS Starter] API token created: API token created'
+      )
+      const html = yield* Effect.promise(() => render(sent[0]!.element))
+      expect(html).toContain('Ops Lead minted')
+      expect(html).toContain('https://app.test/workspaces/starter-lab/api-tokens')
+      expect(html).toContain(
+        'https://app.test/account/notifications?kind=api_token.created'
+      )
+    })
+  )
 
-  it('acks without sending when the recipient moved the kind off instant', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const digest = yield* run(context, message, { channel: 'digest' })
-        const off = yield* run(context, message, { channel: 'off' })
-        expect(digest).toEqual({ outcome: 'ack', sent: [] })
-        expect(off).toEqual({ outcome: 'ack', sent: [] })
-      })
-    ))
+  it.effect('acks without sending when the recipient moved the kind off instant', () =>
+    Effect.gen(function* () {
+      const digest = yield* run(context, message, { channel: 'digest' })
+      const off = yield* run(context, message, { channel: 'off' })
+      expect(digest).toEqual({ outcome: 'ack', sent: [] })
+      expect(off).toEqual({ outcome: 'ack', sent: [] })
+    })
+  )
 
-  it('acks without sending when the notification is gone or already read', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, sent } = yield* run(null, message)
-        expect(outcome).toBe('ack')
-        expect(sent).toHaveLength(0)
-      })
-    ))
+  it.effect('acks without sending when the notification is gone or already read', () =>
+    Effect.gen(function* () {
+      const { outcome, sent } = yield* run(null, message)
+      expect(outcome).toBe('ack')
+      expect(sent).toHaveLength(0)
+    })
+  )
 
-  it('acks a malformed message as terminal', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome, sent } = yield* run(context, { notificationId: 42 })
-        expect(outcome).toBe('ack')
-        expect(sent).toHaveLength(0)
-      })
-    ))
+  it.effect('acks a malformed message as terminal', () =>
+    Effect.gen(function* () {
+      const { outcome, sent } = yield* run(context, { notificationId: 42 })
+      expect(outcome).toBe('ack')
+      expect(sent).toHaveLength(0)
+    })
+  )
 
-  it('surfaces a send failure so the queue retries', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const error = yield* Effect.flip(run(context, message, { fail: true }))
-        expect(error._tag).toBe('EmailSendError')
-      })
-    ))
+  it.effect('surfaces a send failure so the queue retries', () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(run(context, message, { fail: true }))
+      expect(error._tag).toBe('EmailSendError')
+    })
+  )
 })
 
 describe('notification links', () => {

--- a/apps/background/src/seat-sync-consumer.test.ts
+++ b/apps/background/src/seat-sync-consumer.test.ts
@@ -5,7 +5,7 @@ import {
 import { CapabilityUnavailable } from '@b2b-saas-starter/capabilities/errors'
 import { SeatSyncQueueMessage } from '@b2b-saas-starter/capabilities/billing/seat-sync'
 import { Effect, Layer } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 
 import { processSeatSyncMessage } from './seat-sync-consumer.ts'
 import {
@@ -42,11 +42,9 @@ function stubBilling(
 
 function run(body: unknown, billing: Layer.Layer<Billing>) {
   return Effect.map(
-    Effect.scoped(
-      processSeatSyncMessage(
-        readDelivery(SeatSyncQueueMessage, { id: 'qmsg_seat', body, attempts: 0 })
-      ).pipe(Effect.provide(billing))
-    ),
+    processSeatSyncMessage(
+      readDelivery(SeatSyncQueueMessage, { id: 'qmsg_seat', body, attempts: 0 })
+    ).pipe(Effect.provide(billing)),
     (outcome) => ({ outcome })
   )
 }
@@ -91,94 +89,87 @@ describe('readDelivery', () => {
 })
 
 describe('processSeatSyncMessage', () => {
-  it('acks an honest no-op outcome', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls: Array<SyncCall> = []
-        const { outcome } = yield* run(
+  it.effect('acks an honest no-op outcome', () =>
+    Effect.gen(function* () {
+      const calls: Array<SyncCall> = []
+      const { outcome } = yield* run(
+        message,
+        stubBilling(calls, () =>
+          Effect.succeed({ outcome: 'no_subscription', quantity: null })
+        )
+      )
+      expect(outcome).toBe<DeliveryOutcome>('ack')
+      expect(calls).toEqual([{ workspaceId: 'wrk_starter', reason: 'member_added' }])
+    })
+  )
+
+  it.effect('acks a synced outcome', () =>
+    Effect.gen(function* () {
+      const { outcome } = yield* run(
+        message,
+        stubBilling([], () => Effect.succeed({ outcome: 'synced', quantity: 5 }))
+      )
+      expect(outcome).toBe<DeliveryOutcome>('ack')
+    })
+  )
+
+  it.effect('acks a malformed message without calling the capability', () =>
+    Effect.gen(function* () {
+      const calls: Array<SyncCall> = []
+      const { outcome } = yield* run(
+        { nope: true },
+        stubBilling(calls, () => Effect.die('not reached'))
+      )
+      expect(outcome).toBe<DeliveryOutcome>('ack')
+      expect(calls).toEqual([])
+    })
+  )
+
+  it.effect('propagates a provider failure for the consumer entry to fold', () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        run(
           message,
-          stubBilling(calls, () =>
-            Effect.succeed({ outcome: 'no_subscription', quantity: null })
-          )
-        )
-        expect(outcome).toBe<DeliveryOutcome>('ack')
-        expect(calls).toEqual([{ workspaceId: 'wrk_starter', reason: 'member_added' }])
-      })
-    ))
-
-  it('acks a synced outcome', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { outcome } = yield* run(
-          message,
-          stubBilling([], () => Effect.succeed({ outcome: 'synced', quantity: 5 }))
-        )
-        expect(outcome).toBe<DeliveryOutcome>('ack')
-      })
-    ))
-
-  it('acks a malformed message without calling the capability', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls: Array<SyncCall> = []
-        const { outcome } = yield* run(
-          { nope: true },
-          stubBilling(calls, () => Effect.die('not reached'))
-        )
-        expect(outcome).toBe<DeliveryOutcome>('ack')
-        expect(calls).toEqual([])
-      })
-    ))
-
-  it('propagates a provider failure for the consumer entry to fold', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const error = yield* Effect.flip(
-          run(
-            message,
-            stubBilling([], () =>
-              Effect.fail(
-                new CapabilityUnavailable({
-                  capability: 'billing',
-                  reason: 'stripe request failed'
-                })
-              )
+          stubBilling([], () =>
+            Effect.fail(
+              new CapabilityUnavailable({
+                capability: 'billing',
+                reason: 'stripe request failed'
+              })
             )
           )
         )
-        expect(error._tag).toBe('CapabilityUnavailable')
-      })
-    ))
+      )
+      expect(error._tag).toBe('CapabilityUnavailable')
+    })
+  )
 
-  it("folds an escaped provider failure into the entry's retry outcome", () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        // The fold in `consumerInvocation` — outside `withTriggerScope`, so
-        // the wide event exits with the cause before it becomes an outcome —
-        // went from dead code to the load-bearing path for every retryable
-        // consumer when the per-consumer wrapper was deleted. Drive it
-        // directly: a program that fails must answer `retry`.
-        const outcome = yield* Effect.scoped(
-          consumerInvocation(
-            {},
-            {
-              event: 'seat_sync',
-              delivery: readDelivery(SeatSyncQueueMessage, {
-                id: 'qmsg_fold',
-                body: message,
-                attempts: 1
-              }),
-              program: Effect.fail(
-                new CapabilityUnavailable({
-                  capability: 'billing',
-                  reason: 'stripe request failed'
-                })
-              ),
-              onFailure: 'retry'
-            }
-          )
-        )
-        expect(outcome).toBe<DeliveryOutcome>('retry')
-      })
-    ))
+  it.effect("folds an escaped provider failure into the entry's retry outcome", () =>
+    Effect.gen(function* () {
+      // The fold in `consumerInvocation` — outside `withTriggerScope`, so
+      // the wide event exits with the cause before it becomes an outcome —
+      // went from dead code to the load-bearing path for every retryable
+      // consumer when the per-consumer wrapper was deleted. Drive it
+      // directly: a program that fails must answer `retry`.
+      const outcome = yield* consumerInvocation(
+        {},
+        {
+          event: 'seat_sync',
+          delivery: readDelivery(SeatSyncQueueMessage, {
+            id: 'qmsg_fold',
+            body: message,
+            attempts: 1
+          }),
+          program: Effect.fail(
+            new CapabilityUnavailable({
+              capability: 'billing',
+              reason: 'stripe request failed'
+            })
+          ),
+          onFailure: 'retry'
+        }
+      )
+      expect(outcome).toBe<DeliveryOutcome>('retry')
+    })
+  )
 })

--- a/apps/background/src/stripe-endpoint.test.ts
+++ b/apps/background/src/stripe-endpoint.test.ts
@@ -3,7 +3,7 @@ import {
   type ApplySubscriptionEventInput
 } from '@b2b-saas-starter/capabilities/billing/billing'
 import { Effect, Layer } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 
 import checkoutCompleted from './fixtures/stripe/checkout.session.completed.json'
 import subscriptionCreated from './fixtures/stripe/customer.subscription.created.json'
@@ -57,131 +57,122 @@ function payloadOf(fixture: unknown): string {
 function run(fixture: unknown) {
   const calls: RecordedCalls = { plans: [], subscriptions: [] }
   return Effect.map(
-    Effect.scoped(
-      processStripeEvent(payloadOf(fixture)).pipe(
-        Effect.provide(recordingBilling(calls))
-      )
+    processStripeEvent(payloadOf(fixture)).pipe(
+      Effect.provide(recordingBilling(calls))
     ),
     () => calls
   )
 }
 
 describe('processStripeEvent', () => {
-  it('maps checkout completion to a plan change plus a subscription link', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls = yield* run(checkoutCompleted)
-        expect(calls.plans).toEqual([
-          {
-            workspaceId: 'wrk_starter',
-            planId: 'team',
-            detail: { source: 'checkout.session.completed' }
-          }
-        ])
-        expect(calls.subscriptions).toEqual([
-          {
-            workspaceId: 'wrk_starter',
-            customerId: 'cus_seed_starter_lab',
-            subscriptionId: 'sub_seed_starter_lab',
-            subscriptionItemId: undefined,
-            quantity: undefined,
-            deleted: undefined,
-            detail: { source: 'checkout.session.completed' }
-          }
-        ])
-      })
-    ))
-
-  it('reconciles the seat quantity from a subscription update', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls = yield* run(subscriptionUpdated)
-        // No plan change rides a quantity update — the checkout already set it.
-        expect(calls.plans).toEqual([])
-        expect(calls.subscriptions).toEqual([
-          {
-            workspaceId: 'wrk_starter',
-            customerId: 'cus_seed_starter_lab',
-            subscriptionId: 'sub_seed_starter_lab',
-            subscriptionItemId: 'si_seed_starter_lab',
-            quantity: 6,
-            deleted: undefined,
-            detail: { source: 'customer.subscription.updated' }
-          }
-        ])
-      })
-    ))
-
-  it('maps deletion to the downgrade plus a seat-item detach', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls = yield* run(subscriptionDeleted)
-        expect(calls.plans).toEqual([
-          {
-            workspaceId: 'wrk_starter',
-            planId: 'starter',
-            detail: { source: 'customer.subscription.deleted' }
-          }
-        ])
-        expect(calls.subscriptions).toEqual([
-          {
-            workspaceId: 'wrk_starter',
-            customerId: undefined,
-            subscriptionId: undefined,
-            subscriptionItemId: undefined,
-            quantity: undefined,
-            deleted: true,
-            detail: { source: 'customer.subscription.deleted' }
-          }
-        ])
-      })
-    ))
-
-  it('records the first subscription state without a plan change', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls = yield* run(subscriptionCreated)
-        expect(calls.plans).toEqual([])
-        expect(calls.subscriptions[0]).toMatchObject({
+  it.effect('maps checkout completion to a plan change plus a subscription link', () =>
+    Effect.gen(function* () {
+      const calls = yield* run(checkoutCompleted)
+      expect(calls.plans).toEqual([
+        {
           workspaceId: 'wrk_starter',
+          planId: 'team',
+          detail: { source: 'checkout.session.completed' }
+        }
+      ])
+      expect(calls.subscriptions).toEqual([
+        {
+          workspaceId: 'wrk_starter',
+          customerId: 'cus_seed_starter_lab',
+          subscriptionId: 'sub_seed_starter_lab',
+          subscriptionItemId: undefined,
+          quantity: undefined,
+          deleted: undefined,
+          detail: { source: 'checkout.session.completed' }
+        }
+      ])
+    })
+  )
+
+  it.effect('reconciles the seat quantity from a subscription update', () =>
+    Effect.gen(function* () {
+      const calls = yield* run(subscriptionUpdated)
+      // No plan change rides a quantity update — the checkout already set it.
+      expect(calls.plans).toEqual([])
+      expect(calls.subscriptions).toEqual([
+        {
+          workspaceId: 'wrk_starter',
+          customerId: 'cus_seed_starter_lab',
+          subscriptionId: 'sub_seed_starter_lab',
           subscriptionItemId: 'si_seed_starter_lab',
-          quantity: 4
-        })
-      })
-    ))
+          quantity: 6,
+          deleted: undefined,
+          detail: { source: 'customer.subscription.updated' }
+        }
+      ])
+    })
+  )
 
-  it('ignores unhandled event types without calling the capability', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls = yield* run({
-          type: 'invoice.paid',
-          data: { object: { customer: 'cus_seed_starter_lab' } }
-        })
-        expect(calls.plans).toEqual([])
-        expect(calls.subscriptions).toEqual([])
-      })
-    ))
+  it.effect('maps deletion to the downgrade plus a seat-item detach', () =>
+    Effect.gen(function* () {
+      const calls = yield* run(subscriptionDeleted)
+      expect(calls.plans).toEqual([
+        {
+          workspaceId: 'wrk_starter',
+          planId: 'starter',
+          detail: { source: 'customer.subscription.deleted' }
+        }
+      ])
+      expect(calls.subscriptions).toEqual([
+        {
+          workspaceId: 'wrk_starter',
+          customerId: undefined,
+          subscriptionId: undefined,
+          subscriptionItemId: undefined,
+          quantity: undefined,
+          deleted: true,
+          detail: { source: 'customer.subscription.deleted' }
+        }
+      ])
+    })
+  )
 
-  it('skips a handled event that names no workspace', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls = yield* run({
-          type: 'customer.subscription.updated',
-          data: {
-            object: { id: 'sub_x', items: { data: [{ id: 'si_x', quantity: 2 }] } }
-          }
-        })
-        expect(calls.plans).toEqual([])
-        expect(calls.subscriptions).toEqual([])
+  it.effect('records the first subscription state without a plan change', () =>
+    Effect.gen(function* () {
+      const calls = yield* run(subscriptionCreated)
+      expect(calls.plans).toEqual([])
+      expect(calls.subscriptions[0]).toMatchObject({
+        workspaceId: 'wrk_starter',
+        subscriptionItemId: 'si_seed_starter_lab',
+        quantity: 4
       })
-    ))
+    })
+  )
 
-  it('tolerates a malformed body as a skip, not a failure', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const calls = yield* run({ type: 'checkout.session.completed', data: 'nope' })
-        expect(calls.plans).toEqual([])
-        expect(calls.subscriptions).toEqual([])
+  it.effect('ignores unhandled event types without calling the capability', () =>
+    Effect.gen(function* () {
+      const calls = yield* run({
+        type: 'invoice.paid',
+        data: { object: { customer: 'cus_seed_starter_lab' } }
       })
-    ))
+      expect(calls.plans).toEqual([])
+      expect(calls.subscriptions).toEqual([])
+    })
+  )
+
+  it.effect('skips a handled event that names no workspace', () =>
+    Effect.gen(function* () {
+      const calls = yield* run({
+        type: 'customer.subscription.updated',
+        data: {
+          object: { id: 'sub_x', items: { data: [{ id: 'si_x', quantity: 2 }] } }
+        }
+      })
+      expect(calls.plans).toEqual([])
+      expect(calls.subscriptions).toEqual([])
+    })
+  )
+
+  it.effect('tolerates a malformed body as a skip, not a failure', () =>
+    Effect.gen(function* () {
+      const calls = yield* run({ type: 'checkout.session.completed', data: 'nope' })
+      expect(calls.plans).toEqual([])
+      expect(calls.subscriptions).toEqual([])
+    })
+  )
 })

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@babel/core": "catalog:",
     "@cloudflare/workers-types": "catalog:",
+    "@effect/vitest": "catalog:",
     "@playwright/test": "catalog:",
     "@rolldown/plugin-babel": "catalog:",
     "@tailwindcss/vite": "catalog:",

--- a/apps/web/src/lib/observability.test.ts
+++ b/apps/web/src/lib/observability.test.ts
@@ -82,6 +82,7 @@ describe('runWebRequestScope', () => {
       async () => {
         // Two nested runs, exactly as a loader and a server function do it: a
         // bare `Effect.runPromise*` over `withWebRequestScope`.
+        // oxlint-disable-next-line starter/no-run-promise-in-tests -- a bare runtime inside the promise callback is the interop under test, the documented shape loaders and server fns use
         await Effect.runPromise(
           withWebRequestScope(
             { event: 'capability.workspace', metadata: { workspaceSlug: 'acme' } },
@@ -89,6 +90,7 @@ describe('runWebRequestScope', () => {
             lookupRequest
           )
         )
+        // oxlint-disable-next-line starter/no-run-promise-in-tests -- a bare runtime inside the promise callback is the interop under test, the documented shape loaders and server fns use
         await Effect.runPromiseExit(
           withWebRequestScope(
             { event: 'capability.global' },
@@ -134,6 +136,7 @@ describe('runWebRequestScope', () => {
     await runWebRequestScope(
       { request: registered, handlerType: 'router' },
       async () => {
+        // oxlint-disable-next-line starter/no-run-promise-in-tests -- a bare runtime inside the promise callback is the interop under test, the documented shape loaders and server fns use
         await Effect.runPromise(
           withWebRequestScope(
             { event: 'capability.global' },
@@ -279,6 +282,7 @@ describe('withWebRequestScope', () => {
   it('flags its own event as standalone when there is no request to join', async () => {
     ambient.request = undefined
 
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- a bare runtime inside the promise callback is the interop under test, the documented shape loaders and server fns use
     await Effect.runPromise(
       withWebRequestScope(
         { event: 'capability.global', metadata: { workspaceSlug: 'acme' } },

--- a/apps/web/src/lib/rate-limit.test.ts
+++ b/apps/web/src/lib/rate-limit.test.ts
@@ -1,5 +1,5 @@
-import { Effect, type Scope } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { Effect } from 'effect'
+import { describe, expect, it } from '@effect/vitest'
 import {
   authRateLimitBucket,
   clientKey,
@@ -11,34 +11,30 @@ function request(headers: Record<string, string>): Request {
   return new Request('http://localhost:3071/api/auth/sign-in', { headers })
 }
 
-// `take` annotates the request's wide event, so it needs a Scope; tests
-// supply it with `Effect.scoped`.
-function runScoped<A, E>(effect: Effect.Effect<A, E, Scope.Scope>): Promise<A> {
-  return Effect.runPromise(Effect.scoped(effect))
-}
-
 describe('rate limiter fallback (no Cloudflare bindings)', () => {
-  it('enforces the auth_write limit across per-request layer rebuilds', async () => {
-    // The auth route builds the layer on every request (api.auth.$.ts), so
-    // this test rebuilds it per take — the fallback counters must survive.
-    function take(key: string) {
-      return Effect.gen(function* () {
-        const limiter = yield* RateLimiter
-        return yield* limiter.take({ bucket: 'auth_write', key })
-      }).pipe(Effect.provide(makeRateLimiterLayer({})))
-    }
+  it.effect('enforces the auth_write limit across per-request layer rebuilds', () =>
+    Effect.gen(function* () {
+      // The auth route builds the layer on every request (api.auth.$.ts), so
+      // this test rebuilds it per take — the fallback counters must survive.
+      function take(key: string) {
+        return Effect.gen(function* () {
+          const limiter = yield* RateLimiter
+          return yield* limiter.take({ bucket: 'auth_write', key })
+        }).pipe(Effect.provide(makeRateLimiterLayer({})))
+      }
 
-    const key = `test-${Date.now()}-${Math.random()}`
-    const outcomes: Array<boolean> = []
-    for (let i = 0; i < 21; i += 1) {
-      outcomes.push(await runScoped(take(key)))
-    }
-    // auth_write allows 20 per window; the 21st take is denied.
-    expect(outcomes.slice(0, 20).every(Boolean)).toBe(true)
-    expect(outcomes[20]).toBe(false)
-    // A different key is unaffected.
-    expect(await runScoped(take(`${key}-other`))).toBe(true)
-  })
+      const key = `test-${Date.now()}-${Math.random()}`
+      const outcomes: Array<boolean> = []
+      for (let i = 0; i < 21; i += 1) {
+        outcomes.push(yield* take(key))
+      }
+      // auth_write allows 20 per window; the 21st take is denied.
+      expect(outcomes.slice(0, 20).every(Boolean)).toBe(true)
+      expect(outcomes[20]).toBe(false)
+      // A different key is unaffected.
+      expect(yield* take(`${key}-other`)).toBe(true)
+    })
+  )
 })
 
 describe('authRateLimitBucket', () => {
@@ -63,22 +59,24 @@ describe('authRateLimitBucket', () => {
     expect(authRateLimitBucket(method, pathname)).toBe(expected)
   })
 
-  it('enforces the tighter auth_sign_in fallback limit', async () => {
-    function take(key: string) {
-      return Effect.gen(function* () {
-        const limiter = yield* RateLimiter
-        return yield* limiter.take({ bucket: 'auth_sign_in', key })
-      }).pipe(Effect.provide(makeRateLimiterLayer({})))
-    }
-    const key = `sign-in-${Date.now()}-${Math.random()}`
-    const outcomes: Array<boolean> = []
-    for (let i = 0; i < 6; i += 1) {
-      outcomes.push(await runScoped(take(key)))
-    }
-    // auth_sign_in allows 5 per window; the 6th take is denied.
-    expect(outcomes.slice(0, 5).every(Boolean)).toBe(true)
-    expect(outcomes[5]).toBe(false)
-  })
+  it.effect('enforces the tighter auth_sign_in fallback limit', () =>
+    Effect.gen(function* () {
+      function take(key: string) {
+        return Effect.gen(function* () {
+          const limiter = yield* RateLimiter
+          return yield* limiter.take({ bucket: 'auth_sign_in', key })
+        }).pipe(Effect.provide(makeRateLimiterLayer({})))
+      }
+      const key = `sign-in-${Date.now()}-${Math.random()}`
+      const outcomes: Array<boolean> = []
+      for (let i = 0; i < 6; i += 1) {
+        outcomes.push(yield* take(key))
+      }
+      // auth_sign_in allows 5 per window; the 6th take is denied.
+      expect(outcomes.slice(0, 5).every(Boolean)).toBe(true)
+      expect(outcomes[5]).toBe(false)
+    })
+  )
 })
 
 describe('clientKey', () => {

--- a/apps/web/src/lib/server/account-delete-hooks.test.ts
+++ b/apps/web/src/lib/server/account-delete-hooks.test.ts
@@ -89,6 +89,7 @@ function planFor(): AccountDeletionPlan {
 }
 
 function makeRunner(layer: Layer.Layer<AccountLifecycle>): AccountLifecycleRunner {
+  // oxlint-disable-next-line starter/no-run-promise-in-tests -- the AccountLifecycleRunner port must return a Promise — Better Auth invokes it outside any runtime
   return async (effect) => Effect.runPromise(Effect.provide(effect, layer))
 }
 

--- a/apps/web/src/lib/server/auth-audit/auth-audit.test.ts
+++ b/apps/web/src/lib/server/auth-audit/auth-audit.test.ts
@@ -33,6 +33,7 @@ function runRecordAuthAudit(
   request: Request,
   response: Response
 ): Promise<AuthAuditOutcome> {
+  // oxlint-disable-next-line starter/no-run-promise-in-tests -- the suite asserts through await expect(...).resolves over these promises across dozens of sites; folding every body would grow arms and legs
   return Effect.runPromise(
     Effect.scoped(recordAuthAudit(exchangeOf(request), response, runCapabilities))
   )
@@ -583,6 +584,7 @@ describe('recordAuthAudit', () => {
     })
     const clone = vi.spyOn(response, 'clone')
     const json = vi.spyOn(response, 'json')
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the suite asserts through await expect(...).resolves over these promises across dozens of sites; folding every body would grow arms and legs
     const outcome = await Effect.runPromise(
       Effect.scoped(
         recordAuthAudit(exchangeOf(request), response, runCapabilities, {
@@ -972,6 +974,7 @@ describe('recordAuthAudit with a pre-handler context', () => {
     response: Response,
     context: AuthAuditContext
   ): Promise<AuthAuditOutcome> {
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the suite asserts through await expect(...).resolves over these promises across dozens of sites; folding every body would grow arms and legs
     return Effect.runPromise(
       Effect.scoped(
         recordAuthAudit(exchangeOf(request), response, runCapabilities, context)

--- a/apps/web/src/lib/server/authorize.test.ts
+++ b/apps/web/src/lib/server/authorize.test.ts
@@ -6,8 +6,8 @@ import {
   type Workspace,
   type WorkspaceRole
 } from '@b2b-saas-starter/capabilities/governance/workspace-identity'
-import { Effect } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { Effect, type Scope } from 'effect'
+import { describe, expect, it } from '@effect/vitest'
 
 import { requireWorkspacePermission } from './authorize'
 
@@ -24,73 +24,87 @@ function actor(role: WorkspaceRole): Actor {
 
 /**
  * `requirePermission` annotates the request's wide event on denial, so it needs
- * a Scope. Server functions get one from `runWorkspaceCapabilities`; tests
- * supply their own with `Effect.scoped`.
+ * a Scope. Server functions get one from `runWorkspaceCapabilities`; the
+ * TestContext behind `it.effect` supplies one here.
  */
 function decide(
   actorOrNull: Actor | null,
   permission: Parameters<typeof requireWorkspacePermission>[0]
-): Promise<string> {
-  return Effect.runPromise(
-    Effect.scoped(requireWorkspacePermission(permission)).pipe(
-      Effect.as('allowed'),
-      Effect.catchTag('AuthorizationDenied', (error) => Effect.succeed(error.reason)),
-      Effect.provide(testWorkspaceContext(workspace, actorOrNull))
-    )
+): Effect.Effect<string, never, Scope.Scope> {
+  return requireWorkspacePermission(permission).pipe(
+    Effect.as('allowed'),
+    Effect.catchTag('AuthorizationDenied', (error) => Effect.succeed(error.reason)),
+    Effect.provide(testWorkspaceContext(workspace, actorOrNull))
   )
 }
 
 describe('requireWorkspacePermission', () => {
-  it('lets an owner create an API token', async () => {
-    expect(await decide(actor('owner'), { apiToken: ['create'] })).toBe('allowed')
-  })
+  it.effect('lets an owner create an API token', () =>
+    Effect.gen(function* () {
+      expect(yield* decide(actor('owner'), { apiToken: ['create'] })).toBe('allowed')
+    })
+  )
 
-  it('lets an admin create an API token', async () => {
-    expect(await decide(actor('admin'), { apiToken: ['create'] })).toBe('allowed')
-  })
+  it.effect('lets an admin create an API token', () =>
+    Effect.gen(function* () {
+      expect(yield* decide(actor('admin'), { apiToken: ['create'] })).toBe('allowed')
+    })
+  )
 
-  it('refuses a member the token, webhook and audit-log surfaces', async () => {
-    const member = actor('member')
-    expect(await decide(member, { apiToken: ['create'] })).toBe(
-      'insufficient_permission'
-    )
-    expect(await decide(member, { webhook: ['create'] })).toBe(
-      'insufficient_permission'
-    )
-    expect(await decide(member, { auditLog: ['read'] })).toBe('insufficient_permission')
-  })
+  it.effect('refuses a member the token, webhook and audit-log surfaces', () =>
+    Effect.gen(function* () {
+      const member = actor('member')
+      expect(yield* decide(member, { apiToken: ['create'] })).toBe(
+        'insufficient_permission'
+      )
+      expect(yield* decide(member, { webhook: ['create'] })).toBe(
+        'insufficient_permission'
+      )
+      expect(yield* decide(member, { auditLog: ['read'] })).toBe(
+        'insufficient_permission'
+      )
+    })
+  )
 
-  it('refuses a member member-management actions', async () => {
-    expect(await decide(actor('member'), { member: ['create'] })).toBe(
-      'insufficient_permission'
-    )
-    expect(await decide(actor('member'), { member: ['delete'] })).toBe(
-      'insufficient_permission'
-    )
-  })
+  it.effect('refuses a member member-management actions', () =>
+    Effect.gen(function* () {
+      expect(yield* decide(actor('member'), { member: ['create'] })).toBe(
+        'insufficient_permission'
+      )
+      expect(yield* decide(actor('member'), { member: ['delete'] })).toBe(
+        'insufficient_permission'
+      )
+    })
+  )
 
-  it('still lets a member read the workspace content', async () => {
-    expect(await decide(actor('member'), { notification: ['read'] })).toBe('allowed')
-    expect(await decide(actor('member'), { ac: ['read'] })).toBe('allowed')
-  })
+  it.effect('still lets a member read the workspace content', () =>
+    Effect.gen(function* () {
+      expect(yield* decide(actor('member'), { notification: ['read'] })).toBe('allowed')
+      expect(yield* decide(actor('member'), { ac: ['read'] })).toBe('allowed')
+    })
+  )
 
-  it('fails closed when the context resolved no actor', async () => {
-    // A trusted read (the public showcase loader) omits the actor entirely.
-    // Reaching the guard without one means nothing was proved, so it denies.
-    expect(await decide(null, { notification: ['read'] })).toBe('no_principal')
-  })
+  it.effect('fails closed when the context resolved no actor', () =>
+    Effect.gen(function* () {
+      // A trusted read (the public showcase loader) omits the actor entirely.
+      // Reaching the guard without one means nothing was proved, so it denies.
+      expect(yield* decide(null, { notification: ['read'] })).toBe('no_principal')
+    })
+  )
 
-  it('grants a system admin nothing inside the workspace', async () => {
-    // `user.role === 'admin'` is a separate axis. A system admin who is only a
-    // workspace member gets the member's answer, so the bypass stays absent
-    // from the audit log because it does not exist.
-    const systemAdminMember: Actor = {
-      userId: 'usr_sysadmin',
-      role: 'member',
-      systemRole: 'admin'
-    }
-    expect(await decide(systemAdminMember, { apiToken: ['create'] })).toBe(
-      'insufficient_permission'
-    )
-  })
+  it.effect('grants a system admin nothing inside the workspace', () =>
+    Effect.gen(function* () {
+      // `user.role === 'admin'` is a separate axis. A system admin who is only a
+      // workspace member gets the member's answer, so the bypass stays absent
+      // from the audit log because it does not exist.
+      const systemAdminMember: Actor = {
+        userId: 'usr_sysadmin',
+        role: 'member',
+        systemRole: 'admin'
+      }
+      expect(yield* decide(systemAdminMember, { apiToken: ['create'] })).toBe(
+        'insufficient_permission'
+      )
+    })
+  )
 })

--- a/apps/web/src/lib/server/impersonation-guard.test.ts
+++ b/apps/web/src/lib/server/impersonation-guard.test.ts
@@ -66,8 +66,11 @@ describe('impersonationGuardResponse', () => {
         post('/api/auth/change-password'),
         impersonated
       )
-      expect(response?.status).toBe(403)
-      expect(yield* Effect.promise(() => response!.json())).toEqual({
+      if (response === null) {
+        return yield* Effect.fail('the guard must answer a forbidden action')
+      }
+      expect(response.status).toBe(403)
+      expect(yield* Effect.promise(() => response.json())).toEqual({
         code: 'forbidden_while_impersonating',
         action: 'change_password'
       })

--- a/apps/web/src/lib/server/impersonation-guard.test.ts
+++ b/apps/web/src/lib/server/impersonation-guard.test.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 import {
   impersonationForbiddenAction,
   impersonationGuardResponse
@@ -60,32 +60,36 @@ describe('impersonationForbiddenAction', () => {
 })
 
 describe('impersonationGuardResponse', () => {
-  it('answers 403 for a forbidden action on an impersonation session', async () => {
-    const response = await Effect.runPromise(
-      impersonationGuardResponse(post('/api/auth/change-password'), impersonated)
-    )
-    expect(response?.status).toBe(403)
-    expect(await response?.json()).toEqual({
-      code: 'forbidden_while_impersonating',
-      action: 'change_password'
+  it.effect('answers 403 for a forbidden action on an impersonation session', () =>
+    Effect.gen(function* () {
+      const response = yield* impersonationGuardResponse(
+        post('/api/auth/change-password'),
+        impersonated
+      )
+      expect(response?.status).toBe(403)
+      expect(yield* Effect.promise(() => response!.json())).toEqual({
+        code: 'forbidden_while_impersonating',
+        action: 'change_password'
+      })
     })
-  })
+  )
 
-  it('lets an ordinary session, an anonymous request, and an allowed action through', async () => {
-    expect(
-      await Effect.runPromise(
-        impersonationGuardResponse(post('/api/auth/change-password'), ordinary)
-      )
-    ).toBeNull()
-    expect(
-      await Effect.runPromise(
-        impersonationGuardResponse(post('/api/auth/change-password'), undefined)
-      )
-    ).toBeNull()
-    expect(
-      await Effect.runPromise(
-        impersonationGuardResponse(post('/api/auth/sign-out'), impersonated)
-      )
-    ).toBeNull()
-  })
+  it.effect(
+    'lets an ordinary session, an anonymous request, and an allowed action through',
+    () =>
+      Effect.gen(function* () {
+        expect(
+          yield* impersonationGuardResponse(post('/api/auth/change-password'), ordinary)
+        ).toBeNull()
+        expect(
+          yield* impersonationGuardResponse(
+            post('/api/auth/change-password'),
+            undefined
+          )
+        ).toBeNull()
+        expect(
+          yield* impersonationGuardResponse(post('/api/auth/sign-out'), impersonated)
+        ).toBeNull()
+      })
+  )
 })

--- a/apps/web/src/lib/server/invitations.test.ts
+++ b/apps/web/src/lib/server/invitations.test.ts
@@ -212,6 +212,7 @@ describe('previewInvitation — the non-disclosure collapse', () => {
   }
 
   it('describes a pending invitation to its recipient', async () => {
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- server-fn handler pattern per apps/web/AGENTS.md keeps plain it (TestClock epoch 0 vs session-expiry fixtures)
     const preview = await Effect.runPromise(previewInvitation(invitation(), INVITEE))
     expect(preview).toEqual({
       state: 'pending',
@@ -223,6 +224,7 @@ describe('previewInvitation — the non-disclosure collapse', () => {
   })
 
   it('answers a wrong-recipient viewer with the same opaque answer as an unknown id', async () => {
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- server-fn handler pattern per apps/web/AGENTS.md keeps plain it (TestClock epoch 0 vs session-expiry fixtures)
     const preview = await Effect.runPromise(
       previewInvitation(invitation(), 'someone-else@example.com')
     )
@@ -230,6 +232,7 @@ describe('previewInvitation — the non-disclosure collapse', () => {
   })
 
   it('answers an expired invitation with the same opaque answer', async () => {
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- server-fn handler pattern per apps/web/AGENTS.md keeps plain it (TestClock epoch 0 vs session-expiry fixtures)
     const preview = await Effect.runPromise(
       previewInvitation(invitation({ expiresAt: PAST }), INVITEE)
     )
@@ -237,6 +240,7 @@ describe('previewInvitation — the non-disclosure collapse', () => {
   })
 
   it('answers an already-settled invitation with the same opaque answer', async () => {
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- server-fn handler pattern per apps/web/AGENTS.md keeps plain it (TestClock epoch 0 vs session-expiry fixtures)
     const preview = await Effect.runPromise(
       previewInvitation(invitation({ status: 'accepted' }), INVITEE)
     )

--- a/apps/web/src/lib/server/social-account-audit.test.ts
+++ b/apps/web/src/lib/server/social-account-audit.test.ts
@@ -20,9 +20,11 @@ function makeFixture() {
   const seedLayer = SeedAuditEventLog([])
   type AccountAuditEffect = Parameters<RunAccountAudit>[0]
   function runAgainstSeed(effect: AccountAuditEffect) {
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the RunAccountAudit port is a Promise — the hooks under test are Better Auth promise callbacks
     return Effect.runPromise(Effect.provide(effect, seedLayer))
   }
   function recordedEvents() {
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the RunAccountAudit port is a Promise — the hooks under test are Better Auth promise callbacks
     return Effect.runPromise(
       Effect.gen(function* () {
         const audit = yield* AuditEventLog

--- a/apps/web/src/lib/server/sso-discovery.test.ts
+++ b/apps/web/src/lib/server/sso-discovery.test.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 
 import { resolveOidcIssuer, validateSamlMetadata } from './sso-discovery'
 
@@ -26,35 +26,45 @@ const METADATA = `<?xml version="1.0"?>
 </EntityDescriptor>`
 
 describe('validateSamlMetadata', () => {
-  it('extracts the entity id and the redirect binding URL from valid metadata', async () => {
-    const result = await Effect.runPromise(validateSamlMetadata(METADATA))
-    expect(result.entityId).toBe('https://idp.acme.com/saml')
-    expect(result.entryPoint).toBe('https://idp.acme.com/saml/sso')
-  })
+  it.effect(
+    'extracts the entity id and the redirect binding URL from valid metadata',
+    () =>
+      Effect.gen(function* () {
+        const result = yield* validateSamlMetadata(METADATA)
+        expect(result.entityId).toBe('https://idp.acme.com/saml')
+        expect(result.entryPoint).toBe('https://idp.acme.com/saml/sso')
+      })
+  )
 
-  it('refuses metadata with no usable SSO service', async () => {
-    // samlify parses garbage leniently — no entity id, no bindings — so the
-    // refusal lands on the missing-entry-point code either way.
-    const failure = await Effect.runPromise(
-      Effect.flip(validateSamlMetadata('this is not saml metadata'))
-    )
-    expect(failure).toMatchObject({ code: 'saml_metadata_missing_entry_point' })
-  })
+  it.effect('refuses metadata with no usable SSO service', () =>
+    Effect.gen(function* () {
+      // samlify parses garbage leniently — no entity id, no bindings — so the
+      // refusal lands on the missing-entry-point code either way.
+      const failure = yield* Effect.flip(
+        validateSamlMetadata('this is not saml metadata')
+      )
+      expect(failure).toMatchObject({ code: 'saml_metadata_missing_entry_point' })
+    })
+  )
 
-  it('refuses metadata without an HTTP-Redirect SSO binding', async () => {
-    const postOnly = METADATA.replace('HTTP-Redirect', 'HTTP-Custom-Binding')
-    const failure = await Effect.runPromise(Effect.flip(validateSamlMetadata(postOnly)))
-    expect(failure).toMatchObject({ code: 'saml_metadata_missing_entry_point' })
-  })
+  it.effect('refuses metadata without an HTTP-Redirect SSO binding', () =>
+    Effect.gen(function* () {
+      const postOnly = METADATA.replace('HTTP-Redirect', 'HTTP-Custom-Binding')
+      const failure = yield* Effect.flip(validateSamlMetadata(postOnly))
+      expect(failure).toMatchObject({ code: 'saml_metadata_missing_entry_point' })
+    })
+  )
 })
 
 describe('resolveOidcIssuer', () => {
-  it('fails discovery_unreachable for an issuer nothing answers', async () => {
-    // No network in tests: `.invalid` never resolves, which is the same
-    // refusal the form shows for a typo'd issuer.
-    const failure = await Effect.runPromise(
-      Effect.flip(resolveOidcIssuer('https://login.unreachable.invalid'))
-    )
-    expect(failure).toMatchObject({ code: 'discovery_unreachable' })
-  })
+  it.effect('fails discovery_unreachable for an issuer nothing answers', () =>
+    Effect.gen(function* () {
+      // No network in tests: `.invalid` never resolves, which is the same
+      // refusal the form shows for a typo'd issuer.
+      const failure = yield* Effect.flip(
+        resolveOidcIssuer('https://login.unreachable.invalid')
+      )
+      expect(failure).toMatchObject({ code: 'discovery_unreachable' })
+    })
+  )
 })

--- a/apps/web/src/lib/server/sso-sign-in-gate.test.ts
+++ b/apps/web/src/lib/server/sso-sign-in-gate.test.ts
@@ -1,5 +1,5 @@
 import { Effect, Option, Schema } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 
 import { type SsoSignInTarget } from '@b2b-saas-starter/capabilities/governance/workspace-sso-connections'
 
@@ -113,62 +113,66 @@ describe('disabledConnectionResponse (the SSO half)', () => {
 })
 
 describe('the request wrappers against the Seed layer', () => {
-  it('refuses a direct /sign-in/sso for the seeded disabled connection', async () => {
-    const response = await Effect.runPromise(
-      refuseDisabledConnection(
+  it.effect('refuses a direct /sign-in/sso for the seeded disabled connection', () =>
+    Effect.gen(function* () {
+      const response = yield* refuseDisabledConnection(
         gateRequest('/sign-in/sso', { email: 'someone@acme-corp.example' }),
         { method: 'POST', pathname: '/api/auth/sign-in/sso' }
       )
-    )
-    expect(response?.status).toBe(403)
-    expect(decodeRefusal(await response?.json())).toMatchObject({
-      code: 'sso_connection_disabled'
+      expect(response?.status).toBe(403)
+      expect(
+        decodeRefusal(yield* Effect.promise(() => response!.json()))
+      ).toMatchObject({
+        code: 'sso_connection_disabled'
+      })
     })
-  })
+  )
 
-  it('refuses a providerId-addressed /sign-in/sso for the same row', async () => {
-    const response = await Effect.runPromise(
-      refuseDisabledConnection(
+  it.effect('refuses a providerId-addressed /sign-in/sso for the same row', () =>
+    Effect.gen(function* () {
+      const response = yield* refuseDisabledConnection(
         gateRequest('/sign-in/sso', { providerId: 'sso_example_oidc' }),
         { method: 'POST', pathname: '/api/auth/sign-in/sso' }
       )
-    )
-    expect(response?.status).toBe(403)
-  })
+      expect(response?.status).toBe(403)
+    })
+  )
 
-  it('lets /sign-in/sso through for a domain with no connection', async () => {
-    const response = await Effect.runPromise(
-      refuseDisabledConnection(
+  it.effect('lets /sign-in/sso through for a domain with no connection', () =>
+    Effect.gen(function* () {
+      const response = yield* refuseDisabledConnection(
         gateRequest('/sign-in/sso', { email: 'demo@starter.local' }),
         { method: 'POST', pathname: '/api/auth/sign-in/sso' }
       )
-    )
-    expect(response).toBeNull()
-  })
-
-  it('lets the credential path through for the disabled connection — it does not demand SSO', async () => {
-    const response = await Effect.runPromise(
-      enforceSsoRequired(
-        gateRequest('/sign-in/email', { email: 'someone@acme-corp.example' }),
-        {
-          method: 'POST',
-          pathname: '/api/auth/sign-in/email'
-        }
-      )
-    )
-    expect(response).toBeNull()
-  })
-
-  it('ignores a non-JSON body instead of failing the sign-in', async () => {
-    const request = new Request('http://localhost:3071/api/auth/sign-in/sso', {
-      method: 'POST'
+      expect(response).toBeNull()
     })
-    const response = await Effect.runPromise(
-      refuseDisabledConnection(request, {
+  )
+
+  it.effect(
+    'lets the credential path through for the disabled connection — it does not demand SSO',
+    () =>
+      Effect.gen(function* () {
+        const response = yield* enforceSsoRequired(
+          gateRequest('/sign-in/email', { email: 'someone@acme-corp.example' }),
+          {
+            method: 'POST',
+            pathname: '/api/auth/sign-in/email'
+          }
+        )
+        expect(response).toBeNull()
+      })
+  )
+
+  it.effect('ignores a non-JSON body instead of failing the sign-in', () =>
+    Effect.gen(function* () {
+      const request = new Request('http://localhost:3071/api/auth/sign-in/sso', {
+        method: 'POST'
+      })
+      const response = yield* refuseDisabledConnection(request, {
         method: 'POST',
         pathname: '/api/auth/sign-in/sso'
       })
-    )
-    expect(response).toBeNull()
-  })
+      expect(response).toBeNull()
+    })
+  )
 })

--- a/apps/web/src/lib/server/sso-sign-in-gate.test.ts
+++ b/apps/web/src/lib/server/sso-sign-in-gate.test.ts
@@ -119,12 +119,15 @@ describe('the request wrappers against the Seed layer', () => {
         gateRequest('/sign-in/sso', { email: 'someone@acme-corp.example' }),
         { method: 'POST', pathname: '/api/auth/sign-in/sso' }
       )
-      expect(response?.status).toBe(403)
-      expect(
-        decodeRefusal(yield* Effect.promise(() => response!.json()))
-      ).toMatchObject({
-        code: 'sso_connection_disabled'
-      })
+      if (response === null) {
+        return yield* Effect.fail('the gate must answer a disabled connection')
+      }
+      expect(response.status).toBe(403)
+      expect(decodeRefusal(yield* Effect.promise(() => response.json()))).toMatchObject(
+        {
+          code: 'sso_connection_disabled'
+        }
+      )
     })
   )
 

--- a/apps/web/src/lib/server/workspace-sso.effects.test.ts
+++ b/apps/web/src/lib/server/workspace-sso.effects.test.ts
@@ -197,6 +197,7 @@ describe('notifyOwnersOfFailedTest — the owner fan-out rule', () => {
   const REASON = 'issuer unreachable'
 
   it('notifies every owner, only the owners, with the domain and reason', async () => {
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- server-fn handler pattern per apps/web/AGENTS.md keeps plain it (TestClock epoch 0 vs session-expiry fixtures)
     const visibleTo = await Effect.runPromise(
       Effect.gen(function* () {
         const roster = yield* makeSeedRoster(members)

--- a/lint.config.ts
+++ b/lint.config.ts
@@ -706,6 +706,13 @@ const { lint = {} } = defineConfig({
       {
         files: ['**/test/**', '**/*.test.ts', '**/*.test.tsx', '**/vitest.setup.ts'],
         rules: {
+          // A test that hand-starts a runtime with Effect.runPromise swaps
+          // TestContext for a bare one: no Scope from the runner, failures
+          // outside the fiber, and time reads that leave the TestClock — the
+          // exact hazards the it.effect migration removed. Interop sites (a
+          // runner port a non-Effect framework calls) keep the call behind a
+          // per-site disable naming the port.
+          'starter/no-run-promise-in-tests': 'error',
           'no-empty-function': 'off',
           'unicorn/consistent-function-scoping': 'off',
           // Tests keep the escape hatches (forcing a defect is a legitimate

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -16,6 +16,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plus": "catalog:",

--- a/packages/ai/src/openai.test.ts
+++ b/packages/ai/src/openai.test.ts
@@ -1,5 +1,5 @@
 import { failureMessage } from '@b2b-saas-starter/failure'
-import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+import { afterEach, describe, expect, it, vi } from '@effect/vitest'
 import { Effect, Schema } from 'effect'
 import { LanguageModel, Prompt } from 'effect/unstable/ai'
 import { type OpenAIConfig, makeOpenAIModel } from './openai.ts'
@@ -88,51 +88,47 @@ describe('openai-compatible model', () => {
     )
   })
 
-  it('refuses a prompt carrying a part it cannot send as plain chat', () => {
+  it.effect('refuses a prompt carrying a part it cannot send as plain chat', () => {
     const posted = stubFetch(() =>
       jsonResponse({ choices: [{ message: { content: 'never read' } }] })
     )
-    return Effect.runPromise(
-      Effect.gen(function* () {
-        const model = yield* LanguageModel.LanguageModel
-        const error = yield* Effect.flip(
-          model.generateText({
-            prompt: Prompt.make([
-              {
-                role: 'user',
-                content: [
-                  { type: 'text', text: 'summarize this' },
-                  { type: 'file', mediaType: 'text/plain', data: 'notes.txt' }
-                ]
-              }
-            ])
-          })
-        )
-        expect(error._tag).toBe('AiError')
-        expect(error.reason._tag).toBe('InvalidUserInputError')
-        expect(posted).toHaveLength(0)
-      }).pipe(Effect.provide(makeOpenAIModel(TEST_CONFIG)))
-    )
+    return Effect.gen(function* () {
+      const model = yield* LanguageModel.LanguageModel
+      const error = yield* Effect.flip(
+        model.generateText({
+          prompt: Prompt.make([
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'summarize this' },
+                { type: 'file', mediaType: 'text/plain', data: 'notes.txt' }
+              ]
+            }
+          ])
+        })
+      )
+      expect(error._tag).toBe('AiError')
+      expect(error.reason._tag).toBe('InvalidUserInputError')
+      expect(posted).toHaveLength(0)
+    }).pipe(Effect.provide(makeOpenAIModel(TEST_CONFIG)))
   })
 
-  it('refuses structured-output requests before any request is sent', () => {
+  it.effect('refuses structured-output requests before any request is sent', () => {
     const posted = stubFetch(() =>
       jsonResponse({ choices: [{ message: { content: 'never read' } }] })
     )
-    return Effect.runPromise(
-      Effect.gen(function* () {
-        const model = yield* LanguageModel.LanguageModel
-        const error = yield* Effect.flip(
-          model.generateObject({
-            prompt: 'Answer with a reply object.',
-            schema: Schema.Struct({ answer: Schema.String }),
-            objectName: 'reply'
-          })
-        )
-        expect(failureMessage(error)).toContain('structured output')
-        expect(posted).toHaveLength(0)
-      }).pipe(Effect.provide(makeOpenAIModel(TEST_CONFIG)))
-    )
+    return Effect.gen(function* () {
+      const model = yield* LanguageModel.LanguageModel
+      const error = yield* Effect.flip(
+        model.generateObject({
+          prompt: 'Answer with a reply object.',
+          schema: Schema.Struct({ answer: Schema.String }),
+          objectName: 'reply'
+        })
+      )
+      expect(failureMessage(error)).toContain('structured output')
+      expect(posted).toHaveLength(0)
+    }).pipe(Effect.provide(makeOpenAIModel(TEST_CONFIG)))
   })
 
   it('maps a rate-limited provider onto AssistantUnavailable', () => {

--- a/packages/ai/src/workers-ai.test.ts
+++ b/packages/ai/src/workers-ai.test.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect'
 import { LanguageModel, Prompt } from 'effect/unstable/ai'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 import { ask, askFails, assistantOn } from './test-ask.ts'
 import { makeWorkersAIModel, type WorkersAIBinding } from './workers-ai.ts'
 
@@ -40,25 +40,24 @@ describe('workers-ai model', () => {
       }
     ))
 
-  it('refuses a prompt carrying a message it cannot send as plain chat', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const model = yield* LanguageModel.LanguageModel
-        const error = yield* Effect.flip(
-          model.generateText({
-            prompt: Prompt.make([
-              { role: 'assistant', content: [{ type: 'text', text: 'a prior turn' }] }
-            ])
-          })
-        )
-        expect(error._tag).toBe('AiError')
-        expect(error.reason._tag).toBe('InvalidUserInputError')
-      }).pipe(
-        Effect.provide(
-          makeWorkersAIModel({ run: () => Promise.resolve({ response: 'x' }) })
-        )
+  it.effect('refuses a prompt carrying a message it cannot send as plain chat', () =>
+    Effect.gen(function* () {
+      const model = yield* LanguageModel.LanguageModel
+      const error = yield* Effect.flip(
+        model.generateText({
+          prompt: Prompt.make([
+            { role: 'assistant', content: [{ type: 'text', text: 'a prior turn' }] }
+          ])
+        })
       )
-    ))
+      expect(error._tag).toBe('AiError')
+      expect(error.reason._tag).toBe('InvalidUserInputError')
+    }).pipe(
+      Effect.provide(
+        makeWorkersAIModel({ run: () => Promise.resolve({ response: 'x' }) })
+      )
+    )
+  )
 
   it('fails unavailable when the binding returns no response', () =>
     askFails(

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -23,6 +23,7 @@
     "effectful-better-auth": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "jose": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/packages/auth/src/live-email-flows.test.ts
+++ b/packages/auth/src/live-email-flows.test.ts
@@ -72,6 +72,7 @@ const capturingEmailSender: AuthEmailSender = {
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-email-flows.test.ts
+++ b/packages/auth/src/live-email-flows.test.ts
@@ -3,7 +3,7 @@ import { user, verification } from '@b2b-saas-starter/db/schema'
 import { Effect, type Layer } from 'effect'
 import { type BetterAuthApiError } from 'effectful-better-auth'
 import { eq } from 'drizzle-orm'
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test'
+import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest'
 import { type AuthEmailSender, Auth } from './index.ts'
 import {
   buildAuthLayer,
@@ -86,55 +86,60 @@ beforeAll(
 afterAll(() => provisioned.dispose())
 
 function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
-  return Effect.runPromise(Effect.provide(effect, authLayer))
+  return Effect.provide(effect, authLayer)
 }
 
 describe('account lifecycle email flows', () => {
-  it('sends a verification email on sign-up and verifies through the token hop', () =>
-    run(
-      Effect.gen(function* () {
-        const email = 'newbie@lifecycle.test'
-        const auth = yield* Auth.Tag
-        const before = sentEmails.length
+  it.live(
+    'sends a verification email on sign-up and verifies through the token hop',
+    () =>
+      run(
+        Effect.gen(function* () {
+          const email = 'newbie@lifecycle.test'
+          const auth = yield* Auth.Tag
+          const before = sentEmails.length
 
-        const signUp = yield* auth.api.signUpEmail({
-          body: {
-            name: 'Newbie',
-            email,
-            password: 'correct-horse-battery-staple',
-            callbackURL: 'http://localhost:3071/verify-email'
-          }
+          const signUp = yield* auth.api.signUpEmail({
+            body: {
+              name: 'Newbie',
+              email,
+              password: 'correct-horse-battery-staple',
+              callbackURL: 'http://localhost:3071/verify-email'
+            }
+          })
+          expect(signUp.user.emailVerified).toBe(false)
+
+          const sent = sentEmails
+            .slice(before)
+            .filter((entry) => entry.kind === 'verification')
+          expect(sent).toHaveLength(1)
+          const url = sent[0]?.url ?? ''
+          // The link points at the auth handler's token-exchange route with our
+          // landing page as the callback — not straight at the app route.
+          expect(url).toContain('http://localhost:3071/api/auth/verify-email?token=')
+          expect(url).toContain(
+            encodeURIComponent('http://localhost:3071/verify-email')
+          )
+
+          const response = yield* Effect.promise(() =>
+            auth.instance.handler(new Request(url))
+          )
+          expect(response.status).toBe(302)
+          expect(response.headers.get('location')).toBe(
+            'http://localhost:3071/verify-email'
+          )
+          // autoSignInAfterVerification: the hop sets a session cookie.
+          expect(response.headers.get('set-cookie')).toContain('better-auth')
+
+          const rows = yield* Effect.promise(() =>
+            db.select().from(user).where(eq(user.email, email))
+          )
+          expect(rows[0]?.emailVerified).toBe(true)
         })
-        expect(signUp.user.emailVerified).toBe(false)
+      )
+  )
 
-        const sent = sentEmails
-          .slice(before)
-          .filter((entry) => entry.kind === 'verification')
-        expect(sent).toHaveLength(1)
-        const url = sent[0]?.url ?? ''
-        // The link points at the auth handler's token-exchange route with our
-        // landing page as the callback — not straight at the app route.
-        expect(url).toContain('http://localhost:3071/api/auth/verify-email?token=')
-        expect(url).toContain(encodeURIComponent('http://localhost:3071/verify-email'))
-
-        const response = yield* Effect.promise(() =>
-          auth.instance.handler(new Request(url))
-        )
-        expect(response.status).toBe(302)
-        expect(response.headers.get('location')).toBe(
-          'http://localhost:3071/verify-email'
-        )
-        // autoSignInAfterVerification: the hop sets a session cookie.
-        expect(response.headers.get('set-cookie')).toContain('better-auth')
-
-        const rows = yield* Effect.promise(() =>
-          db.select().from(user).where(eq(user.email, email))
-        )
-        expect(rows[0]?.emailVerified).toBe(true)
-      })
-    ))
-
-  it('rejects a bad verification token by redirecting with an error param', () =>
+  it.live('rejects a bad verification token by redirecting with an error param', () =>
     run(
       Effect.gen(function* () {
         const auth = yield* Auth.Tag
@@ -149,9 +154,10 @@ describe('account lifecycle email flows', () => {
         const location = response.headers.get('location') ?? ''
         expect(new URL(location).searchParams.get('error')).toBeTruthy()
       })
-    ))
+    )
+  )
 
-  it('round-trips a password reset: request, hop, set, old sessions revoked', () =>
+  it.live('round-trips a password reset: request, hop, set, old sessions revoked', () =>
     run(
       Effect.gen(function* () {
         const email = 'resetter@lifecycle.test'
@@ -226,9 +232,10 @@ describe('account lifecycle email flows', () => {
         })
         expect(fresh.user.email).toBe(email)
       })
-    ))
+    )
+  )
 
-  it('answers unknown-email reset requests identically and sends nothing', () =>
+  it.live('answers unknown-email reset requests identically and sends nothing', () =>
     run(
       Effect.gen(function* () {
         const auth = yield* Auth.Tag
@@ -244,7 +251,8 @@ describe('account lifecycle email flows', () => {
         expect(requested.message).toContain('If this email exists')
         expect(sentEmails.slice(before)).toHaveLength(0)
       })
-    ))
+    )
+  )
 })
 
 describe('email-otp plugin', () => {
@@ -276,7 +284,7 @@ describe('email-otp plugin', () => {
     })
   }
 
-  it('sends a six-digit sign-in code and signs the holder in', () =>
+  it.live('sends a six-digit sign-in code and signs the holder in', () =>
     run(
       Effect.gen(function* () {
         const email = 'coder@otp.test'
@@ -299,9 +307,10 @@ describe('email-otp plugin', () => {
         expect(response.user.email).toBe(email)
         expect(headers.getSetCookie().join(' ')).toContain('better-auth')
       })
-    ))
+    )
+  )
 
-  it('locks the code after three failed attempts, even for the correct one', () =>
+  it.live('locks the code after three failed attempts, even for the correct one', () =>
     run(
       Effect.gen(function* () {
         const email = 'lockout@otp.test'
@@ -339,9 +348,10 @@ describe('email-otp plugin', () => {
         )
         expect(consumed).toEqual({ ok: false, status: 400 })
       })
-    ))
+    )
+  )
 
-  it('answers an unknown email identically and sends nothing', () =>
+  it.live('answers an unknown email identically and sends nothing', () =>
     run(
       Effect.gen(function* () {
         const email = 'ghost@otp.test'
@@ -360,9 +370,10 @@ describe('email-otp plugin', () => {
         )
         expect(verify).toEqual({ ok: false, status: 400 })
       })
-    ))
+    )
+  )
 
-  it('verifies an email address with a code and opens a session', () =>
+  it.live('verifies an email address with a code and opens a session', () =>
     run(
       Effect.gen(function* () {
         const email = 'verify-by-code@otp.test'
@@ -391,9 +402,10 @@ describe('email-otp plugin', () => {
         )
         expect(rows[0]?.emailVerified).toBe(true)
       })
-    ))
+    )
+  )
 
-  it('resets a password with a code and revokes the prior sessions', () =>
+  it.live('resets a password with a code and revokes the prior sessions', () =>
     run(
       Effect.gen(function* () {
         const email = 'otp-reset@otp.test'
@@ -430,7 +442,8 @@ describe('email-otp plugin', () => {
         })
         expect(fresh.user.email).toBe(email)
       })
-    ))
+    )
+  )
 })
 
 describe('magic-link sign-in', () => {
@@ -442,7 +455,7 @@ describe('magic-link sign-in', () => {
     errorCallbackURL: 'http://localhost:3071/magic-link/verify'
   }
 
-  it('round-trips a link for an existing user: request, hop, session', () =>
+  it.live('round-trips a link for an existing user: request, hop, session', () =>
     run(
       Effect.gen(function* () {
         const email = 'linker@magic.test'
@@ -476,9 +489,10 @@ describe('magic-link sign-in', () => {
         // is already signed in.
         expect(response.headers.get('set-cookie')).toContain('better-auth')
       })
-    ))
+    )
+  )
 
-  it('stores the token hashed, not as the emailed plaintext', () =>
+  it.live('stores the token hashed, not as the emailed plaintext', () =>
     run(
       Effect.gen(function* () {
         const email = 'hashed@magic.test'
@@ -500,9 +514,10 @@ describe('magic-link sign-in', () => {
         const rows = yield* Effect.promise(() => db.select().from(verification))
         expect(rows.some((row) => row.identifier === token)).toBe(false)
       })
-    ))
+    )
+  )
 
-  it('creates a verified user when an unknown email consumes a link', () =>
+  it.live('creates a verified user when an unknown email consumes a link', () =>
     run(
       Effect.gen(function* () {
         const email = 'newcomer@magic.test'
@@ -535,5 +550,6 @@ describe('magic-link sign-in', () => {
         expect(rows).toHaveLength(1)
         expect(rows[0]?.emailVerified).toBe(true)
       })
-    ))
+    )
+  )
 })

--- a/packages/auth/src/live-email-flows.test.ts
+++ b/packages/auth/src/live-email-flows.test.ts
@@ -72,7 +72,7 @@ const capturingEmailSender: AuthEmailSender = {
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
-    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the hook is the port: layer() suites expose no live tester for a real-clock suite, and a memoized fixture could not dispose its workerd process
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-mcp-oauth.test.ts
+++ b/packages/auth/src/live-mcp-oauth.test.ts
@@ -7,7 +7,7 @@ import { type DrizzleDatabase } from './ports.ts'
 import { oauthClient, oauthClientResource } from '@b2b-saas-starter/db/schema'
 import { Effect, type Layer, Schema } from 'effect'
 import { createLocalJWKSet, jwtVerify } from 'jose'
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test'
+import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest'
 import { Auth, MCP_CONSENT_PAGE, MCP_WORKSPACE_SELECTED_HEADER } from './index.ts'
 import {
   buildAuthLayer,
@@ -47,7 +47,7 @@ beforeAll(
 afterAll(() => provisioned.dispose())
 
 function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
-  return Effect.runPromise(Effect.provide(effect, authLayer))
+  return Effect.provide(effect, authLayer)
 }
 
 describe('mcp oauth authorization server', () => {
@@ -112,182 +112,188 @@ describe('mcp oauth authorization server', () => {
     })
   }
 
-  it('serves discovery: the JWKS and the RFC 8414 metadata at the issuer-inserted path', () =>
-    run(
-      Effect.gen(function* () {
-        const auth = yield* Auth.Tag
-        const jwks = yield* Effect.promise(() =>
-          auth.instance.handler(new Request('http://localhost:3071/api/auth/jwks'))
-        )
-        expect(jwks.status).toBe(200)
-        const keys = yield* Effect.promise(() => jwks.json())
-        expect(Array.isArray(keys.keys) && keys.keys.length > 0).toBe(true)
+  it.live(
+    'serves discovery: the JWKS and the RFC 8414 metadata at the issuer-inserted path',
+    () =>
+      run(
+        Effect.gen(function* () {
+          const auth = yield* Auth.Tag
+          const jwks = yield* Effect.promise(() =>
+            auth.instance.handler(new Request('http://localhost:3071/api/auth/jwks'))
+          )
+          expect(jwks.status).toBe(200)
+          const keys = yield* Effect.promise(() => jwks.json())
+          expect(Array.isArray(keys.keys) && keys.keys.length > 0).toBe(true)
 
-        // The request arrives at the origin root, outside `/api/auth/*` — the
-        // web app forwards it (`routes/[.]well-known.oauth-authorization-server.$.ts`).
-        const metadata = yield* Effect.promise(() =>
-          auth.instance.handler(
-            new Request(
-              'http://localhost:3071/.well-known/oauth-authorization-server/api/auth'
+          // The request arrives at the origin root, outside `/api/auth/*` — the
+          // web app forwards it (`routes/[.]well-known.oauth-authorization-server.$.ts`).
+          const metadata = yield* Effect.promise(() =>
+            auth.instance.handler(
+              new Request(
+                'http://localhost:3071/.well-known/oauth-authorization-server/api/auth'
+              )
             )
           )
-        )
-        expect(metadata.status).toBe(200)
-        const document = yield* Effect.promise(() => metadata.json())
-        expect(document.issuer).toBe('http://localhost:3071/api/auth')
-        expect(document.authorization_endpoint).toBe(
-          'http://localhost:3071/api/auth/oauth2/authorize'
-        )
-        expect(document.jwks_uri).toBe('http://localhost:3071/api/auth/jwks')
-        expect(document.code_challenge_methods_supported).toContain('S256')
-        expect(document.client_id_metadata_document_supported).toBe(true)
-      })
-    ))
-
-  it('issues a workspace-bound access token after the consent page picks a workspace', () =>
-    run(
-      Effect.gen(function* () {
-        const auth = yield* Auth.Tag
-        const { headers, userId } = yield* signUpSession('member@mcp.test')
-        const workspace = yield* auth.api.createOrganization({
-          body: { name: 'MCP Co', slug: 'mcp-co' },
-          headers
-        })
-        // A CIMD client, as the plugin would have registered it on discovery:
-        // registration links the client to the MCP resource it asked for.
-        yield* Effect.promise(() =>
-          db
-            .insert(oauthClient)
-            .values({
-              id: 'oac_live_mcp',
-              clientId: CLIENT_ID,
-              name: 'Live MCP client',
-              redirectUris: [REDIRECT_URI],
-              tokenEndpointAuthMethod: 'none',
-              grantTypes: ['authorization_code', 'refresh_token'],
-              responseTypes: ['code'],
-              scopes: ['openid', 'offline_access', 'mcp:read'],
-              requirePKCE: true
-            })
-            .run()
-        )
-        yield* Effect.promise(() =>
-          db
-            .insert(oauthClientResource)
-            .values({
-              id: 'ocr_live_mcp',
-              clientId: CLIENT_ID,
-              resourceId: 'http://localhost:8787/mcp'
-            })
-            .run()
-        )
-        const { verifier, challenge } = pkce()
-
-        // 1. The client sends the browser to /oauth2/authorize. Signed in, with
-        //    no workspace vouched for, the provider's post-login hop sends it to
-        //    the consent page carrying the signed request.
-        const authorize = new URL('http://localhost:3071/api/auth/oauth2/authorize')
-        authorize.searchParams.set('client_id', CLIENT_ID)
-        authorize.searchParams.set('redirect_uri', REDIRECT_URI)
-        authorize.searchParams.set('response_type', 'code')
-        authorize.searchParams.set('scope', 'openid offline_access mcp:read')
-        authorize.searchParams.set('state', 'xyz')
-        authorize.searchParams.set('code_challenge', challenge)
-        authorize.searchParams.set('code_challenge_method', 'S256')
-        authorize.searchParams.set('resource', 'http://localhost:8787/mcp')
-        const toConsent = yield* redirectTarget(
-          yield* Effect.promise(() =>
-            auth.instance.handler(new Request(authorize, { headers }))
+          expect(metadata.status).toBe(200)
+          const document = yield* Effect.promise(() => metadata.json())
+          expect(document.issuer).toBe('http://localhost:3071/api/auth')
+          expect(document.authorization_endpoint).toBe(
+            'http://localhost:3071/api/auth/oauth2/authorize'
           )
-        )
-        expect(toConsent.pathname).toBe(MCP_CONSENT_PAGE)
-        expect(toConsent.searchParams.get('client_id')).toBe(CLIENT_ID)
-        expect(toConsent.searchParams.has('sig')).toBe(true)
-
-        // 2. The consent server function: pick the workspace, then resume the
-        //    authorization vouching for the pick.
-        yield* auth.api.setActiveOrganization({
-          body: { organizationId: workspace.id },
-          headers
+          expect(document.jwks_uri).toBe('http://localhost:3071/api/auth/jwks')
+          expect(document.code_challenge_methods_supported).toContain('S256')
+          expect(document.client_id_metadata_document_supported).toBe(true)
         })
-        const vouching = new Headers(headers)
-        vouching.set(MCP_WORKSPACE_SELECTED_HEADER, workspace.id)
-        const continued = yield* postForRedirect(auth, '/oauth2/continue', vouching, {
-          postLogin: true,
-          oauth_query: toConsent.search.slice(1)
-        })
-        // No standing consent yet: back to the consent page, this time as the
-        // consent hop (the provider marks the pick as cleared for this session).
-        expect(continued.pathname).toBe(MCP_CONSENT_PAGE)
-        expect(continued.searchParams.has('ba_pl')).toBe(true)
+      )
+  )
 
-        // 3. Accept — the code is issued to the client's redirect URI.
-        const callback = yield* postForRedirect(auth, '/oauth2/consent', headers, {
-          accept: true,
-          oauth_query: continued.search.slice(1)
-        })
-        expect(callback.origin + callback.pathname).toBe(REDIRECT_URI)
-        expect(callback.searchParams.get('state')).toBe('xyz')
-        const code = callback.searchParams.get('code')
-        expect(code).not.toBeNull()
-
-        // 4. The client exchanges the code.
-        const tokenResponse = yield* Effect.promise(() =>
-          auth.instance.handler(
-            new Request('http://localhost:3071/api/auth/oauth2/token', {
-              method: 'POST',
-              headers: { 'content-type': 'application/x-www-form-urlencoded' },
-              body: new URLSearchParams({
-                grant_type: 'authorization_code',
-                code: code ?? '',
-                redirect_uri: REDIRECT_URI,
-                client_id: CLIENT_ID,
-                code_verifier: verifier,
-                resource: 'http://localhost:8787/mcp'
-              })
-            })
-          )
-        )
-        expect(tokenResponse.status).toBe(200)
-        const TokenPair = Schema.Struct({
-          access_token: Schema.String,
-          refresh_token: Schema.String
-        })
-        const decodeTokenPair = Schema.decodeUnknownSync(TokenPair)
-        const tokens = decodeTokenPair(
-          yield* Effect.promise(() => tokenResponse.json())
-        )
-        expect(tokens.access_token.length).toBeGreaterThan(0)
-        expect(tokens.refresh_token.length).toBeGreaterThan(0)
-
-        // 5. The access token verifies against the published JWKS and names
-        //    the picked workspace — the claims the API worker acts on.
-        const jwksResponse = yield* Effect.promise(() =>
-          auth.instance.handler(new Request('http://localhost:3071/api/auth/jwks'))
-        )
-        const keySet = createLocalJWKSet(
-          yield* Effect.promise(() => jwksResponse.json())
-        )
-        const { payload } = yield* Effect.promise(() =>
-          jwtVerify(tokens.access_token, keySet, {
-            issuer: 'http://localhost:3071/api/auth',
-            audience: 'http://localhost:8787/mcp'
+  it.live(
+    'issues a workspace-bound access token after the consent page picks a workspace',
+    () =>
+      run(
+        Effect.gen(function* () {
+          const auth = yield* Auth.Tag
+          const { headers, userId } = yield* signUpSession('member@mcp.test')
+          const workspace = yield* auth.api.createOrganization({
+            body: { name: 'MCP Co', slug: 'mcp-co' },
+            headers
           })
-        )
-        expect(payload.sub).toBe(userId)
-        expect(payload.scope).toBe('openid offline_access mcp:read')
-        expect(payload[MCP_WORKSPACE_ID_CLAIM]).toBe(workspace.id)
-        expect(payload[MCP_WORKSPACE_SLUG_CLAIM]).toBe('mcp-co')
-        expect(payload[MCP_WORKSPACE_ROLE_CLAIM]).toBe('owner')
+          // A CIMD client, as the plugin would have registered it on discovery:
+          // registration links the client to the MCP resource it asked for.
+          yield* Effect.promise(() =>
+            db
+              .insert(oauthClient)
+              .values({
+                id: 'oac_live_mcp',
+                clientId: CLIENT_ID,
+                name: 'Live MCP client',
+                redirectUris: [REDIRECT_URI],
+                tokenEndpointAuthMethod: 'none',
+                grantTypes: ['authorization_code', 'refresh_token'],
+                responseTypes: ['code'],
+                scopes: ['openid', 'offline_access', 'mcp:read'],
+                requirePKCE: true
+              })
+              .run()
+          )
+          yield* Effect.promise(() =>
+            db
+              .insert(oauthClientResource)
+              .values({
+                id: 'ocr_live_mcp',
+                clientId: CLIENT_ID,
+                resourceId: 'http://localhost:8787/mcp'
+              })
+              .run()
+          )
+          const { verifier, challenge } = pkce()
 
-        // The consent row carries the workspace as its reference, so a consent
-        // for this workspace is no consent for another.
-        const consents = yield* auth.api.getOAuthConsents({ headers })
-        expect(consents.map((consent) => consent.referenceId)).toEqual([workspace.id])
-      })
-    ))
+          // 1. The client sends the browser to /oauth2/authorize. Signed in, with
+          //    no workspace vouched for, the provider's post-login hop sends it to
+          //    the consent page carrying the signed request.
+          const authorize = new URL('http://localhost:3071/api/auth/oauth2/authorize')
+          authorize.searchParams.set('client_id', CLIENT_ID)
+          authorize.searchParams.set('redirect_uri', REDIRECT_URI)
+          authorize.searchParams.set('response_type', 'code')
+          authorize.searchParams.set('scope', 'openid offline_access mcp:read')
+          authorize.searchParams.set('state', 'xyz')
+          authorize.searchParams.set('code_challenge', challenge)
+          authorize.searchParams.set('code_challenge_method', 'S256')
+          authorize.searchParams.set('resource', 'http://localhost:8787/mcp')
+          const toConsent = yield* redirectTarget(
+            yield* Effect.promise(() =>
+              auth.instance.handler(new Request(authorize, { headers }))
+            )
+          )
+          expect(toConsent.pathname).toBe(MCP_CONSENT_PAGE)
+          expect(toConsent.searchParams.get('client_id')).toBe(CLIENT_ID)
+          expect(toConsent.searchParams.has('sig')).toBe(true)
 
-  it('refuses to authorize without a workspace pick', () =>
+          // 2. The consent server function: pick the workspace, then resume the
+          //    authorization vouching for the pick.
+          yield* auth.api.setActiveOrganization({
+            body: { organizationId: workspace.id },
+            headers
+          })
+          const vouching = new Headers(headers)
+          vouching.set(MCP_WORKSPACE_SELECTED_HEADER, workspace.id)
+          const continued = yield* postForRedirect(auth, '/oauth2/continue', vouching, {
+            postLogin: true,
+            oauth_query: toConsent.search.slice(1)
+          })
+          // No standing consent yet: back to the consent page, this time as the
+          // consent hop (the provider marks the pick as cleared for this session).
+          expect(continued.pathname).toBe(MCP_CONSENT_PAGE)
+          expect(continued.searchParams.has('ba_pl')).toBe(true)
+
+          // 3. Accept — the code is issued to the client's redirect URI.
+          const callback = yield* postForRedirect(auth, '/oauth2/consent', headers, {
+            accept: true,
+            oauth_query: continued.search.slice(1)
+          })
+          expect(callback.origin + callback.pathname).toBe(REDIRECT_URI)
+          expect(callback.searchParams.get('state')).toBe('xyz')
+          const code = callback.searchParams.get('code')
+          expect(code).not.toBeNull()
+
+          // 4. The client exchanges the code.
+          const tokenResponse = yield* Effect.promise(() =>
+            auth.instance.handler(
+              new Request('http://localhost:3071/api/auth/oauth2/token', {
+                method: 'POST',
+                headers: { 'content-type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams({
+                  grant_type: 'authorization_code',
+                  code: code ?? '',
+                  redirect_uri: REDIRECT_URI,
+                  client_id: CLIENT_ID,
+                  code_verifier: verifier,
+                  resource: 'http://localhost:8787/mcp'
+                })
+              })
+            )
+          )
+          expect(tokenResponse.status).toBe(200)
+          const TokenPair = Schema.Struct({
+            access_token: Schema.String,
+            refresh_token: Schema.String
+          })
+          const decodeTokenPair = Schema.decodeUnknownSync(TokenPair)
+          const tokens = decodeTokenPair(
+            yield* Effect.promise(() => tokenResponse.json())
+          )
+          expect(tokens.access_token.length).toBeGreaterThan(0)
+          expect(tokens.refresh_token.length).toBeGreaterThan(0)
+
+          // 5. The access token verifies against the published JWKS and names
+          //    the picked workspace — the claims the API worker acts on.
+          const jwksResponse = yield* Effect.promise(() =>
+            auth.instance.handler(new Request('http://localhost:3071/api/auth/jwks'))
+          )
+          const keySet = createLocalJWKSet(
+            yield* Effect.promise(() => jwksResponse.json())
+          )
+          const { payload } = yield* Effect.promise(() =>
+            jwtVerify(tokens.access_token, keySet, {
+              issuer: 'http://localhost:3071/api/auth',
+              audience: 'http://localhost:8787/mcp'
+            })
+          )
+          expect(payload.sub).toBe(userId)
+          expect(payload.scope).toBe('openid offline_access mcp:read')
+          expect(payload[MCP_WORKSPACE_ID_CLAIM]).toBe(workspace.id)
+          expect(payload[MCP_WORKSPACE_SLUG_CLAIM]).toBe('mcp-co')
+          expect(payload[MCP_WORKSPACE_ROLE_CLAIM]).toBe('owner')
+
+          // The consent row carries the workspace as its reference, so a consent
+          // for this workspace is no consent for another.
+          const consents = yield* auth.api.getOAuthConsents({ headers })
+          expect(consents.map((consent) => consent.referenceId)).toEqual([workspace.id])
+        })
+      )
+  )
+
+  it.live('refuses to authorize without a workspace pick', () =>
     run(
       Effect.gen(function* () {
         const auth = yield* Auth.Tag
@@ -328,5 +334,6 @@ describe('mcp oauth authorization server', () => {
         expect(continued.pathname).toBe(MCP_CONSENT_PAGE)
         expect(continued.searchParams.has('ba_pl')).toBe(false)
       })
-    ))
+    )
+  )
 })

--- a/packages/auth/src/live-mcp-oauth.test.ts
+++ b/packages/auth/src/live-mcp-oauth.test.ts
@@ -33,7 +33,7 @@ let authLayer: Layer.Layer<AuthService>
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
-    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the hook is the port: layer() suites expose no live tester for a real-clock suite, and a memoized fixture could not dispose its workerd process
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-mcp-oauth.test.ts
+++ b/packages/auth/src/live-mcp-oauth.test.ts
@@ -33,6 +33,7 @@ let authLayer: Layer.Layer<AuthService>
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-organization.test.ts
+++ b/packages/auth/src/live-organization.test.ts
@@ -27,6 +27,7 @@ let authLayer: Layer.Layer<AuthService>
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-organization.test.ts
+++ b/packages/auth/src/live-organization.test.ts
@@ -2,7 +2,7 @@ import { type DrizzleDatabase } from './ports.ts'
 import { user, workspaceInvitations, workspaces } from '@b2b-saas-starter/db/schema'
 import { Effect, type Layer } from 'effect'
 import { eq } from 'drizzle-orm'
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test'
+import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest'
 import { Auth } from './index.ts'
 import {
   buildAuthLayer,
@@ -41,7 +41,7 @@ beforeAll(
 afterAll(() => provisioned.dispose())
 
 function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
-  return Effect.runPromise(Effect.provide(effect, authLayer))
+  return Effect.provide(effect, authLayer)
 }
 
 /** The plugin needs an existing user to own the workspace it creates. */
@@ -50,7 +50,7 @@ function seedUser(id: string, email: string) {
 }
 
 describe('organization plugin', () => {
-  it('creates a workspace through the remapped organization model', () =>
+  it.live('creates a workspace through the remapped organization model', () =>
     run(
       Effect.gen(function* () {
         yield* seedUser('usr_acme_owner', 'owner@acme.test')
@@ -68,9 +68,10 @@ describe('organization plugin', () => {
         expect(rows).toHaveLength(1)
         expect(rows[0]?.name).toBe('Acme')
       })
-    ))
+    )
+  )
 
-  it('carries planId and updatedAt as organization additional fields', () =>
+  it.live('carries planId and updatedAt as organization additional fields', () =>
     run(
       Effect.gen(function* () {
         yield* seedUser('usr_plan_owner', 'owner@plan.test')
@@ -86,9 +87,10 @@ describe('organization plugin', () => {
         expect(created.planId).toBe('starter')
         expect(created.updatedAt).toBeInstanceOf(Date)
       })
-    ))
+    )
+  )
 
-  it('creates an invitation through the remapped invitation model', () =>
+  it.live('creates an invitation through the remapped invitation model', () =>
     run(
       Effect.gen(function* () {
         const { headers } = yield* signUpSession('inviter@invite.test')
@@ -119,9 +121,10 @@ describe('organization plugin', () => {
         expect(rows[0]?.status).toBe('pending')
         expect(rows[0]?.workspaceId).toBe(workspace.id)
       })
-    ))
+    )
+  )
 
-  it('answers hasPermission from the starter statement set', () =>
+  it.live('answers hasPermission from the starter statement set', () =>
     run(
       Effect.gen(function* () {
         const { headers } = yield* signUpSession('owner@perm.test')
@@ -143,12 +146,13 @@ describe('organization plugin', () => {
 
         expect(result.success).toBe(true)
       })
-    ))
+    )
+  )
 
   // The two below guard configuration that is correct today; they exist to fail
   // if it is changed, not because they drove it.
 
-  it('keeps the plugin default statements working under the starter roles', () =>
+  it.live('keeps the plugin default statements working under the starter roles', () =>
     run(
       Effect.gen(function* () {
         const owner = yield* signUpSession('owner@roles.test')
@@ -198,9 +202,10 @@ describe('organization plugin', () => {
         expect(memberUpdates.success).toBe(false)
         expect(memberReadsNotifications.success).toBe(true)
       })
-    ))
+    )
+  )
 
-  it('exposes no team endpoints', () =>
+  it.live('exposes no team endpoints', () =>
     run(
       Effect.gen(function* () {
         const auth = yield* Auth.Tag
@@ -212,11 +217,12 @@ describe('organization plugin', () => {
         expect(endpoints).not.toContain('createTeam')
         expect(endpoints).not.toContain('setActiveTeam')
       })
-    ))
+    )
+  )
 })
 
 describe('two-factor plugin', () => {
-  it('enables TOTP, verifies it, and flips twoFactorEnabled on the user', () =>
+  it.live('enables TOTP, verifies it, and flips twoFactorEnabled on the user', () =>
     run(
       Effect.gen(function* () {
         const session = yield* signUpSession('totp@twofactor.test')
@@ -233,5 +239,6 @@ describe('two-factor plugin', () => {
         )
         expect(rows[0]?.twoFactorEnabled).toBe(true)
       })
-    ))
+    )
+  )
 })

--- a/packages/auth/src/live-organization.test.ts
+++ b/packages/auth/src/live-organization.test.ts
@@ -27,7 +27,7 @@ let authLayer: Layer.Layer<AuthService>
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
-    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the hook is the port: layer() suites expose no live tester for a real-clock suite, and a memoized fixture could not dispose its workerd process
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-passkey.test.ts
+++ b/packages/auth/src/live-passkey.test.ts
@@ -13,7 +13,7 @@ import {
   mergeCookiePairs
 } from 'effectful-better-auth'
 import { eq } from 'drizzle-orm'
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test'
+import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest'
 import { Auth } from './index.ts'
 import {
   buildAuthLayer,
@@ -66,7 +66,7 @@ beforeAll(
 afterAll(() => provisioned.dispose())
 
 function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
-  return Effect.runPromise(Effect.provide(effect, authLayer))
+  return Effect.provide(effect, authLayer)
 }
 
 /* -------------------------------------------------------------------------- */
@@ -402,7 +402,7 @@ function signInWithPasskey(authenticator: ReturnType<typeof makeAuthenticator>) 
 /* -------------------------------------------------------------------------- */
 
 describe('passkey plugin', () => {
-  it('registers a passkey under a user-chosen name against the mapped table', () =>
+  it.live('registers a passkey under a user-chosen name against the mapped table', () =>
     run(
       Effect.gen(function* () {
         const { cookieHeader } = yield* signUpSession('passkey@owner.test')
@@ -422,9 +422,10 @@ describe('passkey plugin', () => {
         expect(rows[0]?.name).toBe('MacBook Touch ID')
         expect(rows[0]?.credentialID).toBe(created.credentialID)
       })
-    ))
+    )
+  )
 
-  it('lists, renames, and removes the signed-in user passkeys', () =>
+  it.live('lists, renames, and removes the signed-in user passkeys', () =>
     run(
       Effect.gen(function* () {
         const { cookieHeader } = yield* signUpSession('passkey@manage.test')
@@ -451,9 +452,10 @@ describe('passkey plugin', () => {
         const after = yield* auth.api.listPasskeys({ headers })
         expect(after).toHaveLength(0)
       })
-    ))
+    )
+  )
 
-  it('signs in with a passkey and opens a working session', () =>
+  it.live('signs in with a passkey and opens a working session', () =>
     run(
       Effect.gen(function* () {
         const { cookieHeader } = yield* signUpSession('passkey@signin.test')
@@ -473,9 +475,10 @@ describe('passkey plugin', () => {
         expect(listed).toHaveLength(1)
         expect(listed[0]?.name).toBe('Key')
       })
-    ))
+    )
+  )
 
-  it('rejects an assertion whose challenge does not match the issued one', () =>
+  it.live('rejects an assertion whose challenge does not match the issued one', () =>
     run(
       Effect.gen(function* () {
         const { cookieHeader } = yield* signUpSession('passkey@tamper.test')
@@ -504,33 +507,37 @@ describe('passkey plugin', () => {
           )
         expect(attempt.refused).toBe(true)
       })
-    ))
+    )
+  )
 
-  it('satisfies the two-factor requirement: TOTP-enabled users sign in without a code', () =>
-    run(
-      Effect.gen(function* () {
-        const session = yield* signUpSession('passkey@twofactor.test')
-        const authenticator = makeAuthenticator()
+  it.live(
+    'satisfies the two-factor requirement: TOTP-enabled users sign in without a code',
+    () =>
+      run(
+        Effect.gen(function* () {
+          const session = yield* signUpSession('passkey@twofactor.test')
+          const authenticator = makeAuthenticator()
 
-        // Enable TOTP the way the account panel does — the shared ceremony's
-        // returned cookie carries the session through every rotation.
-        const { freshCookieHeader } = yield* enableTotp(session)
+          // Enable TOTP the way the account panel does — the shared ceremony's
+          // returned cookie carries the session through every rotation.
+          const { freshCookieHeader } = yield* enableTotp(session)
 
-        // The passkey ceremony opens a session DIRECTLY — no twoFactorRedirect
-        // hop exists on this path (ADR 0056): the two-factor plugin's after
-        // hook matches the credential sign-in endpoints only.
-        yield* registerPasskey(freshCookieHeader, authenticator, 'Key')
-        const { verification, cookies } = yield* signInWithPasskey(authenticator)
-        expect(verification.response.session).toBeDefined()
+          // The passkey ceremony opens a session DIRECTLY — no twoFactorRedirect
+          // hop exists on this path (ADR 0056): the two-factor plugin's after
+          // hook matches the credential sign-in endpoints only.
+          yield* registerPasskey(freshCookieHeader, authenticator, 'Key')
+          const { verification, cookies } = yield* signInWithPasskey(authenticator)
+          expect(verification.response.session).toBeDefined()
 
-        const rows = yield* Effect.promise(() =>
-          db.select().from(user).where(eq(user.email, 'passkey@twofactor.test'))
-        )
-        expect(rows[0]?.twoFactorEnabled).toBe(true)
+          const rows = yield* Effect.promise(() =>
+            db.select().from(user).where(eq(user.email, 'passkey@twofactor.test'))
+          )
+          expect(rows[0]?.twoFactorEnabled).toBe(true)
 
-        // The challenge cookie is not a session: only the ceremony's session
-        // cookie opens one (the set above proves it).
-        expect(cookies).toContain('better-auth.session_token=')
-      })
-    ))
+          // The challenge cookie is not a session: only the ceremony's session
+          // cookie opens one (the set above proves it).
+          expect(cookies).toContain('better-auth.session_token=')
+        })
+      )
+  )
 })

--- a/packages/auth/src/live-passkey.test.ts
+++ b/packages/auth/src/live-passkey.test.ts
@@ -52,7 +52,7 @@ let authLayer: Layer.Layer<AuthService>
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
-    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the hook is the port: layer() suites expose no live tester for a real-clock suite, and a memoized fixture could not dispose its workerd process
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-passkey.test.ts
+++ b/packages/auth/src/live-passkey.test.ts
@@ -52,6 +52,7 @@ let authLayer: Layer.Layer<AuthService>
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-two-factor.test.ts
+++ b/packages/auth/src/live-two-factor.test.ts
@@ -58,6 +58,7 @@ const capturingEmailSender: AuthEmailSender = {
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-two-factor.test.ts
+++ b/packages/auth/src/live-two-factor.test.ts
@@ -58,7 +58,7 @@ const capturingEmailSender: AuthEmailSender = {
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
-    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the hook is the port: layer() suites expose no live tester for a real-clock suite, and a memoized fixture could not dispose its workerd process
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/live-two-factor.test.ts
+++ b/packages/auth/src/live-two-factor.test.ts
@@ -3,7 +3,7 @@ import { user } from '@b2b-saas-starter/db/schema'
 import { Effect, type Layer } from 'effect'
 import { cookieHeader as toCookieHeader, cookiePairs } from 'effectful-better-auth'
 import { eq } from 'drizzle-orm'
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test'
+import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest'
 import { type AuthEmailSender, Auth } from './index.ts'
 import {
   buildAuthLayer,
@@ -72,7 +72,7 @@ beforeAll(
 afterAll(() => provisioned.dispose())
 
 function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
-  return Effect.runPromise(Effect.provide(effect, authLayer))
+  return Effect.provide(effect, authLayer)
 }
 
 /** The raw instance handler's answer for one credential sign-in attempt. */
@@ -146,31 +146,36 @@ function codeFor(email: string): string {
 }
 
 describe('the two-factor challenge hop', () => {
-  it('diverts a TOTP-enabled credential sign-in and leaves no working session', () =>
-    run(
-      Effect.gen(function* () {
-        const email = 'challenge@twofactor.test'
-        yield* totpUser(email)
+  it.live(
+    'diverts a TOTP-enabled credential sign-in and leaves no working session',
+    () =>
+      run(
+        Effect.gen(function* () {
+          const email = 'challenge@twofactor.test'
+          yield* totpUser(email)
 
-        const signIn = yield* signInWithEmail(email)
-        expect(signIn.status).toBe(200)
-        const body = yield* Effect.promise(() => signIn.json())
-        // The hook's answer replaces the sign-in's own.
-        expect(body.twoFactorRedirect).toBe(true)
+          const signIn = yield* signInWithEmail(email)
+          expect(signIn.status).toBe(200)
+          const body = yield* Effect.promise(() => signIn.json())
+          // The hook's answer replaces the sign-in's own.
+          expect(body.twoFactorRedirect).toBe(true)
 
-        // The challenge cookie is set in place of the session: the hook
-        // deletes the session it had minted and expires its cookie, so the
-        // jar the response builds opens nothing.
-        const cookies = signIn.headers.getSetCookie().join(' ')
-        expect(cookies).toContain('two_factor')
-        const probe = yield* getSessionWith(toCookieHeader(cookiePairs(signIn.headers)))
-        expect(probe.status).toBe(200)
-        const probeBody = yield* Effect.promise(() => probe.json())
-        expect(probeBody).toBeNull()
-      })
-    ))
+          // The challenge cookie is set in place of the session: the hook
+          // deletes the session it had minted and expires its cookie, so the
+          // jar the response builds opens nothing.
+          const cookies = signIn.headers.getSetCookie().join(' ')
+          expect(cookies).toContain('two_factor')
+          const probe = yield* getSessionWith(
+            toCookieHeader(cookiePairs(signIn.headers))
+          )
+          expect(probe.status).toBe(200)
+          const probeBody = yield* Effect.promise(() => probe.json())
+          expect(probeBody).toBeNull()
+        })
+      )
+  )
 
-  it('mints the session when the challenge is completed with a code', () =>
+  it.live('mints the session when the challenge is completed with a code', () =>
     run(
       Effect.gen(function* () {
         const email = 'completer@twofactor.test'
@@ -197,25 +202,29 @@ describe('the two-factor challenge hop', () => {
         const probeBody = yield* Effect.promise(() => probe.json())
         expect(probeBody?.user?.email).toBe(email)
       })
-    ))
+    )
+  )
 
-  it('still mints an email-OTP session for that same user — the gap the app gate closes', () =>
-    run(
-      Effect.gen(function* () {
-        const email = 'otp-gap@twofactor.test'
-        yield* totpUser(email)
-        const auth = yield* Auth.Tag
+  it.live(
+    'still mints an email-OTP session for that same user — the gap the app gate closes',
+    () =>
+      run(
+        Effect.gen(function* () {
+          const email = 'otp-gap@twofactor.test'
+          yield* totpUser(email)
+          const auth = yield* Auth.Tag
 
-        yield* auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+          yield* auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
 
-        // The plugin's two-factor hook matches the credential sign-in
-        // endpoints only, so the emailed code mints the session outright —
-        // documented here so the app-layer gate has a pinned reason to exist.
-        const { response, headers } = yield* auth.full.signInEmailOTP({
-          body: { email, otp: codeFor(email) }
+          // The plugin's two-factor hook matches the credential sign-in
+          // endpoints only, so the emailed code mints the session outright —
+          // documented here so the app-layer gate has a pinned reason to exist.
+          const { response, headers } = yield* auth.full.signInEmailOTP({
+            body: { email, otp: codeFor(email) }
+          })
+          expect(response.user.email).toBe(email)
+          expect(headers.getSetCookie().join(' ')).toContain('session_token=')
         })
-        expect(response.user.email).toBe(email)
-        expect(headers.getSetCookie().join(' ')).toContain('session_token=')
-      })
-    ))
+      )
+  )
 })

--- a/packages/auth/src/options.test.ts
+++ b/packages/auth/src/options.test.ts
@@ -1,6 +1,6 @@
 import { adminSystemRole } from '@b2b-saas-starter/db/enums'
 import { Effect } from 'effect'
-import { describe, expect, it, vi } from 'vite-plus/test'
+import { describe, expect, it, vi } from '@effect/vitest'
 import {
   type AuthConfigInterface,
   MAGIC_LINK_EXPIRES_IN_SECONDS,
@@ -157,26 +157,25 @@ describe('makeAuthOptions', () => {
   })
 
   describe('account linking hooks', () => {
-    it("hands account rows to the caller's link and unlink hooks", () =>
-      Effect.runPromise(
-        Effect.gen(function* () {
-          // The port's promise shape matters: `Effect.promise` awaits what the
-          // hook returns, so the doubles resolve rather than answer undefined.
-          const onAccountLinked = vi.fn().mockResolvedValue(undefined)
-          const onAccountUnlinked = vi.fn().mockResolvedValue(undefined)
-          const hooks = makeAuthOptions({
-            ...baseConfig,
-            accountHooks: { onAccountLinked, onAccountUnlinked }
-          }).databaseHooks.account
-          const account = { providerId: 'github', userId: 'usr_demo' }
+    it.effect("hands account rows to the caller's link and unlink hooks", () =>
+      Effect.gen(function* () {
+        // The port's promise shape matters: `Effect.promise` awaits what the
+        // hook returns, so the doubles resolve rather than answer undefined.
+        const onAccountLinked = vi.fn().mockResolvedValue(undefined)
+        const onAccountUnlinked = vi.fn().mockResolvedValue(undefined)
+        const hooks = makeAuthOptions({
+          ...baseConfig,
+          accountHooks: { onAccountLinked, onAccountUnlinked }
+        }).databaseHooks.account
+        const account = { providerId: 'github', userId: 'usr_demo' }
 
-          yield* Effect.promise(() => hooks.create.after(account))
-          yield* Effect.promise(() => hooks.delete.after(account))
+        yield* Effect.promise(() => hooks.create.after(account))
+        yield* Effect.promise(() => hooks.delete.after(account))
 
-          expect(onAccountLinked).toHaveBeenCalledWith(account)
-          expect(onAccountUnlinked).toHaveBeenCalledWith(account)
-        })
-      ))
+        expect(onAccountLinked).toHaveBeenCalledWith(account)
+        expect(onAccountUnlinked).toHaveBeenCalledWith(account)
+      })
+    )
   })
 
   describe('background tasks', () => {

--- a/packages/auth/src/social-auth.test.ts
+++ b/packages/auth/src/social-auth.test.ts
@@ -128,7 +128,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
-    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the hook is the port: layer() suites expose no live tester for a real-clock suite, and a memoized fixture could not dispose its workerd process
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/social-auth.test.ts
+++ b/packages/auth/src/social-auth.test.ts
@@ -128,6 +128,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/social-auth.test.ts
+++ b/packages/auth/src/social-auth.test.ts
@@ -11,7 +11,7 @@ import {
   expect,
   it,
   vi
-} from 'vite-plus/test'
+} from '@effect/vitest'
 import { type AuthAccountChange, Auth } from './index.ts'
 import {
   buildAuthLayer,
@@ -157,7 +157,7 @@ afterEach(() => {
 afterAll(() => provisioned.dispose())
 
 function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
-  return Effect.runPromise(Effect.provide(effect, authLayer))
+  return Effect.provide(effect, authLayer)
 }
 
 /** A verified email/password user — the implicit-linking precondition. */
@@ -222,75 +222,81 @@ function completeGithubRoundTrip() {
 }
 
 describe('social sign-in', () => {
-  it('links a matching verified social email to the existing account and signs in', () =>
-    run(
-      Effect.gen(function* () {
-        useGithubIdentity('linked@social.test', 987_654)
-        const userId = yield* seedVerifiedLocalUser('linked@social.test')
-        const before = accountChanges.length
+  it.live(
+    'links a matching verified social email to the existing account and signs in',
+    () =>
+      run(
+        Effect.gen(function* () {
+          useGithubIdentity('linked@social.test', 987_654)
+          const userId = yield* seedVerifiedLocalUser('linked@social.test')
+          const before = accountChanges.length
 
-        const callback = yield* completeGithubRoundTrip()
+          const callback = yield* completeGithubRoundTrip()
 
-        // The round trip ends in a redirect to the callback URL with a fresh
-        // session cookie — the sign-in completed.
-        expect(callback.status).toBe(302)
-        expect(callback.headers.get('location')).toBe(
-          'http://localhost:3071/workspaces'
-        )
-        expect(
-          callback.headers
-            .getSetCookie()
-            .some((cookie) => cookie.startsWith('better-auth'))
-        ).toBe(true)
+          // The round trip ends in a redirect to the callback URL with a fresh
+          // session cookie — the sign-in completed.
+          expect(callback.status).toBe(302)
+          expect(callback.headers.get('location')).toBe(
+            'http://localhost:3071/workspaces'
+          )
+          expect(
+            callback.headers
+              .getSetCookie()
+              .some((cookie) => cookie.startsWith('better-auth'))
+          ).toBe(true)
 
-        // Implicit linking: the GitHub account row belongs to the existing
-        // email/password user, not a second user.
-        const rows = yield* Effect.promise(() =>
-          db
-            .select()
-            .from(account)
-            .where(and(eq(account.providerId, 'github'), eq(account.userId, userId)))
-        )
-        expect(rows).toHaveLength(1)
-        expect(rows[0]?.accountId).toBe(String(githubProfile.id))
+          // Implicit linking: the GitHub account row belongs to the existing
+          // email/password user, not a second user.
+          const rows = yield* Effect.promise(() =>
+            db
+              .select()
+              .from(account)
+              .where(and(eq(account.providerId, 'github'), eq(account.userId, userId)))
+          )
+          expect(rows).toHaveLength(1)
+          expect(rows[0]?.accountId).toBe(String(githubProfile.id))
 
-        // The linking audit port saw the same row. Better Auth hands the
-        // whole account row to the hook; the port's contract is the two
-        // fields the audit reads.
-        const change = accountChanges
-          .slice(before)
-          .find((entry) => entry.kind === 'linked')
-        expect(change?.account).toMatchObject({ providerId: 'github', userId })
+          // The linking audit port saw the same row. Better Auth hands the
+          // whole account row to the hook; the port's contract is the two
+          // fields the audit reads.
+          const change = accountChanges
+            .slice(before)
+            .find((entry) => entry.kind === 'linked')
+          expect(change?.account).toMatchObject({ providerId: 'github', userId })
 
-        // Still exactly one user for that mailbox.
-        const users = yield* Effect.promise(() =>
-          db.select().from(user).where(eq(user.email, 'linked@social.test'))
-        )
-        expect(users).toHaveLength(1)
-      })
-    ))
-
-  it('signs up a first-time social visitor as one user with the provider account', () =>
-    run(
-      Effect.gen(function* () {
-        useGithubIdentity('first-time@social.test', 654_321)
-        const before = accountChanges.length
-
-        const callback = yield* completeGithubRoundTrip()
-
-        expect(callback.status).toBe(302)
-        const users = yield* Effect.promise(() =>
-          db.select().from(user).where(eq(user.email, 'first-time@social.test'))
-        )
-        expect(users).toHaveLength(1)
-        expect(accountChanges.slice(before).at(-1)?.account).toMatchObject({
-          providerId: 'github',
-          userId: users[0]!.id
+          // Still exactly one user for that mailbox.
+          const users = yield* Effect.promise(() =>
+            db.select().from(user).where(eq(user.email, 'linked@social.test'))
+          )
+          expect(users).toHaveLength(1)
         })
-      })
-    ))
+      )
+  )
 
-  it('refuses the link when the local mailbox is not verified', () =>
+  it.live(
+    'signs up a first-time social visitor as one user with the provider account',
+    () =>
+      run(
+        Effect.gen(function* () {
+          useGithubIdentity('first-time@social.test', 654_321)
+          const before = accountChanges.length
+
+          const callback = yield* completeGithubRoundTrip()
+
+          expect(callback.status).toBe(302)
+          const users = yield* Effect.promise(() =>
+            db.select().from(user).where(eq(user.email, 'first-time@social.test'))
+          )
+          expect(users).toHaveLength(1)
+          expect(accountChanges.slice(before).at(-1)?.account).toMatchObject({
+            providerId: 'github',
+            userId: users[0]!.id
+          })
+        })
+      )
+  )
+
+  it.live('refuses the link when the local mailbox is not verified', () =>
     run(
       Effect.gen(function* () {
         useGithubIdentity('squatter@social.test', 111_222)
@@ -331,9 +337,10 @@ describe('social sign-in', () => {
         expect(users).toHaveLength(1)
         expect(users[0]?.id).toBe(squatter.id)
       })
-    ))
+    )
+  )
 
-  it('unlinks a provider through the endpoint and reports it to the port', () =>
+  it.live('unlinks a provider through the endpoint and reports it to the port', () =>
     run(
       Effect.gen(function* () {
         useGithubIdentity('unlink@social.test', 333_444)
@@ -382,5 +389,6 @@ describe('social sign-in', () => {
           userId
         })
       })
-    ))
+    )
+  )
 })

--- a/packages/auth/src/sso.test.ts
+++ b/packages/auth/src/sso.test.ts
@@ -4,7 +4,7 @@ import { Effect, type Layer } from 'effect'
 import { cookieHeader, cookiePairs } from 'effectful-better-auth'
 import { eq } from 'drizzle-orm'
 import { createSign, generateKeyPairSync } from 'node:crypto'
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test'
+import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest'
 import { Auth } from './index.ts'
 import {
   buildAuthLayer,
@@ -144,180 +144,186 @@ afterAll(() => {
 })
 
 function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
-  return Effect.runPromise(Effect.provide(effect, authLayer))
+  return Effect.provide(effect, authLayer)
 }
 
 describe('workspace SSO over the sso plugin', () => {
-  it('round-trips a mocked OIDC connection and provisions the member with the connection’s role', () =>
-    run(
-      Effect.gen(function* () {
-        const auth = yield* Auth.Tag
+  it.live(
+    'round-trips a mocked OIDC connection and provisions the member with the connection’s role',
+    () =>
+      run(
+        Effect.gen(function* () {
+          const auth = yield* Auth.Tag
 
-        // The owner registers the connection against their workspace.
-        const owner = yield* signUpSession('owner@roundtrip.test')
-        const workspace = yield* auth.api.createOrganization({
-          body: { name: 'Roundtrip Co', slug: 'roundtrip', userId: owner.userId }
-        })
-        const registered = yield* auth.api.registerSSOProvider({
-          body: {
-            providerId: PROVIDER_ID,
-            issuer: ISSUER,
-            domain: 'roundtrip.test',
-            organizationId: workspace.id,
-            oidcConfig: {
-              clientId: 'rt-client',
-              clientSecret: 'rt-secret',
-              pkce: false,
-              skipDiscovery: true,
-              authorizationEndpoint: `${ISSUER}/authorize`,
-              tokenEndpoint: `${ISSUER}/token`,
-              jwksEndpoint: `${ISSUER}/jwks`,
-              userInfoEndpoint: `${ISSUER}/userinfo`
-            },
-            enabled: true,
-            defaultWorkspaceRole: 'admin'
-          },
-          headers: owner.headers
-        })
-        expect(registered.providerId).toBe(PROVIDER_ID)
-
-        // Domain routing: the email resolves to the connection and the plugin
-        // answers with the authorization redirect. The response also sets the
-        // signed state cookie the callback re-checks, so it is threaded
-        // through like a browser would.
-        const signIn = yield* auth.full.signInSSO({
-          body: {
-            email: 'provisioned@roundtrip.test',
-            callbackURL: 'http://localhost:3071/workspaces'
-          }
-        })
-        expect(signIn.response.redirect).toBe(true)
-        const authorizationUrl = new URL(signIn.response.url)
-        expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
-          `${ISSUER}/authorize`
-        )
-        const state = authorizationUrl.searchParams.get('state')
-        expect(state).toBeTruthy()
-        const stateCookie = cookieHeader(cookiePairs(signIn.headers))
-
-        // The IdP redirects back with a code; the stubbed token endpoint
-        // answers with a signed ID token, the JWKS endpoint with the key.
-        const callback = yield* Effect.promise(() =>
-          auth.instance.api.callbackSSO({
-            params: { providerId: PROVIDER_ID },
-            query: { state: state ?? '', code: 'rt-auth-code' },
-            headers: new Headers({ cookie: stateCookie }),
-            asResponse: true
+          // The owner registers the connection against their workspace.
+          const owner = yield* signUpSession('owner@roundtrip.test')
+          const workspace = yield* auth.api.createOrganization({
+            body: { name: 'Roundtrip Co', slug: 'roundtrip', userId: owner.userId }
           })
-        )
-        expect(callback.status).toBeGreaterThanOrEqual(300)
-        expect(callback.status).toBeLessThan(400)
-        // The session cookie is the proof of a completed sign-in.
-        expect(callback.headers.getSetCookie().length).toBeGreaterThan(0)
-
-        // Provisioning: the user was created…
-        const users = yield* Effect.promise(() =>
-          db.select().from(user).where(eq(user.email, 'provisioned@roundtrip.test'))
-        )
-        expect(users).toHaveLength(1)
-        const provisionedUser = users[0]
-        // …linked to the IdP account…
-        const accounts = yield* Effect.promise(() =>
-          db.select().from(account).where(eq(account.providerId, PROVIDER_ID))
-        )
-        expect(accounts).toHaveLength(1)
-        expect(accounts[0]?.userId).toBe(provisionedUser?.id)
-        // …and added to the workspace with the connection's default role.
-        const members: Array<typeof workspaceMembers.$inferSelect> =
-          yield* Effect.promise(() =>
-            db
-              .select()
-              .from(workspaceMembers)
-              .where(eq(workspaceMembers.workspaceId, workspace.id))
-          )
-        const provisionedMember = members.find(
-          (member) => member.userId === provisionedUser?.id
-        )
-        expect(provisionedMember?.role).toBe('admin')
-
-        // The plugin's own list is sanitized: the secret never leaves the row,
-        // the client id's tail does.
-        const providers = yield* auth.api.listSSOProviders({
-          headers: owner.headers
-        })
-        const serialized = JSON.stringify(providers)
-        expect(serialized).not.toContain('rt-secret')
-        expect(serialized).toContain('rt-client'.slice(-4))
-        expect(serialized).not.toContain('rt-client')
-      })
-    ))
-
-  it('provisions `member` when the stored default role is not a provisioned role', () =>
-    run(
-      Effect.gen(function* () {
-        const auth = yield* Auth.Tag
-        const owner = yield* signUpSession('owner2@roundtrip.test')
-        const workspace = yield* auth.api.createOrganization({
-          body: { name: 'Fallback Co', slug: 'fallback', userId: owner.userId }
-        })
-        // `owner` is NOT a provisioned role: written raw (the plugin types
-        // additional fields as plain strings), the read must narrow it back.
-        yield* auth.api.registerSSOProvider({
-          body: {
-            providerId: 'rt_fallback',
-            issuer: ISSUER,
-            domain: 'fallback.test',
-            organizationId: workspace.id,
-            oidcConfig: {
-              clientId: 'rt-client',
-              clientSecret: 'rt-secret',
-              pkce: false,
-              skipDiscovery: true,
-              authorizationEndpoint: `${ISSUER}/authorize`,
-              tokenEndpoint: `${ISSUER}/token`,
-              jwksEndpoint: `${ISSUER}/jwks`,
-              userInfoEndpoint: `${ISSUER}/userinfo`
+          const registered = yield* auth.api.registerSSOProvider({
+            body: {
+              providerId: PROVIDER_ID,
+              issuer: ISSUER,
+              domain: 'roundtrip.test',
+              organizationId: workspace.id,
+              oidcConfig: {
+                clientId: 'rt-client',
+                clientSecret: 'rt-secret',
+                pkce: false,
+                skipDiscovery: true,
+                authorizationEndpoint: `${ISSUER}/authorize`,
+                tokenEndpoint: `${ISSUER}/token`,
+                jwksEndpoint: `${ISSUER}/jwks`,
+                userInfoEndpoint: `${ISSUER}/userinfo`
+              },
+              enabled: true,
+              defaultWorkspaceRole: 'admin'
             },
-            enabled: true,
-            defaultWorkspaceRole: 'owner'
-          },
-          headers: owner.headers
-        })
-
-        idTokenSubject = 'idp-user-2'
-        idTokenEmail = 'fallback@fallback.test'
-        idTokenName = 'Fallback Member'
-        const signIn = yield* auth.full.signInSSO({
-          body: {
-            email: 'fallback@fallback.test',
-            callbackURL: 'http://localhost:3071/workspaces'
-          }
-        })
-        const state = new URL(signIn.response.url).searchParams.get('state')
-        const stateCookie = cookieHeader(cookiePairs(signIn.headers))
-        yield* Effect.promise(() =>
-          auth.instance.api.callbackSSO({
-            params: { providerId: 'rt_fallback' },
-            query: { state: state ?? '', code: 'rt-auth-code-2' },
-            headers: new Headers({ cookie: stateCookie }),
-            asResponse: true
+            headers: owner.headers
           })
-        )
+          expect(registered.providerId).toBe(PROVIDER_ID)
 
-        const users = yield* Effect.promise(() =>
-          db.select().from(user).where(eq(user.email, 'fallback@fallback.test'))
-        )
-        expect(users).toHaveLength(1)
-        const members: Array<typeof workspaceMembers.$inferSelect> =
-          yield* Effect.promise(() =>
-            db
-              .select()
-              .from(workspaceMembers)
-              .where(eq(workspaceMembers.workspaceId, workspace.id))
+          // Domain routing: the email resolves to the connection and the plugin
+          // answers with the authorization redirect. The response also sets the
+          // signed state cookie the callback re-checks, so it is threaded
+          // through like a browser would.
+          const signIn = yield* auth.full.signInSSO({
+            body: {
+              email: 'provisioned@roundtrip.test',
+              callbackURL: 'http://localhost:3071/workspaces'
+            }
+          })
+          expect(signIn.response.redirect).toBe(true)
+          const authorizationUrl = new URL(signIn.response.url)
+          expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
+            `${ISSUER}/authorize`
           )
-        const member = members.find((row) => row.userId === users[0]?.id)
-        // Never `owner`: the guard narrows the raw value back to `member`.
-        expect(member?.role).toBe('member')
-      })
-    ))
+          const state = authorizationUrl.searchParams.get('state')
+          expect(state).toBeTruthy()
+          const stateCookie = cookieHeader(cookiePairs(signIn.headers))
+
+          // The IdP redirects back with a code; the stubbed token endpoint
+          // answers with a signed ID token, the JWKS endpoint with the key.
+          const callback = yield* Effect.promise(() =>
+            auth.instance.api.callbackSSO({
+              params: { providerId: PROVIDER_ID },
+              query: { state: state ?? '', code: 'rt-auth-code' },
+              headers: new Headers({ cookie: stateCookie }),
+              asResponse: true
+            })
+          )
+          expect(callback.status).toBeGreaterThanOrEqual(300)
+          expect(callback.status).toBeLessThan(400)
+          // The session cookie is the proof of a completed sign-in.
+          expect(callback.headers.getSetCookie().length).toBeGreaterThan(0)
+
+          // Provisioning: the user was created…
+          const users = yield* Effect.promise(() =>
+            db.select().from(user).where(eq(user.email, 'provisioned@roundtrip.test'))
+          )
+          expect(users).toHaveLength(1)
+          const provisionedUser = users[0]
+          // …linked to the IdP account…
+          const accounts = yield* Effect.promise(() =>
+            db.select().from(account).where(eq(account.providerId, PROVIDER_ID))
+          )
+          expect(accounts).toHaveLength(1)
+          expect(accounts[0]?.userId).toBe(provisionedUser?.id)
+          // …and added to the workspace with the connection's default role.
+          const members: Array<typeof workspaceMembers.$inferSelect> =
+            yield* Effect.promise(() =>
+              db
+                .select()
+                .from(workspaceMembers)
+                .where(eq(workspaceMembers.workspaceId, workspace.id))
+            )
+          const provisionedMember = members.find(
+            (member) => member.userId === provisionedUser?.id
+          )
+          expect(provisionedMember?.role).toBe('admin')
+
+          // The plugin's own list is sanitized: the secret never leaves the row,
+          // the client id's tail does.
+          const providers = yield* auth.api.listSSOProviders({
+            headers: owner.headers
+          })
+          const serialized = JSON.stringify(providers)
+          expect(serialized).not.toContain('rt-secret')
+          expect(serialized).toContain('rt-client'.slice(-4))
+          expect(serialized).not.toContain('rt-client')
+        })
+      )
+  )
+
+  it.live(
+    'provisions `member` when the stored default role is not a provisioned role',
+    () =>
+      run(
+        Effect.gen(function* () {
+          const auth = yield* Auth.Tag
+          const owner = yield* signUpSession('owner2@roundtrip.test')
+          const workspace = yield* auth.api.createOrganization({
+            body: { name: 'Fallback Co', slug: 'fallback', userId: owner.userId }
+          })
+          // `owner` is NOT a provisioned role: written raw (the plugin types
+          // additional fields as plain strings), the read must narrow it back.
+          yield* auth.api.registerSSOProvider({
+            body: {
+              providerId: 'rt_fallback',
+              issuer: ISSUER,
+              domain: 'fallback.test',
+              organizationId: workspace.id,
+              oidcConfig: {
+                clientId: 'rt-client',
+                clientSecret: 'rt-secret',
+                pkce: false,
+                skipDiscovery: true,
+                authorizationEndpoint: `${ISSUER}/authorize`,
+                tokenEndpoint: `${ISSUER}/token`,
+                jwksEndpoint: `${ISSUER}/jwks`,
+                userInfoEndpoint: `${ISSUER}/userinfo`
+              },
+              enabled: true,
+              defaultWorkspaceRole: 'owner'
+            },
+            headers: owner.headers
+          })
+
+          idTokenSubject = 'idp-user-2'
+          idTokenEmail = 'fallback@fallback.test'
+          idTokenName = 'Fallback Member'
+          const signIn = yield* auth.full.signInSSO({
+            body: {
+              email: 'fallback@fallback.test',
+              callbackURL: 'http://localhost:3071/workspaces'
+            }
+          })
+          const state = new URL(signIn.response.url).searchParams.get('state')
+          const stateCookie = cookieHeader(cookiePairs(signIn.headers))
+          yield* Effect.promise(() =>
+            auth.instance.api.callbackSSO({
+              params: { providerId: 'rt_fallback' },
+              query: { state: state ?? '', code: 'rt-auth-code-2' },
+              headers: new Headers({ cookie: stateCookie }),
+              asResponse: true
+            })
+          )
+
+          const users = yield* Effect.promise(() =>
+            db.select().from(user).where(eq(user.email, 'fallback@fallback.test'))
+          )
+          expect(users).toHaveLength(1)
+          const members: Array<typeof workspaceMembers.$inferSelect> =
+            yield* Effect.promise(() =>
+              db
+                .select()
+                .from(workspaceMembers)
+                .where(eq(workspaceMembers.workspaceId, workspace.id))
+            )
+          const member = members.find((row) => row.userId === users[0]?.id)
+          // Never `owner`: the guard narrows the raw value back to `member`.
+          expect(member?.role).toBe('member')
+        })
+      )
+  )
 })

--- a/packages/auth/src/sso.test.ts
+++ b/packages/auth/src/sso.test.ts
@@ -126,6 +126,7 @@ async function stubbedFetch(
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process and the fetch stub
 beforeAll(
   () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/auth/src/sso.test.ts
+++ b/packages/auth/src/sso.test.ts
@@ -126,7 +126,7 @@ async function stubbedFetch(
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process and the fetch stub
 beforeAll(
   () =>
-    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the hook is the port: layer() suites expose no live tester for a real-clock suite, and a memoized fixture could not dispose its workerd process
     Effect.runPromise(
       Effect.gen(function* () {
         provisioned = yield* Effect.promise(() => provisionAuthD1())

--- a/packages/capabilities/src/governance/account-lifecycle.live.test.ts
+++ b/packages/capabilities/src/governance/account-lifecycle.live.test.ts
@@ -204,6 +204,7 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live account lifecycle', (
           userId: 'usr_mixed',
           password: DELETE_PASSWORD,
           beforeDelete: (userId) =>
+            // oxlint-disable-next-line starter/no-run-promise-in-tests -- Better Auth calls these hooks as plain promise callbacks outside any Effect runtime; the runPromise is the port
             Effect.runPromise(
               Effect.flatMap(AccountLifecycle, (lifecycle) =>
                 lifecycle.prepareDeletion(userId)
@@ -218,6 +219,7 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live account lifecycle', (
               )
             ),
           afterDelete: (userId) =>
+            // oxlint-disable-next-line starter/no-run-promise-in-tests -- Better Auth calls these hooks as plain promise callbacks outside any Effect runtime; the runPromise is the port
             Effect.runPromise(
               Effect.flatMap(AccountLifecycle, (lifecycle) =>
                 Effect.flatMap(readHandoffPlan(hookPlan), (plan) =>

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
+    "@effect/vitest": "catalog:",
     "drizzle-kit": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/packages/db/src/live-d1.test.ts
+++ b/packages/db/src/live-d1.test.ts
@@ -30,6 +30,7 @@ let dbLayer: ReturnType<typeof layerFromD1>
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
     Effect.runPromise(
       Effect.gen(function* () {
         test = yield* Effect.promise(() => provisionTestD1())

--- a/packages/db/src/live-d1.test.ts
+++ b/packages/db/src/live-d1.test.ts
@@ -24,13 +24,13 @@ let dbLayer: ReturnType<typeof layerFromD1>
 
 // getPlatformProxy boots a workerd process (~seconds) that the whole suite
 // shares and must dispose afterwards. The suite lifecycle stays vitest's:
-// `@effect/vitest`'s `it.layer(...)` could own the process as a scoped
-// Layer, but converting setup hooks is a separate change from migrating
-// test bodies.
+// `@effect/vitest`'s `layer(...)` would own the process as a scoped Layer,
+// but it hands its callback a tester with no `live` (`MethodsNonLive`), and
+// these tests read the real clock over workerd — so the hook is the port.
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
-    // oxlint-disable-next-line starter/no-run-promise-in-tests -- suite setup runs outside any test; converting the hook to it.layer is a separate change
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- the hook is the port: layer() suites expose no live tester for a real-clock suite, and a memoized fixture could not dispose its workerd process
     Effect.runPromise(
       Effect.gen(function* () {
         test = yield* Effect.promise(() => provisionTestD1())
@@ -83,7 +83,7 @@ describe('migrations', () => {
   // The organization plugin reads these tables by its own field names. A
   // column the plugin expects but the migration never created is invisible
   // until a plugin endpoint runs, so assert the contract here instead.
-  it.live.each([
+  describe.each([
     {
       table: 'workspaces',
       columns: [
@@ -116,19 +116,19 @@ describe('migrations', () => {
     },
     // The plugin declares this field on `session` unconditionally.
     { table: 'session', columns: ['activeOrganizationId'] }
-  ])('give $table the columns the organization plugin expects', ({ table, columns }) =>
-    Effect.gen(function* () {
-      const rows = yield* Effect.promise(() =>
-        test.d1.prepare(`PRAGMA table_info(${table})`).all<{ name: string }>()
-      )
-      const actual = new Set(rows.results.map((row) => row.name))
-      // oxlint-disable vitest/no-standalone-expect -- it.live.each's double call hides the test block from the rule
-      for (const column of columns) {
-        expect(actual, `${table} is missing ${column}`).toContain(column)
-      }
-      // oxlint-enable vitest/no-standalone-expect
-    })
-  )
+  ])('$table', ({ table, columns }) => {
+    it.live('has the columns the organization plugin expects', () =>
+      Effect.gen(function* () {
+        const rows = yield* Effect.promise(() =>
+          test.d1.prepare(`PRAGMA table_info(${table})`).all<{ name: string }>()
+        )
+        const actual = new Set(rows.results.map((row) => row.name))
+        for (const column of columns) {
+          expect(actual, `${table} is missing ${column}`).toContain(column)
+        }
+      })
+    )
+  })
 })
 
 describe('column modes over live D1', () => {

--- a/packages/db/src/live-d1.test.ts
+++ b/packages/db/src/live-d1.test.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect'
 import { count, eq, getTableName, is, Table } from 'drizzle-orm'
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test'
+import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest'
 import { provisionTestD1, type TestD1 } from './testing.ts'
 import { Database, layerFromD1, type RawD1, batch, DbBatchError } from './service.ts'
 import * as schema from './schema.ts'
@@ -23,9 +23,10 @@ let test: TestD1
 let dbLayer: ReturnType<typeof layerFromD1>
 
 // getPlatformProxy boots a workerd process (~seconds) that the whole suite
-// shares and must dispose afterwards. Expressing that as a scoped Layer needs
-// `@effect/vitest`'s `it.layer(...)`, which this package does not depend on, so
-// vitest's own suite lifecycle owns the process instead.
+// shares and must dispose afterwards. The suite lifecycle stays vitest's:
+// `@effect/vitest`'s `it.layer(...)` could own the process as a scoped
+// Layer, but converting setup hooks is a separate change from migrating
+// test bodies.
 // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the workerd process
 beforeAll(
   () =>
@@ -42,7 +43,7 @@ beforeAll(
 afterAll(() => test.dispose())
 
 function run<A, E>(effect: Effect.Effect<A, E, Database | RawD1>) {
-  return Effect.runPromise(Effect.provide(effect, dbLayer))
+  return Effect.provide(effect, dbLayer)
 }
 
 // Derived from the schema module, not hand-listed: a table added to
@@ -63,26 +64,25 @@ const createdAtFixture = new Date('2026-08-15T09:00:00.000Z')
 const expiresAtFixture = new Date('2026-08-17T09:00:00.000Z')
 
 describe('migrations', () => {
-  it('create every table the schema declares', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const rows = yield* Effect.promise(() =>
-          test.d1
-            .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
-            .all<{ name: string }>()
-        )
-        const tables = new Set(rows.results.map((row) => row.name))
-        expect(schemaTableNames.length).toBeGreaterThan(0)
-        for (const table of schemaTableNames) {
-          expect(tables, `missing table ${table}`).toContain(table)
-        }
-      })
-    ))
+  it.live('create every table the schema declares', () =>
+    Effect.gen(function* () {
+      const rows = yield* Effect.promise(() =>
+        test.d1
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+          .all<{ name: string }>()
+      )
+      const tables = new Set(rows.results.map((row) => row.name))
+      expect(schemaTableNames.length).toBeGreaterThan(0)
+      for (const table of schemaTableNames) {
+        expect(tables, `missing table ${table}`).toContain(table)
+      }
+    })
+  )
 
   // The organization plugin reads these tables by its own field names. A
   // column the plugin expects but the migration never created is invisible
   // until a plugin endpoint runs, so assert the contract here instead.
-  it.each([
+  it.live.each([
     {
       table: 'workspaces',
       columns: [
@@ -116,22 +116,22 @@ describe('migrations', () => {
     // The plugin declares this field on `session` unconditionally.
     { table: 'session', columns: ['activeOrganizationId'] }
   ])('give $table the columns the organization plugin expects', ({ table, columns }) =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const rows = yield* Effect.promise(() =>
-          test.d1.prepare(`PRAGMA table_info(${table})`).all<{ name: string }>()
-        )
-        const actual = new Set(rows.results.map((row) => row.name))
-        for (const column of columns) {
-          expect(actual, `${table} is missing ${column}`).toContain(column)
-        }
-      })
-    )
+    Effect.gen(function* () {
+      const rows = yield* Effect.promise(() =>
+        test.d1.prepare(`PRAGMA table_info(${table})`).all<{ name: string }>()
+      )
+      const actual = new Set(rows.results.map((row) => row.name))
+      // oxlint-disable vitest/no-standalone-expect -- it.live.each's double call hides the test block from the rule
+      for (const column of columns) {
+        expect(actual, `${table} is missing ${column}`).toContain(column)
+      }
+      // oxlint-enable vitest/no-standalone-expect
+    })
   )
 })
 
 describe('column modes over live D1', () => {
-  it('round-trips JSON-mode text columns as parsed values', () =>
+  it.live('round-trips JSON-mode text columns as parsed values', () =>
     run(
       Effect.gen(function* () {
         const database = yield* Database
@@ -155,14 +155,15 @@ describe('column modes over live D1', () => {
           .where(eq(apiTokens.id, 'tok_json_check'))
         expect(rows[0]?.scopes).toEqual(['read', 'write'])
       })
-    ))
+    )
+  )
 })
 
 // Workspace timestamps moved from ISO text to Better Auth's epoch integers.
 // The column has to be an integer for the plugin's date handling to work, and
 // a `Date` on the way back out for the starter's — assert both halves.
 describe('workspace timestamps over live D1', () => {
-  it('stores epoch integers and reads them back as Dates', () =>
+  it.live('stores epoch integers and reads them back as Dates', () =>
     run(
       Effect.gen(function* () {
         const database = yield* Database
@@ -192,9 +193,10 @@ describe('workspace timestamps over live D1', () => {
         expect(raw?.kind).toBe('integer')
         expect(raw?.createdAt).toBe(Math.floor(createdAt.getTime() / 1000))
       })
-    ))
+    )
+  )
 
-  it('defaults planId and stamps timestamps when the plugin omits them', () =>
+  it.live('defaults planId and stamps timestamps when the plugin omits them', () =>
     run(
       Effect.gen(function* () {
         const database = yield* Database
@@ -208,11 +210,12 @@ describe('workspace timestamps over live D1', () => {
         expect(rows[0]?.planId).toBe('starter')
         expect(rows[0]?.createdAt).toBeInstanceOf(Date)
       })
-    ))
+    )
+  )
 })
 
 describe('referential integrity over live D1', () => {
-  it('cascade-deletes workspace children when the workspace is removed', () =>
+  it.live('cascade-deletes workspace children when the workspace is removed', () =>
     run(
       Effect.gen(function* () {
         const database = yield* Database
@@ -280,14 +283,15 @@ describe('referential integrity over live D1', () => {
           invitations: invitations[0]?.value
         }).toEqual({ tokens: 0, notifications: 0, members: 0, invitations: 0 })
       })
-    ))
+    )
+  )
 })
 
 describe('workspace membership over live D1', () => {
   // The plugin addresses members by a surrogate id, so `workspace_members` no
   // longer has a composite primary key. One membership per user per workspace
   // is the invariant that key used to carry, and it must survive the swap.
-  it('refuses a second membership row for the same user and workspace', () =>
+  it.live('refuses a second membership row for the same user and workspace', () =>
     run(
       Effect.gen(function* () {
         const database = yield* Database
@@ -319,14 +323,15 @@ describe('workspace membership over live D1', () => {
         expect(error).toBeDefined()
         expect(rows[0]?.value).toBe(1)
       })
-    ))
+    )
+  )
 })
 
 describe('workspace invitations over live D1', () => {
   // `workspace_invitations` was a dead table before this migration. It now
   // carries the plugin's state machine, so a row must be storable with the
   // status left to its default — that is how the plugin creates one.
-  it('defaults a new invitation to pending', () =>
+  it.live('defaults a new invitation to pending', () =>
     run(
       Effect.gen(function* () {
         const database = yield* Database
@@ -352,9 +357,10 @@ describe('workspace invitations over live D1', () => {
         expect(rows[0]?.status).toBe('pending')
         expect(rows[0]?.expiresAt).toEqual(expiresAt)
       })
-    ))
+    )
+  )
 
-  it('cascade-deletes an invitation when its inviter is removed', () =>
+  it.live('cascade-deletes an invitation when its inviter is removed', () =>
     run(
       Effect.gen(function* () {
         const database = yield* Database
@@ -379,11 +385,12 @@ describe('workspace invitations over live D1', () => {
           .where(eq(workspaceInvitations.id, 'inv_orphan'))
         expect(rows[0]?.value).toBe(0)
       })
-    ))
+    )
+  )
 })
 
 describe('batch atomicity over live D1', () => {
-  it('rolls back every statement when one fails', () =>
+  it.live('rolls back every statement when one fails', () =>
     run(
       Effect.gen(function* () {
         const database = yield* Database
@@ -415,5 +422,6 @@ describe('batch atomicity over live D1', () => {
         expect(error).toBeInstanceOf(DbBatchError)
         expect(rows).toHaveLength(0)
       })
-    ))
+    )
+  )
 })

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -24,6 +24,7 @@
     "react": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@react-email/ui": "catalog:",
     "@types/react": "catalog:",
     "react-email": "catalog:",

--- a/packages/email/src/index.test.ts
+++ b/packages/email/src/index.test.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect'
 import { render } from '@react-email/render'
-import { describe, expect, it, vi } from 'vite-plus/test'
+import { describe, expect, it, vi } from '@effect/vitest'
 import {
   EmailDispatcher,
   LogEmailDispatcherLayer,
@@ -18,72 +18,69 @@ import {
 } from './templates.tsx'
 
 describe('EmailDispatcher', () => {
-  it('logs delivery when no binding is configured', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const dispatcher = yield* EmailDispatcher
-        const result = yield* dispatcher.send({
-          from: 'noreply@example.com',
-          to: 'user@example.com',
-          subject: 'You are invited',
-          element: WorkspaceInvitationEmail({
-            workspaceName: 'Starter Lab',
-            inviteUrl: 'https://example.com/accept'
-          })
+  it.effect('logs delivery when no binding is configured', () =>
+    Effect.gen(function* () {
+      const dispatcher = yield* EmailDispatcher
+      const result = yield* dispatcher.send({
+        from: 'noreply@example.com',
+        to: 'user@example.com',
+        subject: 'You are invited',
+        element: WorkspaceInvitationEmail({
+          workspaceName: 'Starter Lab',
+          inviteUrl: 'https://example.com/accept'
         })
-        expect(result).toEqual({
-          mode: 'log',
-          to: 'user@example.com',
-          subject: 'You are invited'
-        })
-      }).pipe(Effect.provide(LogEmailDispatcherLayer))
-    ))
+      })
+      expect(result).toEqual({
+        mode: 'log',
+        to: 'user@example.com',
+        subject: 'You are invited'
+      })
+    }).pipe(Effect.provide(LogEmailDispatcherLayer))
+  )
 
-  it('renders both html and text, then forwards to the binding', () => {
+  it.effect('renders both html and text, then forwards to the binding', () => {
     const send = vi.fn<(message: SendEmailBuilderArgs) => Promise<void>>(() =>
       Promise.resolve()
     )
     const binding: SendEmailBinding = { send }
 
-    return Effect.runPromise(
-      Effect.gen(function* () {
-        const dispatcher = yield* EmailDispatcher
-        const result = yield* dispatcher.send({
-          from: 'noreply@example.com',
-          to: 'user@example.com',
-          subject: 'Hello from the starter',
-          element: WorkspaceInvitationEmail({
-            workspaceName: 'Acme',
-            inviteUrl: 'https://example.com/accept'
-          })
+    return Effect.gen(function* () {
+      const dispatcher = yield* EmailDispatcher
+      const result = yield* dispatcher.send({
+        from: 'noreply@example.com',
+        to: 'user@example.com',
+        subject: 'Hello from the starter',
+        element: WorkspaceInvitationEmail({
+          workspaceName: 'Acme',
+          inviteUrl: 'https://example.com/accept'
         })
+      })
 
-        expect(send).toHaveBeenCalledTimes(1)
-        const sent = send.mock.calls[0]?.[0]
-        expect(sent?.from).toBe('noreply@example.com')
-        expect(sent?.to).toBe('user@example.com')
-        expect(sent?.subject).toBe('Hello from the starter')
-        expect(sent?.html).toContain('Acme')
-        expect(sent?.html).toContain('https://example.com/accept')
-        expect(sent?.text?.toLowerCase()).toContain('acme')
-        expect(result.mode).toBe('cloudflare-email')
-      }).pipe(Effect.provide(makeCloudflareEmailDispatcherLayer(binding)))
-    )
+      expect(send).toHaveBeenCalledTimes(1)
+      const sent = send.mock.calls[0]?.[0]
+      expect(sent?.from).toBe('noreply@example.com')
+      expect(sent?.to).toBe('user@example.com')
+      expect(sent?.subject).toBe('Hello from the starter')
+      expect(sent?.html).toContain('Acme')
+      expect(sent?.html).toContain('https://example.com/accept')
+      expect(sent?.text?.toLowerCase()).toContain('acme')
+      expect(result.mode).toBe('cloudflare-email')
+    }).pipe(Effect.provide(makeCloudflareEmailDispatcherLayer(binding)))
   })
 })
 
 describe('OneTimeCodeEmail', () => {
   // The purposes the starter's UI sends; `change-email` has no UI surface.
   type SentPurpose = 'sign-in' | 'email-verification' | 'forget-password'
-  type PurposeCase = readonly [purpose: SentPurpose, heading: string]
+  type PurposeCase = { readonly purpose: SentPurpose; readonly heading: string }
 
-  it.each([
-    ['sign-in', 'Sign in to B2B SaaS Starter'],
-    ['email-verification', 'Verify your email address'],
-    ['forget-password', 'Reset your password']
+  it.effect.each([
+    { purpose: 'sign-in', heading: 'Sign in to B2B SaaS Starter' },
+    { purpose: 'email-verification', heading: 'Verify your email address' },
+    { purpose: 'forget-password', heading: 'Reset your password' }
   ] satisfies ReadonlyArray<PurposeCase>)(
-    'renders the %s code and its purpose',
-    (purpose, heading) =>
+    'renders the $purpose code and its purpose',
+    ({ purpose, heading }) =>
       Effect.gen(function* () {
         const html = yield* Effect.promise(() =>
           render(OneTimeCodeEmail({ code: '034135', purpose }))
@@ -92,6 +89,7 @@ describe('OneTimeCodeEmail', () => {
           render(OneTimeCodeEmail({ code: '034135', purpose }), { plainText: true })
         )
         // The code itself is the payload: it must survive both renders intact.
+        // oxlint-disable vitest/no-standalone-expect -- it.effect.each's double call hides the test block from the rule
         expect(html).toContain('034135')
         expect(text).toContain('034135')
         expect(html).toContain(heading)
@@ -101,107 +99,118 @@ describe('OneTimeCodeEmail', () => {
         // between them and the email would be caught first.
         expect(text).toContain('ten minutes')
         expect(text).toContain('three failed attempts')
-      }).pipe(Effect.runPromise)
+        // oxlint-enable vitest/no-standalone-expect
+      })
   )
 
-  it('renders no action link — the code is the payload, not a click-through', () =>
-    Effect.gen(function* () {
-      const html = yield* Effect.promise(() =>
-        render(OneTimeCodeEmail({ code: '034135', purpose: 'sign-in' }))
-      )
-      expect(html).not.toContain('href=')
-    }).pipe(Effect.runPromise))
+  it.effect(
+    'renders no action link — the code is the payload, not a click-through',
+    () =>
+      Effect.gen(function* () {
+        const html = yield* Effect.promise(() =>
+          render(OneTimeCodeEmail({ code: '034135', purpose: 'sign-in' }))
+        )
+        expect(html).not.toContain('href=')
+      })
+  )
 })
 
 describe('MagicLinkEmail', () => {
-  it('renders html and text that both carry the sign-in link', () => {
+  it.effect('renders html and text that both carry the sign-in link', () => {
     const send = vi.fn<(message: SendEmailBuilderArgs) => Promise<void>>(() =>
       Promise.resolve()
     )
 
-    return Effect.runPromise(
-      Effect.gen(function* () {
-        const dispatcher = yield* EmailDispatcher
-        yield* dispatcher.send({
-          from: 'noreply@example.com',
-          to: 'user@example.com',
-          subject: 'Your sign-in link',
-          element: MagicLinkEmail({
-            url: 'http://localhost:3071/api/auth/magic-link/verify?token=tok'
-          })
+    return Effect.gen(function* () {
+      const dispatcher = yield* EmailDispatcher
+      yield* dispatcher.send({
+        from: 'noreply@example.com',
+        to: 'user@example.com',
+        subject: 'Your sign-in link',
+        element: MagicLinkEmail({
+          url: 'http://localhost:3071/api/auth/magic-link/verify?token=tok'
         })
+      })
 
-        const sent = send.mock.calls[0]?.[0]
-        expect(sent?.html).toContain(
-          'http://localhost:3071/api/auth/magic-link/verify?token=tok'
-        )
-        expect(sent?.html).toContain('ten minutes')
-        expect(sent?.text).toContain(
-          'http://localhost:3071/api/auth/magic-link/verify?token=tok'
-        )
-      }).pipe(Effect.provide(makeCloudflareEmailDispatcherLayer({ send })))
-    )
+      const sent = send.mock.calls[0]?.[0]
+      expect(sent?.html).toContain(
+        'http://localhost:3071/api/auth/magic-link/verify?token=tok'
+      )
+      expect(sent?.html).toContain('ten minutes')
+      expect(sent?.text).toContain(
+        'http://localhost:3071/api/auth/magic-link/verify?token=tok'
+      )
+    }).pipe(Effect.provide(makeCloudflareEmailDispatcherLayer({ send })))
   })
 })
 
 describe('PasswordResetEmail', () => {
-  it('names the thirty-minute window the auth config pins', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const text = yield* Effect.promise(() =>
-          render(PasswordResetEmail({ url: 'http://localhost:3071/x' }), {
-            plainText: true
-          })
-        )
-        // `resetPasswordTokenExpiresIn: 60 * 30` in packages/auth — the copy
-        // is where a drift between the config and the promise would surface.
-        expect(text).toContain('thirty minutes')
-        expect(text).not.toContain('hour')
-      })
-    ))
+  it.effect('names the thirty-minute window the auth config pins', () =>
+    Effect.gen(function* () {
+      const text = yield* Effect.promise(() =>
+        render(PasswordResetEmail({ url: 'http://localhost:3071/x' }), {
+          plainText: true
+        })
+      )
+      // `resetPasswordTokenExpiresIn: 60 * 30` in packages/auth — the copy
+      // is where a drift between the config and the promise would surface.
+      expect(text).toContain('thirty minutes')
+      expect(text).not.toContain('hour')
+    })
+  )
 })
 
 describe('PasswordChangedEmail', () => {
-  it.each([
-    ['reset', 'Your password was reset', 'reset through the link'],
-    ['password-change', 'Your password was changed', 'changed from your account']
-  ] satisfies ReadonlyArray<
-    readonly [via: 'reset' | 'password-change', heading: string, flow: string]
-  >)('renders the %s flow, naming what happened', (via, heading, flow) =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const html = yield* Effect.promise(() => render(PasswordChangedEmail({ via })))
-        const text = yield* Effect.promise(() =>
-          render(PasswordChangedEmail({ via }), { plainText: true })
-        )
-        expect(html).toContain(heading)
-        expect(text.toLowerCase()).toContain(heading.toLowerCase())
-        expect(text).toContain(flow)
-      })
-    )
+  it.effect.each([
+    {
+      via: 'reset',
+      heading: 'Your password was reset',
+      flow: 'reset through the link'
+    },
+    {
+      via: 'password-change',
+      heading: 'Your password was changed',
+      flow: 'changed from your account'
+    }
+  ] satisfies ReadonlyArray<{
+    readonly via: 'reset' | 'password-change'
+    readonly heading: string
+    readonly flow: string
+  }>)('renders the $via flow, naming what happened', ({ via, heading, flow }) =>
+    Effect.gen(function* () {
+      const html = yield* Effect.promise(() => render(PasswordChangedEmail({ via })))
+      const text = yield* Effect.promise(() =>
+        render(PasswordChangedEmail({ via }), { plainText: true })
+      )
+      // oxlint-disable vitest/no-standalone-expect -- it.effect.each's double call hides the test block from the rule
+      expect(html).toContain(heading)
+      expect(text.toLowerCase()).toContain(heading.toLowerCase())
+      expect(text).toContain(flow)
+      // oxlint-enable vitest/no-standalone-expect
+    })
   )
 
-  it('renders no action link — a sign-in button in this email is a phishing assist', () =>
-    Effect.runPromise(
+  it.effect(
+    'renders no action link — a sign-in button in this email is a phishing assist',
+    () =>
       Effect.gen(function* () {
         const html = yield* Effect.promise(() =>
           render(PasswordChangedEmail({ via: 'reset' }))
         )
         expect(html).not.toContain('href=')
       })
-    ))
+  )
 })
 
 describe('BackupCodesRotatedEmail', () => {
-  it('warns that the previously saved codes stopped working, with no link', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const text = yield* Effect.promise(() =>
-          render(BackupCodesRotatedEmail(), { plainText: true })
-        )
-        expect(text).toContain('stopped working')
-        const html = yield* Effect.promise(() => render(BackupCodesRotatedEmail()))
-        expect(html).not.toContain('href=')
-      })
-    ))
+  it.effect('warns that the previously saved codes stopped working, with no link', () =>
+    Effect.gen(function* () {
+      const text = yield* Effect.promise(() =>
+        render(BackupCodesRotatedEmail(), { plainText: true })
+      )
+      expect(text).toContain('stopped working')
+      const html = yield* Effect.promise(() => render(BackupCodesRotatedEmail()))
+      expect(html).not.toContain('href=')
+    })
+  )
 })

--- a/packages/email/src/index.test.ts
+++ b/packages/email/src/index.test.ts
@@ -74,33 +74,34 @@ describe('OneTimeCodeEmail', () => {
   type SentPurpose = 'sign-in' | 'email-verification' | 'forget-password'
   type PurposeCase = { readonly purpose: SentPurpose; readonly heading: string }
 
-  it.effect.each([
+  describe.each([
     { purpose: 'sign-in', heading: 'Sign in to B2B SaaS Starter' },
     { purpose: 'email-verification', heading: 'Verify your email address' },
     { purpose: 'forget-password', heading: 'Reset your password' }
   ] satisfies ReadonlyArray<PurposeCase>)(
-    'renders the $purpose code and its purpose',
-    ({ purpose, heading }) =>
-      Effect.gen(function* () {
-        const html = yield* Effect.promise(() =>
-          render(OneTimeCodeEmail({ code: '034135', purpose }))
-        )
-        const text = yield* Effect.promise(() =>
-          render(OneTimeCodeEmail({ code: '034135', purpose }), { plainText: true })
-        )
-        // The code itself is the payload: it must survive both renders intact.
-        // oxlint-disable vitest/no-standalone-expect -- it.effect.each's double call hides the test block from the rule
-        expect(html).toContain('034135')
-        expect(text).toContain('034135')
-        expect(html).toContain(heading)
-        // react-email's plain-text pass uppercases headings.
-        expect(text.toLowerCase()).toContain(heading.toLowerCase())
-        // The stated limits are the plugin's own; the copy is where a drift
-        // between them and the email would be caught first.
-        expect(text).toContain('ten minutes')
-        expect(text).toContain('three failed attempts')
-        // oxlint-enable vitest/no-standalone-expect
-      })
+    'the $purpose code',
+    ({ purpose, heading }) => {
+      it.effect('renders the code and its purpose in both bodies', () =>
+        Effect.gen(function* () {
+          const html = yield* Effect.promise(() =>
+            render(OneTimeCodeEmail({ code: '034135', purpose }))
+          )
+          const text = yield* Effect.promise(() =>
+            render(OneTimeCodeEmail({ code: '034135', purpose }), { plainText: true })
+          )
+          // The code itself is the payload: it must survive both renders intact.
+          expect(html).toContain('034135')
+          expect(text).toContain('034135')
+          expect(html).toContain(heading)
+          // react-email's plain-text pass uppercases headings.
+          expect(text.toLowerCase()).toContain(heading.toLowerCase())
+          // The stated limits are the plugin's own; the copy is where a drift
+          // between them and the email would be caught first.
+          expect(text).toContain('ten minutes')
+          expect(text).toContain('three failed attempts')
+        })
+      )
+    }
   )
 
   it.effect(
@@ -161,7 +162,7 @@ describe('PasswordResetEmail', () => {
 })
 
 describe('PasswordChangedEmail', () => {
-  it.effect.each([
+  describe.each([
     {
       via: 'reset',
       heading: 'Your password was reset',
@@ -176,19 +177,19 @@ describe('PasswordChangedEmail', () => {
     readonly via: 'reset' | 'password-change'
     readonly heading: string
     readonly flow: string
-  }>)('renders the $via flow, naming what happened', ({ via, heading, flow }) =>
-    Effect.gen(function* () {
-      const html = yield* Effect.promise(() => render(PasswordChangedEmail({ via })))
-      const text = yield* Effect.promise(() =>
-        render(PasswordChangedEmail({ via }), { plainText: true })
-      )
-      // oxlint-disable vitest/no-standalone-expect -- it.effect.each's double call hides the test block from the rule
-      expect(html).toContain(heading)
-      expect(text.toLowerCase()).toContain(heading.toLowerCase())
-      expect(text).toContain(flow)
-      // oxlint-enable vitest/no-standalone-expect
-    })
-  )
+  }>)('the $via flow', ({ via, heading, flow }) => {
+    it.effect('names what happened', () =>
+      Effect.gen(function* () {
+        const html = yield* Effect.promise(() => render(PasswordChangedEmail({ via })))
+        const text = yield* Effect.promise(() =>
+          render(PasswordChangedEmail({ via }), { plainText: true })
+        )
+        expect(html).toContain(heading)
+        expect(text.toLowerCase()).toContain(heading.toLowerCase())
+        expect(text).toContain(flow)
+      })
+    )
+  })
 
   it.effect(
     'renders no action link — a sign-in button in this email is a phishing assist',

--- a/packages/email/src/notification-templates.test.tsx
+++ b/packages/email/src/notification-templates.test.tsx
@@ -36,22 +36,20 @@ describe('notification email templates', () => {
     }
   })
 
-  it.effect.each(notificationKinds)(
-    'renders %s with the notification copy and the unsubscribe link',
-    (kind) =>
+  describe.each(notificationKinds)('the %s notification', (kind) => {
+    it.effect('renders with the notification copy and the unsubscribe link', () =>
       Effect.gen(function* () {
         const { html, text } = yield* rendered(notificationEmailFor(kind, props))
         // The heading is the kind's shared label, not bespoke template copy.
-        // oxlint-disable vitest/no-standalone-expect -- it.effect.each's double call hides the test block from the rule
         expect(html).toContain(`>${props.kindLabel}</`)
         expect(html).toContain('Webhook delivery gave up')
         expect(html).toContain('Starter Lab')
         expect(html).toContain(props.openUrl)
         expect(html).toContain(props.preferencesUrl)
         expect(text.toLowerCase()).toContain('unsubscribe')
-        // oxlint-enable vitest/no-standalone-expect
       })
-  )
+    )
+  })
 
   it.effect('omits the workspace line for an account-level notification', () =>
     Effect.gen(function* () {

--- a/packages/email/src/notification-templates.test.tsx
+++ b/packages/email/src/notification-templates.test.tsx
@@ -2,7 +2,7 @@ import { notificationKinds } from '@b2b-saas-starter/db/enums'
 import { render } from '@react-email/render'
 import { Effect } from 'effect'
 import { type ReactElement } from 'react'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it } from '@effect/vitest'
 import {
   NOTIFICATION_EMAIL_TEMPLATES,
   NotificationDigestEmail,
@@ -36,61 +36,58 @@ describe('notification email templates', () => {
     }
   })
 
-  it.each(notificationKinds)(
+  it.effect.each(notificationKinds)(
     'renders %s with the notification copy and the unsubscribe link',
     (kind) =>
-      Effect.runPromise(
-        Effect.gen(function* () {
-          const { html, text } = yield* rendered(notificationEmailFor(kind, props))
-          // The heading is the kind's shared label, not bespoke template copy.
-          expect(html).toContain(`>${props.kindLabel}</`)
-          expect(html).toContain('Webhook delivery gave up')
-          expect(html).toContain('Starter Lab')
-          expect(html).toContain(props.openUrl)
-          expect(html).toContain(props.preferencesUrl)
-          expect(text.toLowerCase()).toContain('unsubscribe')
-        })
-      )
+      Effect.gen(function* () {
+        const { html, text } = yield* rendered(notificationEmailFor(kind, props))
+        // The heading is the kind's shared label, not bespoke template copy.
+        // oxlint-disable vitest/no-standalone-expect -- it.effect.each's double call hides the test block from the rule
+        expect(html).toContain(`>${props.kindLabel}</`)
+        expect(html).toContain('Webhook delivery gave up')
+        expect(html).toContain('Starter Lab')
+        expect(html).toContain(props.openUrl)
+        expect(html).toContain(props.preferencesUrl)
+        expect(text.toLowerCase()).toContain('unsubscribe')
+        // oxlint-enable vitest/no-standalone-expect
+      })
   )
 
-  it('omits the workspace line for an account-level notification', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { html } = yield* rendered(
-          notificationEmailFor('two_factor.changed', { ...props, workspaceName: null })
-        )
-        expect(html).not.toContain('Workspace:')
-      })
-    ))
+  it.effect('omits the workspace line for an account-level notification', () =>
+    Effect.gen(function* () {
+      const { html } = yield* rendered(
+        notificationEmailFor('two_factor.changed', { ...props, workspaceName: null })
+      )
+      expect(html).not.toContain('Workspace:')
+    })
+  )
 
-  it('renders the digest with one row per item and the unsubscribe link', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const { html } = yield* rendered(
-          NotificationDigestEmail(NotificationDigestEmail.PreviewProps)
-        )
-        expect(html).toContain('Your daily notification digest')
-        expect(html).toContain('2 unread notifications')
-        expect(html).toContain('Webhook delivery gave up')
-        expect(html).toContain('Cloudflare Email needs configuration')
-        expect(html).toContain(NotificationDigestEmail.PreviewProps.preferencesUrl)
-      })
-    ))
+  it.effect('renders the digest with one row per item and the unsubscribe link', () =>
+    Effect.gen(function* () {
+      const { html } = yield* rendered(
+        NotificationDigestEmail(NotificationDigestEmail.PreviewProps)
+      )
+      expect(html).toContain('Your daily notification digest')
+      expect(html).toContain('2 unread notifications')
+      expect(html).toContain('Webhook delivery gave up')
+      expect(html).toContain('Cloudflare Email needs configuration')
+      expect(html).toContain(NotificationDigestEmail.PreviewProps.preferencesUrl)
+    })
+  )
 
-  it('renders the digest for a single item with singular copy', () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const [first] = NotificationDigestEmail.PreviewProps.items
-        if (first === undefined) {
-          return yield* Effect.die('preview props need at least one item')
-        }
-        const { html } = yield* rendered(
-          NotificationDigestEmail({
-            ...NotificationDigestEmail.PreviewProps,
-            items: [first]
-          })
-        )
-        expect(html).toContain('One unread notification')
-      })
-    ))
+  it.effect('renders the digest for a single item with singular copy', () =>
+    Effect.gen(function* () {
+      const [first] = NotificationDigestEmail.PreviewProps.items
+      if (first === undefined) {
+        return yield* Effect.die('preview props need at least one item')
+      }
+      const { html } = yield* rendered(
+        NotificationDigestEmail({
+          ...NotificationDigestEmail.PreviewProps,
+          items: [first]
+        })
+      )
+      expect(html).toContain('One unread notification')
+    })
+  )
 })

--- a/packages/oxlint-plugin/src/index.ts
+++ b/packages/oxlint-plugin/src/index.ts
@@ -5,6 +5,7 @@ import noHexColor from './rules/no-hex-color.ts'
 import noInlineSchemaCompile from './rules/no-inline-schema-compile.ts'
 import noInterfaceMergeOutsideDts from './rules/no-interface-merge-outside-dts.ts'
 import noMismatchedAugmentationContext from './rules/no-mismatched-augmentation-context.ts'
+import noRunPromiseInTests from './rules/no-run-promise-in-tests.ts'
 import noUnknownErrorMessage from './rules/no-unknown-error-message.ts'
 import preferEffectPredicate from './rules/prefer-effect-predicate.ts'
 
@@ -19,6 +20,7 @@ export default definePlugin({
     'no-inline-schema-compile': noInlineSchemaCompile,
     'no-interface-merge-outside-dts': noInterfaceMergeOutsideDts,
     'no-mismatched-augmentation-context': noMismatchedAugmentationContext,
+    'no-run-promise-in-tests': noRunPromiseInTests,
     'no-unknown-error-message': noUnknownErrorMessage,
     'prefer-effect-predicate': preferEffectPredicate
   }

--- a/packages/oxlint-plugin/src/internal/ast.ts
+++ b/packages/oxlint-plugin/src/internal/ast.ts
@@ -83,7 +83,7 @@ export function getStringValue(
 export function isIdentifier(
   node: ESTree.Node | null | undefined,
   name?: string
-): boolean {
+): node is Extract<ESTree.Node, { readonly type: 'Identifier' }> {
   if (node === null || node === undefined) {
     return false
   }

--- a/packages/oxlint-plugin/src/rules/no-run-promise-in-tests.test.ts
+++ b/packages/oxlint-plugin/src/rules/no-run-promise-in-tests.test.ts
@@ -1,0 +1,63 @@
+import { assert, describe } from 'vite-plus/test'
+import { createRuleHarness } from '../../test/harness.ts'
+
+const rule = createRuleHarness('starter/no-run-promise-in-tests')
+
+describe('starter/no-run-promise-in-tests', () => {
+  rule.valid(
+    'allows the effect to run under the test runner',
+    `import { Effect } from 'effect'
+import { it } from '@effect/vitest'
+
+it.effect('delivers', () =>
+  Effect.gen(function* () {
+    const outcome = yield* Effect.succeed('ack')
+  }))
+`
+  )
+
+  rule.valid(
+    'allows other Effect members in a test',
+    `import { Effect } from 'effect'
+
+const outcome = Effect.runFork(Effect.succeed('ack'))
+`
+  )
+
+  rule.valid(
+    'allows an unrelated object named Effect that is not the namespace',
+    `const Effect = { runPromise: (x: unknown) => x }
+
+const outcome = Effect.runPromise('not the runtime')
+`
+  )
+
+  rule.invalid(
+    'reports a hand-started runtime awaiting an effect',
+    `import { Effect } from 'effect'
+
+const outcome = await Effect.runPromise(Effect.succeed('ack'))
+`,
+    (messages) => {
+      assert.match(messages, /Effect\.runPromise starts a bare runtime/)
+      assert.match(messages, /it\.effect/)
+      assert.match(messages, /@effect\/vitest/)
+    }
+  )
+
+  rule.invalid(
+    'reports runPromiseExit, the same hazard with an Exit',
+    `import { Effect } from 'effect'
+
+const exit = await Effect.runPromiseExit(Effect.succeed('ack'))
+`
+  )
+
+  rule.invalid(
+    'reports through a renamed namespace import',
+    `import { Effect as E } from 'effect'
+
+const outcome = await E.runPromise(E.succeed('ack'))
+`
+  )
+})

--- a/packages/oxlint-plugin/src/rules/no-run-promise-in-tests.test.ts
+++ b/packages/oxlint-plugin/src/rules/no-run-promise-in-tests.test.ts
@@ -60,4 +60,12 @@ const exit = await Effect.runPromiseExit(Effect.succeed('ack'))
 const outcome = await E.runPromise(E.succeed('ack'))
 `
   )
+
+  rule.invalid(
+    'reports through a namespace import',
+    `import * as Eff from 'effect'
+
+const outcome = await Eff.runPromise(Eff.succeed('ack'))
+`
+  )
 })

--- a/packages/oxlint-plugin/src/rules/no-run-promise-in-tests.ts
+++ b/packages/oxlint-plugin/src/rules/no-run-promise-in-tests.ts
@@ -1,0 +1,85 @@
+import { defineRule, type ESTree } from '@oxlint/plugins'
+import { getPropertyName, isIdentifier, unwrapExpression } from '../internal/ast.ts'
+
+/**
+ * Catches `Effect.runPromise(...)` and `Effect.runPromiseExit(...)` inside test
+ * files: a hand-started runtime that swaps the test's context for a bare one.
+ * `it.effect` from `@effect/vitest` runs the same effect inside TestContext —
+ * the Scope comes from the runner, typed errors fail the test through the
+ * fiber, and interruption guarantees hold. A runPromise call quietly discards
+ * all three, and its real clock hides the TestClock hazards (an `Effect.sleep`
+ * never advancing; a `DateTime.now` reading wall time while the rest of the
+ * suite reads epoch 0, standing expiry fixtures on their head).
+ *
+ * Deliberately only the promise runners: `runFork`/`runSync` have test uses a
+ * blanket ban would misjudge. Path gating lives in the root `lint.config.ts`
+ * test override — outside test files `Effect.runPromise` is the correct way to
+ * bridge into callback and promise code. Genuine interop sites inside tests
+ * (a runner port a non-Effect framework calls) keep an `oxlint-disable` with
+ * the reason.
+ *
+ * The rule only fires when `Effect` is imported from `effect`, so another
+ * object that happens to be named `Effect` stays quiet.
+ */
+
+const RUNNERS = new Set(['runPromise', 'runPromiseExit'])
+
+/** Local names bound to the Effect namespace by an `import … from 'effect'`. */
+function effectNamespaceNames(node: ESTree.ImportDeclaration): Array<string> {
+  if (node.source.value !== 'effect') {
+    return []
+  }
+  const names: Array<string> = []
+  for (const specifier of node.specifiers) {
+    if (specifier.type === 'ImportDefaultSpecifier') {
+      continue
+    }
+    if (specifier.type === 'ImportNamespaceSpecifier') {
+      names.push(specifier.local.name)
+      continue
+    }
+    if (getPropertyName(specifier.imported) === 'Effect') {
+      names.push(specifier.local.name)
+    }
+  }
+  return names
+}
+
+export default defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Effect.runPromise and Effect.runPromiseExit in test files; run the effect under it.effect or it.live from @effect/vitest instead.'
+    }
+  },
+  create(context) {
+    const namespaces = new Set<string>()
+
+    return {
+      ImportDeclaration(node) {
+        for (const name of effectNamespaceNames(node)) {
+          namespaces.add(name)
+        }
+      },
+      CallExpression(node) {
+        const callee = unwrapExpression(node.callee)
+        if (callee?.type !== 'MemberExpression') {
+          return
+        }
+        const object = unwrapExpression(callee.object)
+        if (!isIdentifier(object) || !namespaces.has(object.name)) {
+          return
+        }
+        const runner = getPropertyName(callee.property)
+        if (runner === undefined || !RUNNERS.has(runner)) {
+          return
+        }
+        context.report({
+          node: callee,
+          message: `Effect.${runner} starts a bare runtime inside a test: no TestContext Scope, no fiber-reported failures, and time reads leave the TestClock. Run the effect under it.effect (or it.live when the test needs real time) from '@effect/vitest'. A deliberate promise-interop boundary keeps this call with an oxlint-disable naming the port it bridges.`
+        })
+      }
+    }
+  }
+})

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -15,6 +15,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plus": "catalog:",

--- a/packages/rate-limit/src/index.test.ts
+++ b/packages/rate-limit/src/index.test.ts
@@ -1,5 +1,5 @@
-import { Effect, type Scope } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { Effect } from 'effect'
+import { describe, expect, it } from '@effect/vitest'
 import {
   clientKey,
   makeRateLimiter,
@@ -18,11 +18,8 @@ function config(
   }
 }
 
-// `take` annotates the request's wide event, so it needs a Scope; tests
-// supply it with `Effect.scoped`.
-function runScoped<A, E>(effect: Effect.Effect<A, E, Scope.Scope>): Promise<A> {
-  return Effect.runPromise(Effect.scoped(effect))
-}
+// `take` annotates the request's wide event, so it needs a Scope; the
+// TestContext behind `it.effect` provides it.
 
 // The fallback store lives at module scope, so each test needs a key no other
 // test has used. A counter keeps that deterministic — no clock, no randomness.
@@ -33,27 +30,27 @@ function uniqueKey(): string {
 }
 
 describe('makeRateLimiter fallback (no Cloudflare bindings)', () => {
-  it('enforces the per-bucket limit and keys buckets independently', () =>
-    runScoped(
-      Effect.gen(function* () {
-        const limiter = makeRateLimiter(config())
-        const key = uniqueKey()
-        const outcomes: Array<boolean> = []
-        for (let i = 0; i < 21; i += 1) {
-          outcomes.push(yield* limiter.take({ bucket: 'write', key }))
-        }
-        // `write` allows 20 per window; the 21st take is denied.
-        expect(outcomes.slice(0, 20).every(Boolean)).toBe(true)
-        expect(outcomes[20]).toBe(false)
-        // A different key is unaffected.
-        expect(yield* limiter.take({ bucket: 'write', key: `${key}-other` })).toBe(true)
-        // The same key under a different bucket is unaffected.
-        expect(yield* limiter.take({ bucket: 'read', key })).toBe(true)
-      })
-    ))
+  it.effect('enforces the per-bucket limit and keys buckets independently', () =>
+    Effect.gen(function* () {
+      const limiter = makeRateLimiter(config())
+      const key = uniqueKey()
+      const outcomes: Array<boolean> = []
+      for (let i = 0; i < 21; i += 1) {
+        outcomes.push(yield* limiter.take({ bucket: 'write', key }))
+      }
+      // `write` allows 20 per window; the 21st take is denied.
+      expect(outcomes.slice(0, 20).every(Boolean)).toBe(true)
+      expect(outcomes[20]).toBe(false)
+      // A different key is unaffected.
+      expect(yield* limiter.take({ bucket: 'write', key: `${key}-other` })).toBe(true)
+      // The same key under a different bucket is unaffected.
+      expect(yield* limiter.take({ bucket: 'read', key })).toBe(true)
+    })
+  )
 
-  it('shares fallback state across limiter instances (per-request layer rebuilds)', () =>
-    runScoped(
+  it.effect(
+    'shares fallback state across limiter instances (per-request layer rebuilds)',
+    () =>
       Effect.gen(function* () {
         // Consumers rebuild the rate-limiter layer on every request; the fallback
         // store must live at module scope or the counters reset each request and
@@ -66,29 +63,27 @@ describe('makeRateLimiter fallback (no Cloudflare bindings)', () => {
         const fresh = makeRateLimiter(config())
         expect(yield* fresh.take({ bucket: 'write', key })).toBe(false)
       })
-    ))
+  )
 })
 
 describe('makeRateLimiter with a Cloudflare binding', () => {
-  it('delegates to the binding when it resolves', () =>
-    runScoped(
-      Effect.gen(function* () {
-        const limiter = makeRateLimiter(
-          config(() => ({ limit: () => Promise.resolve({ success: false }) }))
-        )
-        expect(yield* limiter.take({ bucket: 'write', key: uniqueKey() })).toBe(false)
-      })
-    ))
+  it.effect('delegates to the binding when it resolves', () =>
+    Effect.gen(function* () {
+      const limiter = makeRateLimiter(
+        config(() => ({ limit: () => Promise.resolve({ success: false }) }))
+      )
+      expect(yield* limiter.take({ bucket: 'write', key: uniqueKey() })).toBe(false)
+    })
+  )
 
-  it('falls back to the in-memory store when the binding call fails', () =>
-    runScoped(
-      Effect.gen(function* () {
-        const limiter = makeRateLimiter(
-          config(() => ({ limit: () => Promise.reject(new Error('boom')) }))
-        )
-        expect(yield* limiter.take({ bucket: 'write', key: uniqueKey() })).toBe(true)
-      })
-    ))
+  it.effect('falls back to the in-memory store when the binding call fails', () =>
+    Effect.gen(function* () {
+      const limiter = makeRateLimiter(
+        config(() => ({ limit: () => Promise.reject(new Error('boom')) }))
+      )
+      expect(yield* limiter.take({ bucket: 'write', key: uniqueKey() })).toBe(true)
+    })
+  )
 })
 
 describe('clientKey', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260903.1
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -595,6 +598,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260903.1
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
@@ -698,6 +704,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-rc.112
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -775,6 +784,9 @@ importers:
         specifier: 'catalog:'
         version: 1.0.0(better-auth@1.7.2(@cloudflare/workers-types@5.20260903.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.49(@voidzero-dev/vite-plus-core@0.3.0(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.63.1)(supports-color@10.2.2))(drizzle-kit@1.0.0-rc.5-ab785fc)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260903.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(bun-types@1.4.0)(effect@4.0.0-rc.112)(valibot@1.4.2(typescript@7.0.2))(zod@4.5.4))(next@16.3.0(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11))(effect@4.0.0-rc.112)
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11)
       jose:
         specifier: 'catalog:'
         version: 6.2.10
@@ -880,6 +892,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260903.1
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11)
       drizzle-kit:
         specifier: 'catalog:'
         version: 1.0.0-rc.5-ab785fc
@@ -923,6 +938,9 @@ importers:
         specifier: 'catalog:'
         version: 19.2.8
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11)
       '@react-email/ui':
         specifier: 'catalog:'
         version: 6.9.3(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1040,6 +1058,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-rc.112
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1680,9 +1701,6 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
-
-  '@cloudflare/workers-types@5.20260902.1':
-    resolution: {integrity: sha512-FpgVlUNWBLPtC51m/t9Eo8DzbFoOg05MSicoPQRS3eitvPRznJxkxuCy0P23unP2CjLIAczLR5nFNRWlKMJvrA==}
 
   '@cloudflare/workers-types@5.20260903.1':
     resolution: {integrity: sha512-Dgm28XJqMYj3VCNK14Xwo9UPtSPWL8Izo0emiyeQLZCRXWuhc3GnlKENF4Pf3ot+3NaWosq+yq8OIa531dCr6g==}
@@ -10171,8 +10189,6 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260831.1':
     optional: true
 
-  '@cloudflare/workers-types@5.20260902.1': {}
-
   '@cloudflare/workers-types@5.20260903.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -10301,7 +10317,7 @@ snapshots:
 
   '@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112)':
     dependencies:
-      '@cloudflare/workers-types': 5.20260902.1
+      '@cloudflare/workers-types': 5.20260903.1
       effect: 4.0.0-rc.112
 
   '@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112)':


### PR DESCRIPTION
# test: migrate `Effect.runPromise` tests to `it.effect`

## What

Every test that hand-started a runtime with `Effect.runPromise` now runs under `it.effect` (or `it.live` where real time is part of the contract) from `@effect/vitest` — and a new lint rule, `starter/no-run-promise-in-tests`, keeps new sites out.

**168 sites → 25 deliberate ones.** Each survivor carries an inline `oxlint-disable` naming why it stays, so the allowlist lives in the code instead of this description.

## Why

`it.effect` runs the effect inside TestContext: the `Scope` comes from the runner, typed errors fail the test through the fiber, and interruption guarantees hold. A hand-started `runPromise` discards all three, and its real clock hides the TestClock hazards. One of those bit during the migration itself: the signed-download test in `apps/api` mints its link against `DateTime.now`, which reads epoch 0 under TestClock, so the handler (own runtime, real clock) read the signature as expired. That test runs under `it.live`, with a comment.

Phase 0 settled the import question before anything wide: `vite-plus/test` is literally `export * from 'vitest'`, and `@effect/vitest` resolves the same module instance (`expect`/`vi` verified identical by reference). Moving imports wholesale is safe.

## Per commit

| Commit | Scope | Sites | Notes |
|---|---|---|---|
| `b772500c` | `apps/background` | 39 | `runScoped`/`orDie`/`scoped` wrappers deleted |
| `e4486a13` | `apps/api` | 64 | `test` → `it` rename (plain `test` re-export has no `.effect`); signed-download → `it.live`; `runPromiseExit` pair → `Effect.all` of `Effect.exit`; `jsonBody` `orDie`s dropped |
| `94efe190` | `packages/email` | 11 | tuple `.each` tables → object tables (`it.effect.each` passes each case as one arg) |
| `c7a4b8b8` | `packages/ai` | 3 | fetch-stub setup kept; promise `ask`/`askFails` drivers untouched |
| `456e5fa8` | `packages/rate-limit` | 4 | `runScoped` gone; TestContext supplies the `Scope` |
| `20f74771` | `packages/db` | 13 tests | `it.live` (real D1/workerd); `run` helper returns the Effect |
| `fe172ae6` | `packages/auth` | 36 tests | `it.live` (live D1 suites); `options.test.ts` → `it.effect` |
| `35f37374` | `apps/web` | 14 of 29 | the foldable files only, per `apps/web/AGENTS.md` |
| `e5e4d203` | lint rule | — | `starter/no-run-promise-in-tests` |

Follow-on simplifications applied everywhere they earned their keep: manual `Effect.scoped` dropped when `Scope` was the only requirement, `orDie` dropped (a typed error failing the test outright is the more honest signal), rejection catches rebuilt with `Effect.flip`/`Effect.exit`, `Promise.all` of effects → `Effect.all`.

## The sites that stay (25, each with its inline disable)

**Suite setup — 8 sites.** `beforeAll` hooks that provision/dispose a workerd D1: `packages/auth/src/{live-organization:30, live-email-flows:75, social-auth:131, live-passkey:55, live-mcp-oauth:36, sso:129, live-two-factor:61}.test.ts` and `packages/db/src/live-d1.test.ts:33`. Converting setup hooks to `it.layer` is a separate change, not a body migration.

**Effect↔promise interop is the thing under test — 9 sites.** `packages/capabilities/.../account-lifecycle.live.test.ts:207,222` and `apps/web/.../account-delete-hooks.test.ts:92` (Better Auth calls these hooks outside any Effect runtime; the `runPromise` *is* the port), `apps/web/.../social-account-audit.test.ts:23,27` (`RunAccountAudit` port is a Promise), `apps/web/src/lib/observability.test.ts:85,93,139,285` (a bare runtime inside a promise callback is the interop these tests document).

**`apps/web/AGENTS.md` pattern — 9 sites.** `invitations.test.ts:215,227,235,243` and `workspace-sso.effects.test.ts:200` (the server-fn handler pattern; the AGENTS.md is explicit: "No `it.effect` anywhere near these — TestClock epoch 0 puts a post-1970 expiry fixture in the future"), `auth-audit.test.ts:36,587,977` (asserts through `await expect(...).resolves` across dozens of sites; folding every body would grow arms and legs, and the module stamps clock-derived wide-event timestamps).

## The rule

`starter/no-run-promise-in-tests` reports `Effect.runPromise` and `Effect.runPromiseExit` in `*.test.ts(x)`, enabled from the test-files override in `lint.config.ts`. It is import-aware (any local name bound to the `Effect` namespace; a same-named local object stays quiet), syntax-only, no fixer, and its message names the replacement. Production bridges (`plugin-call.ts`, `packages/sdk`, `db/testing.ts`, …) are untouched — the config owns the reach, per the plugin's invariants. Six rule tests run through the real-binary harness.

## Verification

- `vp run --no-cache -r typecheck` — green
- `vp run --no-cache -r test` — green (no TestClock hangs)
- `pnpm run lint` / `format:check` / `dead-code` — green
- `pnpm run check` — green, same bar as PR Gate
- `expect(` count parity checked per file before/after — no assertions lost or gained
- Semantics preserved: same assertions, same fixtures, same coverage; `git diff` of any single test reads as shape-only
