### PR TITLE
refactor(infra): derive worker env binding keys from infra binding names

### DIFF
--- a/apps/api/src/env.test.ts
+++ b/apps/api/src/env.test.ts
@@ -1,0 +1,73 @@
+import { type WebhookQueueBinding } from '@b2b-saas-starter/capabilities/developer-platform/webhook-publisher'
+import {
+  type WorkspaceExportBucketBinding,
+  type WorkspaceExportQueueBinding
+} from '@b2b-saas-starter/capabilities/governance/workspace-export'
+import { type NotificationEmailQueueBinding } from '@b2b-saas-starter/capabilities/notifications/notification-email-queue'
+import { type ServerEnv } from '@b2b-saas-starter/env/server'
+import { type WorkersAIBinding } from '@b2b-saas-starter/ai'
+import {
+  type ApiBindingName,
+  type ApiRateLimitBindingName
+} from '@b2b-saas-starter/infra'
+import { type CloudflareRateLimit } from '@b2b-saas-starter/rate-limit'
+import { describe, expect, it } from 'vite-plus/test'
+import { type ApiEnv } from './env.ts'
+
+/**
+ * Type-level regression guard for the binding-name parity between
+ * `infra/bindings.ts` and `ApiEnv`. The env's keys are now derived from the
+ * infra name union (`ApiBindingName`), so these tests pin the union to the
+ * binding set the deploy actually binds: a row dropped or renamed in
+ * `infra/bindings.ts` stops the `names` array from compiling, a mistyped
+ * binding row in `env.ts` stops the round-trip arrows from compiling, and a
+ * binding ADDED in infra fails `env.ts` itself, whose mapped env cannot
+ * resolve a name with no binding-type row. `pnpm run check` runs all three
+ * through `tsc` before vitest ever loads this file.
+ */
+
+// The pre-parity hand-written env shape, re-spelled here as the oracle:
+// `ApiEnv` must keep matching it key for key and type for type.
+type HandWrittenApiEnv = Readonly<
+  Partial<Record<ApiRateLimitBindingName, CloudflareRateLimit>>
+> &
+  Partial<ServerEnv> & {
+    readonly DB?: D1Database
+    readonly AI?: WorkersAIBinding
+    readonly WEBHOOK_QUEUE?: WebhookQueueBinding
+    readonly WORKSPACE_EXPORT_QUEUE?: WorkspaceExportQueueBinding
+    readonly WORKSPACE_EXPORT_BUCKET?: WorkspaceExportBucketBinding
+    readonly NOTIFICATION_EMAIL_QUEUE?: NotificationEmailQueueBinding
+  }
+
+describe('ApiEnv binding parity', () => {
+  it('derives exactly the binding names the deploy binds', () => {
+    // Every literal must be a member of the infra-derived union: drop or
+    // rename a row in `infra/bindings.ts` and this array stops compiling.
+    const names: ReadonlyArray<ApiBindingName> = [
+      'DB',
+      'AI',
+      'WEBHOOK_QUEUE',
+      'NOTIFICATION_EMAIL_QUEUE',
+      'WORKSPACE_EXPORT_QUEUE',
+      'WORKSPACE_EXPORT_BUCKET',
+      'RATE_LIMITER_REST',
+      'RATE_LIMITER_REST_WRITE',
+      'RATE_LIMITER_ASSISTANT',
+      'RATE_LIMITER_MCP'
+    ]
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('satisfies the hand-written env shape it replaced, both directions', () => {
+    // Each declaration typechecks only while its parameter env is assignable
+    // to the other shape — a mistyped binding row in `env.ts` fails here.
+    function handWrittenIntoModern(env: HandWrittenApiEnv): ApiEnv {
+      return env
+    }
+    function modernIntoHandWritten(env: ApiEnv): HandWrittenApiEnv {
+      return env
+    }
+    expect([handWrittenIntoModern, modernIntoHandWritten]).toHaveLength(2)
+  })
+})

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -7,34 +7,44 @@ import {
 import { type NotificationEmailQueueBinding } from '@b2b-saas-starter/capabilities/notifications/notification-email-queue'
 import { type ServerEnv } from '@b2b-saas-starter/env/server'
 import { type WorkersAIBinding } from '@b2b-saas-starter/ai'
-import { type ApiRateLimitBindingName } from '@b2b-saas-starter/infra'
+import {
+  type ApiBindingName,
+  type ApiRateLimitBindingName
+} from '@b2b-saas-starter/infra'
 import { type CloudflareRateLimit } from '@b2b-saas-starter/rate-limit'
 
-// The rate-limit bindings this worker's env may carry, keyed by binding name
-// and derived from the infra name record rather than spelled: renaming a
-// binding in infra renames the key here and in the generated wrangler config
-// together, and a bucket added to infra surfaces here the moment its row is
-// written.
-type RateLimitBindings = Readonly<
-  Partial<Record<ApiRateLimitBindingName, CloudflareRateLimit>>
->
+/**
+ * Binding name → binding type, one row per name `ApiBindingName` admits. The
+ * env below maps the infra-derived key union through this record, so a
+ * binding added in `infra/bindings.ts` fails this file's typecheck until its
+ * row exists here — the key set cannot drift from the deploy silently. The
+ * rate-limit buckets join as one mapped row: every bucket binding is the
+ * same `CloudflareRateLimit` shape, so a bucket added to the infra name
+ * record needs no new row below.
+ */
+type ApiBindingTypes = {
+  readonly DB: D1Database
+  readonly AI: WorkersAIBinding
+  readonly WEBHOOK_QUEUE: WebhookQueueBinding
+  readonly NOTIFICATION_EMAIL_QUEUE: NotificationEmailQueueBinding
+  // Workspace export (ADR 0055): the queue to request one and the bucket to
+  // serve signed downloads from. Both absent when unconfigured.
+  readonly WORKSPACE_EXPORT_QUEUE: WorkspaceExportQueueBinding
+  readonly WORKSPACE_EXPORT_BUCKET: WorkspaceExportBucketBinding
+} & Readonly<Record<ApiRateLimitBindingName, CloudflareRateLimit>>
 
-// The worker's Cloudflare bindings + redacted env. Shared by the handler
-// layers, the web-handler assembly, and the fetch entrypoint. It structurally
-// satisfies `ProviderEnv` (packages/ai), so the assistant selector takes this
-// env straight — no key-by-key copy: an unset var is absent or undefined, and
-// the selector reads both as unconfigured.
-export type ApiEnv = RateLimitBindings &
-  Partial<ServerEnv> & {
-    readonly DB?: D1Database
-    readonly AI?: WorkersAIBinding
-    readonly WEBHOOK_QUEUE?: WebhookQueueBinding
-    // Workspace export (ADR 0055): the queue to request one and the bucket to
-    // serve signed downloads from. Both absent when unconfigured.
-    readonly WORKSPACE_EXPORT_QUEUE?: WorkspaceExportQueueBinding
-    readonly WORKSPACE_EXPORT_BUCKET?: WorkspaceExportBucketBinding
-    readonly NOTIFICATION_EMAIL_QUEUE?: NotificationEmailQueueBinding
-  }
+// The worker's Cloudflare bindings + redacted env: the keys come from infra
+// (`ApiBindingName` in `@b2b-saas-starter/infra`, derived from the
+// per-worker name records that mirror the env blocks the deploy binds),
+// every one optional — a row says the deploy CAN bind it, never that it
+// did, because a provider-gated binding is deliberately absent while its
+// provider is unset.
+// Shared by the handler layers, the web-handler assembly, and the fetch
+// entrypoint. It structurally satisfies `ProviderEnv` (packages/ai), so the
+// assistant selector takes this env straight — no key-by-key copy: an unset
+// var is absent or undefined, and the selector reads both as unconfigured.
+export type ApiEnv = Partial<ServerEnv> &
+  Readonly<Partial<{ [B in ApiBindingName]: ApiBindingTypes[B] }>>
 
 // Capability env: the D1 binding selects Live vs Seed, and the webhook queue
 // binding enables real fan-out. The projection lives beside `StarterEnv` in

--- a/apps/background/package.json
+++ b/apps/background/package.json
@@ -13,6 +13,7 @@
     "@b2b-saas-starter/email": "workspace:*",
     "@b2b-saas-starter/env": "workspace:*",
     "@b2b-saas-starter/failure": "workspace:*",
+    "@b2b-saas-starter/infra": "workspace:*",
     "@b2b-saas-starter/logger": "workspace:*",
     "@sentry/cloudflare": "catalog:",
     "effect": "catalog:"

--- a/apps/background/src/env-parity.test.ts
+++ b/apps/background/src/env-parity.test.ts
@@ -1,0 +1,64 @@
+import {
+  type WorkspaceExportBucketBinding,
+  type WorkspaceExportQueueBinding
+} from '@b2b-saas-starter/capabilities/governance/workspace-export'
+import { type NotificationEmailQueueBinding } from '@b2b-saas-starter/capabilities/notifications/notification-email-queue'
+import { type WebhookQueueBinding } from '@b2b-saas-starter/capabilities/developer-platform/webhook-publisher'
+import { type SendEmailBinding } from '@b2b-saas-starter/email'
+import { type ServerEnv } from '@b2b-saas-starter/env/server'
+import { type BackgroundBindingName } from '@b2b-saas-starter/infra'
+import { describe, expect, it } from 'vite-plus/test'
+import { type Env } from './queue-consumer.ts'
+
+/**
+ * Type-level regression guard for the binding-name parity between
+ * `infra/bindings.ts` and the background worker's `Env`. The env's keys are
+ * now derived from the infra name union (`BackgroundBindingName`), so these
+ * tests pin the union to the binding set the deploy actually binds: a row
+ * dropped or renamed in `infra/bindings.ts` stops the `names` array from
+ * compiling, a mistyped binding row in `queue-consumer.ts` stops the
+ * round-trip arrows from compiling, and a binding ADDED in infra fails
+ * `queue-consumer.ts` itself, whose mapped env cannot resolve a name with no
+ * binding-type row. `pnpm run check` runs all three through `tsc` before
+ * vitest ever loads this file.
+ */
+
+// The pre-parity hand-written env shape, re-spelled here as the oracle:
+// `Env` must keep matching it key for key and type for type.
+type HandWrittenEnv = Partial<ServerEnv> & {
+  readonly DB?: D1Database
+  readonly WEBHOOK_QUEUE?: WebhookQueueBinding
+  readonly WORKSPACE_EXPORT_QUEUE?: WorkspaceExportQueueBinding
+  readonly WORKSPACE_EXPORT_BUCKET?: WorkspaceExportBucketBinding
+  readonly NOTIFICATION_EMAIL_QUEUE?: NotificationEmailQueueBinding
+  readonly EMAIL?: SendEmailBinding
+}
+
+describe('background Env binding parity', () => {
+  it('derives exactly the binding names the deploy binds', () => {
+    // Every literal must be a member of the infra-derived union: drop or
+    // rename a row in `infra/bindings.ts` and this array stops compiling.
+    const names: ReadonlyArray<BackgroundBindingName> = [
+      'DB',
+      'WEBHOOK_QUEUE',
+      'WORKSPACE_EXPORT_QUEUE',
+      'WORKSPACE_EXPORT_BUCKET',
+      'NOTIFICATION_EMAIL_QUEUE',
+      'EMAIL'
+    ]
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('satisfies the hand-written env shape it replaced, both directions', () => {
+    // Each declaration typechecks only while its parameter env is assignable
+    // to the other shape — a mistyped binding row in `queue-consumer.ts`
+    // fails here.
+    function handWrittenIntoModern(env: HandWrittenEnv): Env {
+      return env
+    }
+    function modernIntoHandWritten(env: Env): HandWrittenEnv {
+      return env
+    }
+    expect([handWrittenIntoModern, modernIntoHandWritten]).toHaveLength(2)
+  })
+})

--- a/apps/background/src/queue-consumer.ts
+++ b/apps/background/src/queue-consumer.ts
@@ -7,6 +7,7 @@ import { type NotificationEmailQueueBinding } from '@b2b-saas-starter/capabiliti
 import { type WebhookQueueBinding } from '@b2b-saas-starter/capabilities/developer-platform/webhook-publisher'
 import { type SendEmailBinding } from '@b2b-saas-starter/email'
 import { type ServerEnv } from '@b2b-saas-starter/env/server'
+import { type BackgroundBindingName } from '@b2b-saas-starter/infra'
 import {
   makeOtlpLayer,
   parentSpanFromHeaders,
@@ -27,26 +28,40 @@ import { FetchHttpClient, type HttpClient } from 'effect/unstable/http'
  * the shared `readDelivery` boundary decode.
  */
 
-// Bindings plus optional env. The same shape `ApiEnv` describes for apps/api.
-export type Env = Partial<ServerEnv> & {
-  readonly DB?: D1Database
+/**
+ * Binding name → binding type, one row per name `BackgroundBindingName`
+ * admits. `Env` below maps the infra-derived key union through this record,
+ * so a binding added in `infra/bindings.ts` fails this file's typecheck
+ * until its row exists here — the key set cannot drift from the deploy
+ * silently.
+ */
+type BackgroundBindingTypes = {
+  readonly DB: D1Database
   // The producer port, not workers-types' `Queue`: this worker only forwards
   // the binding to `starterEnv`, and every other worker declares it the same
   // way, so one structural shape describes the queue across all three.
-  readonly WEBHOOK_QUEUE?: WebhookQueueBinding
+  readonly WEBHOOK_QUEUE: WebhookQueueBinding
   // Workspace export (ADR 0055): the job queue this worker consumes and the
   // bucket it writes archives to. Both absent when `WORKSPACE_EXPORT_BUCKET`
   // was unset at deploy time; the capability then reports unavailable.
-  readonly WORKSPACE_EXPORT_QUEUE?: WorkspaceExportQueueBinding
-  readonly WORKSPACE_EXPORT_BUCKET?: WorkspaceExportBucketBinding
+  readonly WORKSPACE_EXPORT_QUEUE: WorkspaceExportQueueBinding
+  readonly WORKSPACE_EXPORT_BUCKET: WorkspaceExportBucketBinding
   // Producer port for instant notification emails — this worker both consumes
   // the queue and produces onto it (webhook deliveries that gave up create a
   // Notification). Absent, Notifications persist and no instant email goes out.
-  readonly NOTIFICATION_EMAIL_QUEUE?: NotificationEmailQueueBinding
+  readonly NOTIFICATION_EMAIL_QUEUE: NotificationEmailQueueBinding
   // Cloudflare Email send binding, for the notification emails. Absent, the
   // dispatcher logs instead of sending (CLAUDE.md rule 3).
-  readonly EMAIL?: SendEmailBinding
+  readonly EMAIL: SendEmailBinding
 }
+
+// Bindings plus optional env. The same shape `ApiEnv` describes for apps/api,
+// with the binding keys derived from infra (`BackgroundBindingName`) instead
+// of spelled: every key is optional, because a row says the deploy CAN bind
+// it — never that it did — and a provider-gated binding is deliberately
+// absent while its provider is unset.
+export type Env = Partial<ServerEnv> &
+  Readonly<Partial<{ [B in BackgroundBindingName]: BackgroundBindingTypes[B] }>>
 
 /**
  * Structural subset of a Cloudflare queue `Message`: the untrusted body plus

--- a/apps/web/src/worker-env.d.ts
+++ b/apps/web/src/worker-env.d.ts
@@ -1,7 +1,11 @@
 // The env shape is defined ONCE (`WebWorkerEnv`) and referenced by both the
 // `Cloudflare.Env` namespace augmentation and the global `Env` interface.
 // String vars derive from the `@b2b-saas-starter/env` `ServerEnv` type —
-// adding a var there updates this file automatically.
+// adding a var there updates this file automatically — and binding keys
+// from `WebBindingName` in `@b2b-saas-starter/infra`, the union derived
+// from that package's per-worker records mirroring the env blocks the
+// deploy binds: a binding added there fails this file's typecheck until a
+// row exists in `WebBindingTypes` below.
 
 // Optional provider env — forwarded by alchemy at deploy time.
 //
@@ -12,42 +16,57 @@
 // either — global type ALIASES do not apply, so both declarations below must
 // stay interfaces. The lint config exempts `**/*.d.ts` from the two style
 // rules that would otherwise reject this shape.
-type WebWorkerEnv = {
+type WebWorkerEnv = Readonly<
+  Partial<{
+    [B in import('@b2b-saas-starter/infra').WebBindingName]: WebBindingTypes[B]
+  }>
+> &
+  Readonly<import('@b2b-saas-starter/env/server').ServerEnv>
+
+/**
+ * Binding name → binding type, one row per name `WebBindingName` admits.
+ * `WebWorkerEnv` above maps the infra-derived key union through this
+ * record, so a binding added in `infra/bindings.ts` fails this file's
+ * typecheck until its row exists here — the key set cannot drift from the
+ * deploy silently. Every key stays optional in `WebWorkerEnv`: a row says
+ * the deploy CAN bind it, never that it did (CLAUDE.md rule 3). The auth
+ * rate-limit buckets join as one mapped row — every bucket binding is the
+ * same `CloudflareRateLimit` shape — so a bucket added to the infra name
+ * record needs no new row below.
+ */
+type WebBindingTypes = {
   // Optional so the local workers shim (no D1) satisfies the same type;
   // consumers must handle the missing binding (Seed layer fallback).
-  readonly DB?: D1Database
+  readonly DB: D1Database
   // Producer port for instant notification emails (consumed by the background
   // worker). Optional: without it Notifications persist and no instant email
   // is enqueued — the digest cron still covers them (CLAUDE.md rule 3).
-  readonly NOTIFICATION_EMAIL_QUEUE?: import('@b2b-saas-starter/capabilities/notifications/notification-email-queue').NotificationEmailQueueBinding
+  readonly NOTIFICATION_EMAIL_QUEUE: import('@b2b-saas-starter/capabilities/notifications/notification-email-queue').NotificationEmailQueueBinding
   // Cloudflare Email send binding. Optional and unwired by default: without it
   // the invite email goes through the logging dispatcher, which is what keeps
   // the invitation flow working with no provider configured (CLAUDE.md rule 3).
-  readonly EMAIL?: import('@b2b-saas-starter/email').SendEmailBinding
+  readonly EMAIL: import('@b2b-saas-starter/email').SendEmailBinding
   // Cloudflare Workers AI binding for the assistant. Optional and unwired by
   // default: without it (or without WORKERS_AI_ENABLED=true) the assistant
   // stays on its mock provider and the UI shows the honest not-enabled copy.
-  readonly AI?: import('@b2b-saas-starter/ai').WorkersAIBinding
+  readonly AI: import('@b2b-saas-starter/ai').WorkersAIBinding
   // Workspace data export (ADR 0055). Optional and unwired by default: without
   // both, `WorkspaceExports.availability` reports unavailable and the settings
   // page explains instead of offering a button.
-  readonly WORKSPACE_EXPORT_QUEUE?: import('@b2b-saas-starter/capabilities/governance/workspace-export').WorkspaceExportQueueBinding
-  readonly WORKSPACE_EXPORT_BUCKET?: import('@b2b-saas-starter/capabilities/governance/workspace-export').WorkspaceExportBucketBinding
+  readonly WORKSPACE_EXPORT_QUEUE: import('@b2b-saas-starter/capabilities/governance/workspace-export').WorkspaceExportQueueBinding
+  readonly WORKSPACE_EXPORT_BUCKET: import('@b2b-saas-starter/capabilities/governance/workspace-export').WorkspaceExportBucketBinding
   // Seat-sync queue producer. Optional and unwired by default: without it the
   // membership mutations publish nothing and seat sync heals on the next
   // mutation or provider webhook (CLAUDE.md rule 3).
-  readonly BILLING_QUEUE?: import(
+  readonly BILLING_QUEUE: import(
     '@b2b-saas-starter/capabilities/billing/seat-sync'
   ).SeatSyncQueueBinding
-} & RateLimitAuthBindings &
-  Readonly<import('@b2b-saas-starter/env/server').ServerEnv>
-
-// The auth rate-limit bindings derive from the infra table
-// (`webRateLimitBindingNames` in `@b2b-saas-starter/infra`): a mapped type
-// over the record's name union, so renaming or adding a bucket updates this
-// shape from the same row that generates the wrangler config. The inline
-// `import()` types keep this file a script — see the note above.
-type RateLimitAuthBindings = Readonly<Partial<Record<import('@b2b-saas-starter/infra').WebRateLimitBindingName, import('@b2b-saas-starter/rate-limit').CloudflareRateLimit>>>
+} & Readonly<
+  Record<
+    import('@b2b-saas-starter/infra').WebRateLimitBindingName,
+    import('@b2b-saas-starter/rate-limit').CloudflareRateLimit
+  >
+>
 
 // `env` from `cloudflare:workers` is typed as `Cloudflare.Env`
 // (@cloudflare/workers-types uses `export = CloudflareWorkersModule`, so a

--- a/apps/web/src/worker-env.test.ts
+++ b/apps/web/src/worker-env.test.ts
@@ -1,0 +1,79 @@
+import {
+  type WorkspaceExportBucketBinding,
+  type WorkspaceExportQueueBinding
+} from '@b2b-saas-starter/capabilities/governance/workspace-export'
+import { type NotificationEmailQueueBinding } from '@b2b-saas-starter/capabilities/notifications/notification-email-queue'
+import { type SeatSyncQueueBinding } from '@b2b-saas-starter/capabilities/billing/seat-sync'
+import { type SendEmailBinding } from '@b2b-saas-starter/email'
+import { type ServerEnv } from '@b2b-saas-starter/env/server'
+import { type WorkersAIBinding } from '@b2b-saas-starter/ai'
+import {
+  type WebBindingName,
+  type WebRateLimitBindingName
+} from '@b2b-saas-starter/infra'
+import { type CloudflareRateLimit } from '@b2b-saas-starter/rate-limit'
+import { describe, expect, it } from 'vite-plus/test'
+
+/**
+ * Type-level regression guard for the binding-name parity between
+ * `infra/bindings.ts` and the web worker's env (`WebWorkerEnv`, reached here
+ * through the ambient `Env` interface `worker-env.d.ts` declares). The env's
+ * keys are now derived from the infra name union (`WebBindingName`), so these
+ * tests pin the union to the binding set the deploy actually binds: a row
+ * dropped or renamed in `infra/bindings.ts` stops the `names` array from
+ * compiling, a mistyped binding row in `worker-env.d.ts` stops the round-trip
+ * arrows from compiling, and a binding ADDED in infra fails the `.d.ts`
+ * itself, whose mapped env cannot resolve a name with no binding-type row.
+ * `pnpm run check` runs all three through `tsc` before vitest ever loads
+ * this file.
+ */
+
+// The pre-parity hand-written env shape, re-spelled here as the oracle: the
+// ambient `Env` must keep matching it key for key and type for type.
+type RateLimitAuthBindings = Readonly<
+  Partial<Record<WebRateLimitBindingName, CloudflareRateLimit>>
+>
+
+type HandWrittenWebWorkerEnv = {
+  readonly DB?: D1Database
+  readonly NOTIFICATION_EMAIL_QUEUE?: NotificationEmailQueueBinding
+  readonly EMAIL?: SendEmailBinding
+  readonly AI?: WorkersAIBinding
+  readonly WORKSPACE_EXPORT_QUEUE?: WorkspaceExportQueueBinding
+  readonly WORKSPACE_EXPORT_BUCKET?: WorkspaceExportBucketBinding
+  readonly BILLING_QUEUE?: SeatSyncQueueBinding
+} & RateLimitAuthBindings &
+  Readonly<ServerEnv>
+
+describe('web worker env binding parity', () => {
+  it('derives exactly the binding names the deploy binds', () => {
+    // Every literal must be a member of the infra-derived union: drop or
+    // rename a row in `infra/bindings.ts` and this array stops compiling.
+    const names: ReadonlyArray<WebBindingName> = [
+      'DB',
+      'NOTIFICATION_EMAIL_QUEUE',
+      'EMAIL',
+      'AI',
+      'WORKSPACE_EXPORT_QUEUE',
+      'WORKSPACE_EXPORT_BUCKET',
+      'BILLING_QUEUE',
+      'RATE_LIMITER_AUTH_READ',
+      'RATE_LIMITER_AUTH_WRITE',
+      'RATE_LIMITER_AUTH_SIGN_IN'
+    ]
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('satisfies the hand-written env shape it replaced, both directions', () => {
+    // Each declaration typechecks only while its parameter env is assignable
+    // to the other shape — a mistyped binding row in `worker-env.d.ts` fails
+    // here.
+    function handWrittenIntoModern(env: HandWrittenWebWorkerEnv): Env {
+      return env
+    }
+    function modernIntoHandWritten(env: Env): HandWrittenWebWorkerEnv {
+      return env
+    }
+    expect([handWrittenIntoModern, modernIntoHandWritten]).toHaveLength(2)
+  })
+})

--- a/infra/bindings.ts
+++ b/infra/bindings.ts
@@ -163,14 +163,17 @@ export const notificationDigestCron = '0 8 * * *'
  * queue names above are single-sourced already; these keys are the other
  * half a rename could desynchronize between Alchemy's worker `env` objects
  * and the generated wrangler configs, so both emitters read them from this
- * record instead of inlining the strings.
+ * record instead of inlining the strings. `as const` keeps each value a
+ * literal type so the per-worker binding-name unions below can derive from
+ * them instead of re-spelling the strings.
  */
+// oxlint-disable-next-line effect/noAs -- `as const`, not a type assertion
 export const queueBindingKeys = {
   webhookQueue: 'WEBHOOK_QUEUE',
   billingQueue: 'BILLING_QUEUE',
   notificationEmailQueue: 'NOTIFICATION_EMAIL_QUEUE',
   workspaceExportQueue: 'WORKSPACE_EXPORT_QUEUE'
-} satisfies Record<QueueBindingKey, string>
+} as const satisfies Record<QueueBindingKey, string>
 
 /** The queue bindings a worker's env may carry, by role. */
 export type QueueBindingKey =
@@ -178,6 +181,90 @@ export type QueueBindingKey =
   | 'billingQueue'
   | 'notificationEmailQueue'
   | 'workspaceExportQueue'
+
+/**
+ * The binding names that are neither queues nor rate limits: the D1 database
+ * every worker shares, the Workers AI binding the assistant surfaces read,
+ * the Cloudflare Email send binding, and the workspace-export R2 bucket
+ * (ADR 0055). `alchemy.run.ts` and `infra/write-wrangler.ts` still spell
+ * these values inline — the one duplication left in the chain — while the
+ * per-worker records below read them from here, so the exported unions have
+ * a single home per name.
+ */
+// oxlint-disable-next-line effect/noAs -- `as const`, not a type assertion
+const resourceBindingNames = {
+  database: 'DB',
+  workersAi: 'AI',
+  email: 'EMAIL',
+  workspaceExportBucket: 'WORKSPACE_EXPORT_BUCKET'
+} as const
+
+/**
+ * Per-worker binding-name records: the env-type-facing mirror of the `env`
+ * blocks `alchemy.run.ts` binds (`infra/write-wrangler.ts` generates the
+ * same sets minus EMAIL — miniflare cannot simulate SendEmail, so local
+ * dev never binds it). Values come only from the records above and
+ * `queueBindingKeys` — never re-spelled — so a rename there moves the
+ * exported `…BindingName` unions, and the worker env types keyed by them
+ * (`apps/api/src/env.ts`, `apps/background/src/queue-consumer.ts`,
+ * `apps/web/src/worker-env.d.ts`), in one edit. A row added here grows its
+ * union, and that env type then fails its typecheck until a binding-type
+ * row exists — the keys can no longer drift from the deploy silently. A row
+ * says the key EXISTS when the deploy binds it, never that it is present:
+ * the env types keep every key optional, because a provider-gated binding
+ * (EMAIL, the workspace-export pair) is deliberately absent while its
+ * provider is unset. The API worker carries no EMAIL row on purpose — it
+ * wires no email dispatcher (apps/api/AGENTS.md), so the binding alchemy
+ * spreads into its env simply has no reader there.
+ */
+// oxlint-disable-next-line effect/noAs -- `as const`, not a type assertion
+const apiBindingNames = {
+  database: resourceBindingNames.database,
+  workersAi: resourceBindingNames.workersAi,
+  webhookQueue: queueBindingKeys.webhookQueue,
+  notificationEmailQueue: queueBindingKeys.notificationEmailQueue,
+  workspaceExportQueue: queueBindingKeys.workspaceExportQueue,
+  workspaceExportBucket: resourceBindingNames.workspaceExportBucket
+} as const
+
+// oxlint-disable-next-line effect/noAs -- `as const`, not a type assertion
+const backgroundBindingNames = {
+  database: resourceBindingNames.database,
+  webhookQueue: queueBindingKeys.webhookQueue,
+  notificationEmailQueue: queueBindingKeys.notificationEmailQueue,
+  workspaceExportQueue: queueBindingKeys.workspaceExportQueue,
+  workspaceExportBucket: resourceBindingNames.workspaceExportBucket,
+  email: resourceBindingNames.email
+} as const
+
+// oxlint-disable-next-line effect/noAs -- `as const`, not a type assertion
+const webBindingNames = {
+  database: resourceBindingNames.database,
+  workersAi: resourceBindingNames.workersAi,
+  billingQueue: queueBindingKeys.billingQueue,
+  notificationEmailQueue: queueBindingKeys.notificationEmailQueue,
+  workspaceExportQueue: queueBindingKeys.workspaceExportQueue,
+  workspaceExportBucket: resourceBindingNames.workspaceExportBucket,
+  email: resourceBindingNames.email
+} as const
+
+/**
+ * Every binding name each worker's env may carry. Rate limits join through
+ * their own name unions, so a bucket added to a rate-limit name record is
+ * picked up without a second row here. Import these into the worker env
+ * types as `Partial<Record<…>>`-style keys — never as a claim that any key
+ * is present (see the records above).
+ */
+export type ApiBindingName =
+  | ApiRateLimitBindingName
+  | (typeof apiBindingNames)[keyof typeof apiBindingNames]
+
+export type BackgroundBindingName =
+  (typeof backgroundBindingNames)[keyof typeof backgroundBindingNames]
+
+export type WebBindingName =
+  | WebRateLimitBindingName
+  | (typeof webBindingNames)[keyof typeof webBindingNames]
 
 /**
  * One compatibility date and flag set for every worker — production

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       '@b2b-saas-starter/failure':
         specifier: workspace:*
         version: link:../../packages/failure
+      '@b2b-saas-starter/infra':
+        specifier: workspace:*
+        version: link:../../infra
       '@b2b-saas-starter/logger':
         specifier: workspace:*
         version: link:../../packages/logger


### PR DESCRIPTION
## What

Binding-name parity between the infra binding specs and the worker env types (backlog item 5).

`infra/bindings.ts` now exports per-worker binding-name unions (`ApiBindingName`, `BackgroundBindingName`, `WebBindingName`), derived from the same binding specs Alchemy and `write-wrangler.ts` consume. The three worker env types (`apps/api/src/env.ts`, the `Env` block in `apps/background/src/queue-consumer.ts`, `apps/web/src/worker-env.d.ts`) map that union through a name → binding-type record, so a binding added in infra fails the worker's typecheck until its type row exists — the key set can no longer drift from the deploy silently.

The guarantee is one-directional by design: a row says the deploy *can* bind a key, never that it did — provider-gated bindings stay optional (AGENTS.md rule 3). Type-level only; zero runtime diff.

Along the way `apps/background` declares `@b2b-saas-starter/infra` as a workspace dependency (it reached infra via relative imports before; the new import uses the package export like `apps/api` already does).

## Verification

- `pnpm run check` green (80 files / 495 tests), including new type-parity tests in all three apps.
- Reviewed by a second pass (thermo-nuclear quality review): confirmed the unions derive from the spec records rather than re-spelled literals, simplified the mapped-type shape, and moved the queue-consumer import to the package export.