### PR TITLE
perf(web): build the Live capability layer once per request

### DIFF
--- a/apps/web/src/lib/capabilities.test.ts
+++ b/apps/web/src/lib/capabilities.test.ts
@@ -1,9 +1,26 @@
 import { ApiTokenRegistry } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
+import {
+  WorkspaceMembership,
+  type WorkspaceMemberBinding
+} from '@b2b-saas-starter/capabilities/governance/workspace-membership'
 import { Effect } from 'effect'
-import { describe, expect, it } from 'vite-plus/test'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
 import { ForbiddenError } from './capability-error'
-import { runWorkspaceCapabilities } from './capabilities'
+import { runCapabilities, runWorkspaceCapabilities } from './capabilities'
+import { runWebRequestScope } from './observability'
 import { requireWorkspacePermission } from './server/authorize'
+
+// The once-per-request services find the request through `currentRequest`
+// (`memoizePerRequest`'s default lookup), so that module is the one seam these
+// tests steer. The holder defaults to `undefined`, which is what the
+// authorization tests below already run under — outside any request.
+const ambient: { request: Request | undefined } = vi.hoisted(() => ({
+  request: undefined
+}))
+
+vi.mock('./request-context', () => ({
+  currentRequest: () => ambient.request
+}))
 
 /**
  * The whole web enforcement path, end to end against the Seed layer: the
@@ -39,5 +56,114 @@ describe('runWorkspaceCapabilities authorization', () => {
     await expect(createToken('usr_dev')).rejects.toThrow(
       /do not have permission|not allowed/i
     )
+  })
+})
+
+/**
+ * Yields the membership service itself: instance identity is the observable of
+ * "the capability layer was built once". The seed membership adapter is a
+ * `Layer.effect` whose roster is built per layer construction (see
+ * `makeSeedRoster`), so a second build is a second, visibly distinct object —
+ * unlike `Layer.succeed` services, whose values are module singletons either
+ * way.
+ */
+const membershipService = Effect.gen(function* () {
+  return yield* WorkspaceMembership
+})
+
+// A binding that is never invoked — the probe only reads a service — so inert
+// stubs carry exactly the type `CapabilityBindings` asks for.
+const inertMemberBinding: WorkspaceMemberBinding = {
+  addMember: () => Promise.resolve(),
+  removeMember: () => Promise.resolve(),
+  leave: () => Promise.resolve(),
+  changeRole: () => Promise.resolve()
+}
+
+describe('per-request capability services', () => {
+  afterEach(() => {
+    ambient.request = undefined
+  })
+
+  it('builds the services once per request, reusing them across every run in it', async () => {
+    const request = new Request('http://localhost/workspaces/starter-lab')
+    ambient.request = request
+
+    await runWebRequestScope({ request, handlerType: 'router' }, async () => {
+      // Three runs, the shape of a page whose layout and segments each load:
+      // two global runs and one workspace run must land on one build. The
+      // workspace run also proves the per-call context layer still resolves
+      // (`usr_demo` owns the fixture workspace) on top of the shared services.
+      const globalA = await runCapabilities(membershipService)
+      const globalB = await runCapabilities(membershipService)
+      const workspace = await runWorkspaceCapabilities(
+        'starter-lab',
+        membershipService,
+        { userId: 'usr_demo' }
+      )
+      expect(globalA).toBe(globalB)
+      expect(globalA).toBe(workspace)
+      return new Response(null, { status: 204 })
+    })
+  })
+
+  it('builds a fresh services context for a later request', async () => {
+    const first = new Request('http://localhost/workspaces/first')
+    const second = new Request('http://localhost/workspaces/second')
+    let fromFirst: unknown
+    let fromSecond: unknown
+
+    ambient.request = first
+    await runWebRequestScope({ request: first, handlerType: 'router' }, async () => {
+      fromFirst = await runCapabilities(membershipService)
+      return new Response(null, { status: 204 })
+    })
+    ambient.request = second
+    await runWebRequestScope({ request: second, handlerType: 'router' }, async () => {
+      fromSecond = await runCapabilities(membershipService)
+      return new Response(null, { status: 204 })
+    })
+
+    expect(fromFirst).not.toBe(fromSecond)
+  })
+
+  it('builds per call outside a request scope, as tests and scripts still do', async () => {
+    ambient.request = undefined
+
+    const a = await runCapabilities(membershipService)
+    const b = await runCapabilities(membershipService)
+
+    expect(a).not.toBe(b)
+  })
+
+  it('gives plugin bindings their own memo slot, keyed by adapter identity', async () => {
+    const request = new Request('http://localhost/workspaces/starter-lab')
+    ambient.request = request
+    const otherMemberBinding: WorkspaceMemberBinding = {
+      addMember: () => Promise.resolve(),
+      removeMember: () => Promise.resolve(),
+      leave: () => Promise.resolve(),
+      changeRole: () => Promise.resolve()
+    }
+
+    await runWebRequestScope({ request, handlerType: 'router' }, async () => {
+      const plain = await runCapabilities(membershipService)
+      const bound = await runCapabilities(membershipService, {
+        memberBinding: inertMemberBinding
+      })
+      // The same adapter object again — one slot, one build.
+      const boundAgain = await runCapabilities(membershipService, {
+        memberBinding: inertMemberBinding
+      })
+      // A different adapter object — its own slot, never the first call's.
+      const boundElsewhere = await runCapabilities(membershipService, {
+        memberBinding: otherMemberBinding
+      })
+
+      expect(bound).not.toBe(plain)
+      expect(boundAgain).toBe(bound)
+      expect(boundElsewhere).not.toBe(bound)
+      return new Response(null, { status: 204 })
+    })
   })
 })

