### PR TITLE
fix(db): resolve remote D1 by uuid so wrangler skips the config placeholder

### DIFF
--- a/packages/db/scripts/wrangler-d1.ts
+++ b/packages/db/scripts/wrangler-d1.ts
@@ -79,21 +79,24 @@ function runWrangler(
 }
 
 /**
- * Executes SQL against a D1 database by name. `args` carries the target
+ * Executes SQL against a D1 database. `args` carries the target
  * (`--local` / `--remote`) and the payload (`--command=…` / `--file=…`).
- * When `captureJson` is set the `--json` output — and, on failure, wrangler's
- * error, which json mode writes to stdout — is captured for the caller;
- * otherwise wrangler streams straight through and `stdout` comes back empty.
+ * A remote target is passed to wrangler by uuid, a local one by name (see
+ * `remoteDatabaseId`). When `captureJson` is set the `--json` output — and,
+ * on failure, wrangler's error, which json mode writes to stdout — is
+ * captured for the caller; otherwise wrangler streams straight through and
+ * `stdout` comes back empty.
  */
-export function wranglerD1Execute(
+export async function wranglerD1Execute(
   database: string,
   args: ReadonlyArray<string>,
   captureJson: boolean
 ): Promise<WranglerRun> {
+  const target = args.includes('--remote') ? await remoteDatabaseId(database) : database
   return runWrangler(
     [
       'execute',
-      database,
+      target,
       `--config=${join(packageDir, 'wrangler.jsonc')}`,
       ...args,
       ...(captureJson ? ['--json'] : [])
@@ -106,9 +109,45 @@ export function wranglerD1Execute(
 // loudly, rather than producing an empty database list (which baseline.ts
 // would read as "nothing deployed, skip everything").
 const DatabasesJson = Schema.fromJsonString(
-  Schema.Array(Schema.Struct({ name: Schema.String }))
+  Schema.Array(Schema.Struct({ name: Schema.String, uuid: Schema.String }))
 )
 const decodeDatabases = Schema.decodeUnknownSync(DatabasesJson)
+
+type RemoteDatabase = { readonly name: string; readonly uuid: string }
+
+// The account's database list, fetched at most once per process: baseline
+// issues one execute per unrecorded migration, and re-listing the account for
+// each would only add latency. A CLI script's process is too short for the
+// cache to go stale.
+let databasesFetched: Promise<ReadonlyArray<RemoteDatabase>> | undefined
+
+function fetchDatabases(): Promise<ReadonlyArray<RemoteDatabase>> {
+  databasesFetched ??= runWrangler(['list', '--json'], true).then((run) => {
+    if (!run.ok) {
+      throw new Error(`wrangler d1 list failed (exit ${run.code}):\n${run.output}`)
+    }
+    return decodeDatabases(run.stdout)
+  })
+  return databasesFetched
+}
+
+/**
+ * The uuid of one remote D1 database, by name. Wrangler would resolve a bare
+ * name through the account API — but only when no `d1_databases` binding in
+ * the config claims that name, and this package's wrangler.jsonc does claim
+ * it with a placeholder `database_id` that wrangler then uses verbatim. A
+ * uuid matches no binding, so wrangler's own lookup lands on the real
+ * database. Local mode needs no resolution: without `--remote` wrangler keys
+ * its local state by the binding's placeholder id and never calls the API.
+ */
+async function remoteDatabaseId(database: string): Promise<string> {
+  const databases = await fetchDatabases()
+  const found = databases.find((entry) => entry.name === database)
+  if (found === undefined) {
+    throw new Error(`no D1 database named '${database}' exists in the account`)
+  }
+  return found.uuid
+}
 
 /**
  * Every D1 database name in the account, via `wrangler d1 list --json` (auth
@@ -119,9 +158,6 @@ const decodeDatabases = Schema.decodeUnknownSync(DatabasesJson)
  * `CREATE TABLE`, not silently skip schema.
  */
 export async function listRemoteDatabases(): Promise<ReadonlyArray<string>> {
-  const run = await runWrangler(['list', '--json'], true)
-  if (!run.ok) {
-    throw new Error(`wrangler d1 list failed (exit ${run.code}):\n${run.output}`)
-  }
-  return decodeDatabases(run.stdout).map((database) => database.name)
+  const databases = await fetchDatabases()
+  return databases.map((database) => database.name)
 }

--- a/packages/db/wrangler.jsonc
+++ b/packages/db/wrangler.jsonc
@@ -1,8 +1,12 @@
 // CLI helper config — used by `wrangler d1 migrations apply` and
-// `drizzle-kit` to talk to the shared D1 database. The Workers themselves
-// are deployed by Alchemy (see alchemy.run.ts); this file is *not* the
-// source of truth for production bindings. The placeholder `database_id`
-// is replaced by `wrangler d1 ... --remote` at apply time.
+// `drizzle-kit` to talk to the shared D1 database, and by the package
+// scripts' `--local` runs. The Workers themselves are deployed by Alchemy
+// (see alchemy.run.ts); this file is *not* the source of truth for
+// production bindings. Wrangler does NOT replace the placeholder
+// `database_id` with a remote lookup: a name matching `database_name` makes
+// wrangler use the binding's id verbatim. The package scripts therefore
+// resolve a remote target's uuid themselves (scripts/wrangler-d1.ts) and
+// pass the uuid to wrangler; local state stays keyed by the placeholder.
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "b2b-saas-starter-db",


### PR DESCRIPTION
## What

The master deploy died at the baseline step with Cloudflare API error 7400 (`/accounts/…/d1/database/placeholder/query`, invalid uuid), and `db:migrate:remote` had the same latent bug.

Root cause: `wranglerD1Execute` always passed `--config=packages/db/wrangler.jsonc`, and wrangler prefers a `d1_databases` binding matching the positional name over its API name lookup — using the binding's `database_id` verbatim. That binding carries the literal `placeholder` (wrangler's `hasUuid()` is a truthiness check), so every remote execute queried `/d1/database/placeholder`. The config's header comment claimed wrangler replaced the placeholder for `--remote`; it does not.

Fix in `packages/db/scripts/wrangler-d1.ts`: a remote target now resolves name → uuid via `wrangler d1 list --json` (schema gains `uuid`; the list is fetched once per process and shared with `listRemoteDatabases`) and passes the uuid, which matches no binding and forces wrangler's own API path. `--local` is unchanged — local state stays keyed by the binding's placeholder id. Also corrects the wrangler.jsonc comment.

Covers `db:baseline:remote` (master deploy), `db:baseline:stage` (preview), and `db:migrate:remote`.

## Checklist

- [x] `pnpm run check` and `pnpm run build` pass locally
- [ ] Tests added or updated for behavioural changes — no test seam exists for the spawn-based CLI scripts; verified end-to-end instead (below)
- [x] [CONTEXT.md](../CONTEXT.md) updated if new domain language was introduced — none introduced
- [x] ADR added under [docs/adr](../docs/adr) if this is an architectural decision — not one

## Notes for reviewers

- Verified against the live account: `node packages/db/scripts/baseline.ts --remote --database=b2b-saas-starter` now reports "No baselining needed" (previously error 7400); an execute-by-uuid run against the same config confirmed the path before the code change.
- `scripts/seed.ts`'s remote path was never affected — it deliberately omits `--config` for remote runs, which is why stage seeding worked while baseline died.
- No database-id secret is involved: Alchemy adopts the D1 by name (`alchemy.run.ts`), and baseline resolves name → uuid at runtime from `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`.