### PR TITLE
test(billing): make signature tolerance boundary deterministic

### DIFF
--- a/packages/capabilities/src/billing/billing.test.ts
+++ b/packages/capabilities/src/billing/billing.test.ts
@@ -523,7 +523,18 @@ describe('entitlement gate', () => {
 })
 
 describe('stripe signature verification', () => {
-  /* oxlint-disable effect/noAsyncFunction, effect/noGlobals -- these tests exercise the real Web Crypto and wall-clock behavior the verifier depends on; faking either would prove nothing */
+  /* oxlint-disable effect/noAsyncFunction -- these tests exercise the real Web Crypto the verifier depends on; faking it would prove nothing */
+
+  /**
+   * The fixed clock injected as the verifier's `now`: no real-time
+   * dependence, so the tolerance boundary is asserted exactly rather than
+   * raced against wall time.
+   */
+  const nowSeconds = 1_700_000_000
+
+  function fixedNow(): number {
+    return nowSeconds * 1000
+  }
 
   async function signedHeader(secret: string, payload: string, timestamp: number) {
     const key = await crypto.subtle.importKey(
@@ -546,34 +557,24 @@ describe('stripe signature verification', () => {
 
   it('accepts a fresh valid signature and rejects tampering', async () => {
     const payload = '{"type":"checkout.session.completed"}'
-    const header = await signedHeader(
-      'whsec_test',
-      payload,
-      Math.floor(Date.now() / 1000)
-    )
+    const header = await signedHeader('whsec_test', payload, nowSeconds)
     expect(
-      await verifyStripeSignature({
-        secret: 'whsec_test',
-        payload,
-        header
-      })
+      await verifyStripeSignature({ secret: 'whsec_test', payload, header }, fixedNow)
     ).toBe(true)
     expect(
-      await verifyStripeSignature({
-        secret: 'whsec_other',
-        payload,
-        header
-      })
+      await verifyStripeSignature({ secret: 'whsec_other', payload, header }, fixedNow)
     ).toBe(false)
     expect(
-      await verifyStripeSignature({
-        secret: 'whsec_test',
-        payload: '{"type":"tampered"}',
-        header
-      })
+      await verifyStripeSignature(
+        { secret: 'whsec_test', payload: '{"type":"tampered"}', header },
+        fixedNow
+      )
     ).toBe(false)
     expect(
-      await verifyStripeSignature({ secret: 'whsec_test', payload, header: null })
+      await verifyStripeSignature(
+        { secret: 'whsec_test', payload, header: null },
+        fixedNow
+      )
     ).toBe(false)
   })
 
@@ -586,13 +587,22 @@ describe('stripe signature verification', () => {
     }
   })
 
-  it('rejects stale timestamps beyond tolerance', async () => {
+  it('accepts a timestamp 300s old and rejects one 301s old', async () => {
     const payload = 'p'
-    const stale = Math.floor(Date.now() / 1000) - 3600
-    const header = await signedHeader('whsec_test', payload, stale)
-    expect(await verifyStripeSignature({ secret: 'whsec_test', payload, header })).toBe(
-      false
-    )
+    const atTolerance = await signedHeader('whsec_test', payload, nowSeconds - 300)
+    expect(
+      await verifyStripeSignature(
+        { secret: 'whsec_test', payload, header: atTolerance },
+        fixedNow
+      )
+    ).toBe(true)
+    const pastTolerance = await signedHeader('whsec_test', payload, nowSeconds - 301)
+    expect(
+      await verifyStripeSignature(
+        { secret: 'whsec_test', payload, header: pastTolerance },
+        fixedNow
+      )
+    ).toBe(false)
   })
-  /* oxlint-enable effect/noAsyncFunction, effect/noGlobals */
+  /* oxlint-enable effect/noAsyncFunction */
 })

--- a/packages/capabilities/src/billing/stripe.ts
+++ b/packages/capabilities/src/billing/stripe.ts
@@ -334,16 +334,21 @@ export function subscriptionLinkForStripeEvent(
 /**
  * Verifies Stripe's `stripe-signature` header scheme: `t=<ts>,v1=<hex>` where
  * `v1` is HMAC-SHA256 over `<ts>.<payload>` keyed with the webhook secret.
- * Constant-time comparison; `toleranceSeconds` bounds replay. Exported for
- * the background worker and its tests.
+ * Constant-time comparison; `toleranceSeconds` bounds replay, measured on
+ * the injectable `now` wall clock so tests can pin the boundary. Exported
+ * for the background worker and its tests.
  */
 // oxlint-disable-next-line effect/noAsyncFunction -- Web Crypto's HMAC API is promise-based, and this helper is shared with the background worker's plain fetch handler
-export async function verifyStripeSignature(input: {
-  readonly secret: string
-  readonly payload: string
-  readonly header: string | null
-  readonly toleranceSeconds?: number | undefined
-}): Promise<boolean> {
+export async function verifyStripeSignature(
+  input: {
+    readonly secret: string
+    readonly payload: string
+    readonly header: string | null
+    readonly toleranceSeconds?: number | undefined
+  },
+  // oxlint-disable-next-line effect/noGlobals -- replay tolerance is a wall-clock comparison by definition; Clock would tie a pure verification helper to an Effect runtime
+  now: () => number = Date.now
+): Promise<boolean> {
   if (input.header === null) {
     return false
   }
@@ -359,8 +364,7 @@ export async function verifyStripeSignature(input: {
   if (timestamp === undefined || signature === undefined) {
     return false
   }
-  // oxlint-disable-next-line effect/noGlobals -- replay tolerance is a wall-clock comparison by definition; Clock would tie a pure verification helper to an Effect runtime
-  const age = Math.abs(Math.floor(Date.now() / 1000) - Number(timestamp))
+  const age = Math.abs(Math.floor(now() / 1000) - Number(timestamp))
   if (!Number.isFinite(age)) {
     return false
   }


### PR DESCRIPTION
## What changed

- `packages/capabilities/src/billing/stripe.ts` — `verifyStripeSignature` takes an optional second parameter `now: () => number = Date.now`. The replay-window age comparison reads the injected clock (`now()`) instead of calling `Date.now()` inline. The helper stays free of Effect `Clock`; the inline `oxlint-disable-next-line effect/noGlobals` comment explaining why moved with the `Date.now` reference to the parameter default (its text is unchanged — `reportUnusedDisableDirectives: deny` would flag it if left on the now-clean `age` line). The JSDoc now mentions the injectable clock.
- `packages/capabilities/src/billing/billing.test.ts` — the tolerance tests inject a fixed clock (`nowSeconds = 1_700_000_000`, `fixedNow()` returning it in ms) instead of reading `Date.now()`:
  - `accepts a fresh valid signature and rejects tampering` signs at the fixed "now" and passes `fixedNow`, so the tamper assertions still fail for the MAC/secret reason rather than a stale timestamp.
  - the old `rejects stale timestamps beyond tolerance` (3600s, real clock) became `accepts a timestamp 300s old and rejects one 301s old`, asserting the exact boundary: age 300 passes, age 301 fails.
  - the test block's disable comment dropped its now-unused `effect/noGlobals` half (the tests no longer read the wall clock).

## Why

The verifier's 300s replay window was decided by a direct `Date.now()` read, so the tolerance tests could only sample far-from-boundary ages against real time. An optional clock parameter keeps production behavior identical while letting the tests pin the boundary exactly, with no real-time dependence.

## Validation

- No production call-site change: the single call site (`apps/background/src/stripe-endpoint.ts`) still compiles without passing `now`.
- `pnpm run check` green end to end: typecheck (17 projects), lint (0 warnings/errors), format check, dead-code, and 493/493 tests across 79 files — including the 29 billing tests with the two rewritten tolerance tests.