--- a/apps/web/src/lib/capabilities.ts
+++ b/apps/web/src/lib/capabilities.ts
@@ -9,7 +9,7 @@ import {
 import { billingOptionsFromEnv } from '@b2b-saas-starter/capabilities/billing/billing.live'
 import {
   selectCapabilitiesLayer,
-  selectWorkspaceLayer,
+  selectWorkspaceContextLayer,
   type StarterEnv
 } from '@b2b-saas-starter/capabilities/runtime'
 import {
@@ -19,7 +19,7 @@ import {
 import { type CapabilityServices } from '@b2b-saas-starter/capabilities/layers'
 import { env as cloudflareEnv } from 'cloudflare:workers'
 import { notFound } from '@tanstack/react-router'
-import { Cause, Effect, Exit, Option, type Scope } from 'effect'
+import { type Context, Cause, Effect, Exit, Layer, Option, type Scope } from 'effect'
 
 import {
   CapabilityUnavailableError,
@@ -28,7 +28,7 @@ import {
   PlanLimitError,
   UserAdminRefusedError
 } from './capability-error'
-import { webRuntime, withWebRequestScope } from './observability'
+import { memoizePerRequest, webRuntime, withWebRequestScope } from './observability'
 
 export type { CapabilityServices }
 
@@ -41,6 +41,10 @@ export type { CapabilityServices }
  * Better Auth server instance into the client bundle. Server functions — which
  * only ever run on the server — pass one in when they need a mutation. See
  * `server/invitation-binding.ts`.
+ *
+ * Per call also means per memo slot: {@link capabilitiesServices} keys the
+ * per-request build on which adapters were passed, so a mutation never reuses
+ * the shared read-only services, and vice versa.
  */
 export type CapabilityBindings = Pick<
   StarterEnv,
@@ -68,6 +72,97 @@ const starterEnv: StarterEnv = {
   WORKSPACE_EXPORT_BUCKET: cloudflareEnv.WORKSPACE_EXPORT_BUCKET,
   NOTIFICATION_EMAIL_QUEUE: cloudflareEnv.NOTIFICATION_EMAIL_QUEUE,
   billing: billingOptionsFromEnv(cloudflareEnv)
+}
+
+/**
+ * The binding fields a caller may pass per call, declared once so the memo key
+ * below cannot drift from {@link CapabilityBindings}: a field added there
+ * without a row here would silently fold two different adapters onto one
+ * per-request slot.
+ */
+const BINDING_FIELDS = [
+  'memberBinding',
+  'invitationBinding',
+  'lifecycleBinding',
+  'userAdminBinding',
+  'ssoBinding',
+  'accountLifecycleBinding'
+] satisfies ReadonlyArray<keyof CapabilityBindings>
+
+/**
+ * Stable per-object ids for that key. A binding is an opaque bag of plugin
+ * call closures, so object identity — not structure — is the honest
+ * discriminator: two calls passing the same adapter (every server fn imports
+ * its binding from a module, so this is the norm) share one slot, while two
+ * different adapters never share a layer. The map names objects; it holds no
+ * services, so nothing here outlives a request.
+ */
+type AnyCapabilityBinding = NonNullable<CapabilityBindings[keyof CapabilityBindings]>
+
+const bindingSlotIds = new WeakMap<AnyCapabilityBinding, number>()
+let nextBindingSlotId = 1
+
+function bindingSlotId(binding: AnyCapabilityBinding): number {
+  const known = bindingSlotIds.get(binding)
+  if (known !== undefined) {
+    return known
+  }
+  const id = nextBindingSlotId
+  nextBindingSlotId += 1
+  bindingSlotIds.set(binding, id)
+  return id
+}
+
+/**
+ * One memo slot name per distinct set of plugin bindings. Read-only calls —
+ * every loader — pass none and land on one shared slot; a mutation selects its
+ * own, so the layer built around one call's adapters is never reused for
+ * another's.
+ */
+function capabilitiesMemoKey(bindings: CapabilityBindings | undefined): string {
+  if (bindings === undefined) {
+    return 'capabilities.services:none'
+  }
+  const slots = BINDING_FIELDS.flatMap((field) => {
+    const binding = bindings[field]
+    return binding === undefined ? [] : [`${field}:${bindingSlotId(binding)}`]
+  })
+  return slots.length === 0
+    ? 'capabilities.services:none'
+    : `capabilities.services:${slots.join('+')}`
+}
+
+/**
+ * The selected capability services, built once per request and shared by every
+ * Effect run in it: the merged live graph is 17 layers plus a drizzle client,
+ * and one page load fans out into several loader runs that all need the same
+ * one. `memoizePerRequest` is the sanctioned home — slots live on the
+ * request's telemetry, so concurrent requests on one isolate never share a
+ * build. That is deliberately not the API worker's isolate-level layer
+ * (`apps/api/src/http.ts`): these services cannot be hoisted out of the
+ * request, because their plugin-backed adapters arrive per call.
+ *
+ * What is memoized is the built `Context`, not the `Layer` value — Effect
+ * memoizes layer construction per memo map, and sibling runs each bring their
+ * own, so only a shared context actually crosses the run boundary. The scope
+ * the build runs in closes when the build completes; no layer in this graph
+ * registers finalizers (plain constructors across `capabilities`,
+ * `db/service`, and the drizzle D1 drivers), so the services outlive that
+ * close for the rest of the request. A layer that needs `acquireRelease` must
+ * not join this context without revisiting that. Outside a request — unit
+ * tests, scripts, client-side navigations — there is no slot to dedupe
+ * against, so every call builds its own, exactly as before.
+ */
+function capabilitiesServices(
+  bindings?: CapabilityBindings
+): Promise<Context.Context<CapabilityServices>> {
+  return memoizePerRequest(capabilitiesMemoKey(bindings), () =>
+    webRuntime.runPromise(
+      Effect.scoped(
+        Layer.build(selectCapabilitiesLayer({ ...starterEnv, ...bindings }))
+      )
+    )
+  )
 }
 
 // The Effect → TanStack boundary. Loaders and server functions are Promise
@@ -114,6 +209,10 @@ function rethrowCapabilityFailure(cause: Cause.Cause<unknown>): never {
  * Runs a workspace-scoped capability effect for a route loader or server
  * function.
  *
+ * - The capability services come from the once-per-request build ({@link
+ *   capabilitiesServices}); the `WorkspaceContext` layer is provided per
+ *   call, because it is the one service that depends on this request's slug
+ *   and actor — the same split `selectWorkspaceContextLayer` documents.
  * - `actor` is the signed-in user (from `requireSession`); the capabilities
  *   layer verifies workspace membership and fails with `WorkspaceNotFound`
  *   for non-members (non-disclosing). Omit it only for trusted server-side
@@ -135,6 +234,7 @@ export async function runWorkspaceCapabilities<A, E>(
   actor?: ActorRef,
   bindings?: CapabilityBindings
 ): Promise<A> {
+  const services = await capabilitiesServices(bindings)
   const exit = await webRuntime.runPromiseExit(
     withWebRequestScope(
       {
@@ -142,8 +242,15 @@ export async function runWorkspaceCapabilities<A, E>(
         metadata: { workspaceSlug, actorUserId: actor?.userId }
       },
       Effect.provide(
-        effect,
-        selectWorkspaceLayer({ ...starterEnv, ...bindings }, workspaceSlug, actor)
+        Effect.provide(
+          effect,
+          selectWorkspaceContextLayer(
+            { ...starterEnv, ...bindings },
+            workspaceSlug,
+            actor
+          )
+        ),
+        services
       )
     )
   )
@@ -157,17 +264,19 @@ export async function runWorkspaceCapabilities<A, E>(
  * Runs a capability effect that is not scoped to a single workspace — system
  * surfaces (`/admin`'s global audit log) and cross-workspace projections
  * (`listWorkspacesForUser`). Provides the capability services WITHOUT
- * `WorkspaceContext`; `CapabilityUnavailable` maps to
+ * `WorkspaceContext`, from the same once-per-request build
+ * {@link runWorkspaceCapabilities} rides on; `CapabilityUnavailable` maps to
  * `CapabilityUnavailableError` exactly like `runWorkspaceCapabilities`.
  */
 export async function runCapabilities<A, E>(
   effect: Effect.Effect<A, E, CapabilityServices>,
   bindings?: CapabilityBindings
 ): Promise<A> {
+  const services = await capabilitiesServices(bindings)
   const exit = await webRuntime.runPromiseExit(
     withWebRequestScope(
       { event: 'capability.global' },
-      Effect.provide(effect, selectCapabilitiesLayer({ ...starterEnv, ...bindings }))
+      Effect.provide(effect, services)
     )
   )
   if (Exit.isSuccess(exit)) {


### PR DESCRIPTION
## What changed

`apps/web/src/lib/capabilities.ts` only (plus its test). Every loader and server-function run used to rebuild the selected capabilities layer per call — `makeLiveCapabilitiesLayer` (17 layers) plus `layerFromD1` (a drizzle client) — because `runWorkspaceCapabilities` / `runCapabilities` each did `Effect.provide(effect, select*Layer(...))` on a freshly constructed layer value, and sibling runs do not share an Effect layer memo map.

Now a `capabilitiesServices(bindings)` helper builds the selected capabilities layer **once per request** through the existing `memoizePerRequest` (`observability.ts`) and hands every run in that request the same built `Context` via `Effect.provide(effect, context)`:

- `runCapabilities` provides the shared services directly.
- `runWorkspaceCapabilities` provides the shared services **and** a per-call `selectWorkspaceContextLayer` — `WorkspaceContext` is the one service that depends on the request's slug and actor, the split `runtime.ts` already documents. Plugin bindings are still passed per call and key the memo slot (binding-object identity), so a mutation never reuses the read-only services and vice versa.
- Outside a request (unit tests, scripts, client-side navigations) there is no memo slot, so every call builds its own — the previous behavior, preserved.

Constraints honored: no module-level `ManagedRuntime`, no server-only sibling module, no new imports beyond `Layer`/`Context` from `effect` and `memoizePerRequest` from `./observability` (already in the module's graph) — `capabilities.ts` stays import-safe for the browser and drizzle stays out of the client bundle.

## Why

Audit finding (P2, Effect service design review): the per-run rebuild is pure waste — a page load fans out into several loader runs that all need the same 17-layer graph and drizzle client. `memoizePerRequest` is this app's sanctioned request-scoped memoization home (slots die with the request, shared across Start's re-wrapped `Request` instances). This is deliberately *not* the API worker's isolate-level pattern (`apps/api/src/http.ts`): the web layer's plugin-backed adapters arrive per call, not per isolate.

## Validation

- **New tests** in `apps/web/src/lib/capabilities.test.ts` (`per-request capability services`):
  - `builds the services once per request, reusing them across every run in it` — 3 runs inside one `runWebRequestScope` (two `runCapabilities`, one `runWorkspaceCapabilities`) share one service instance; the probe is the seed `WorkspaceMembership` adapter, whose roster is constructed per layer build, so instance identity counts builds.
  - `builds a fresh services context for a later request` — no cross-request leak.
  - `builds per call outside a request scope, as tests and scripts still do`.
  - `gives plugin bindings their own memo slot, keyed by adapter identity` — same adapter shares, different adapters never share.
  - Mutation-checked: bypassing the memo makes the once-per-request and binding-slot tests fail.
- **`pnpm run check`** green (typecheck, lint, format, dead-code, all tests; apps/web: 79 files / 497 tests).
- **`pnpm run build`** in apps/web passes with `assert-client-boundary.mjs` green; `dist/client` contains no drizzle (`drizzle`, `effect-d1` greps: 0 hits) and is byte-size-identical to a master build (6952 KB both).
- **Live path**: e2e could not be used here — the Playwright suite fails identically on master in this sandbox (same 12/17 parallel, same 8/9 serial, failure-for-failure, including capability-free pages like `/forgot-password`), so it is environmental, not from this change. As a substitute, the exact web composition (`Layer.build(selectCapabilitiesLayer({DB}))` → `Effect.provide(effect, ctx)` + per-call `selectWorkspaceContextLayer`) was verified in a scratch vitest against a provisioned local D1 (`@b2b-saas-starter/db/testing`): the shared context served real D1 reads across runs and the workspace context failed closed for a non-member. That scratch was deleted after the check; the committed diff is the two files above.

## Notes

- The task brief referenced `packages/ai/AGENTS.md`, which does not exist in this repo (`packages/ai` has no AGENTS.md); per the brief's fallback I followed the written instructions directly. `packages/db/AGENTS.md` was read as instructed.
- No other files touched; the one behavior delta is that runs inside a single request now observe the same service instances (e.g. seed roster), which matches Live semantics within a request and is unobservable across requests/tests.