### PR TITLE
test(background): assert queue ack/retry semantics with vitest-pool-workers

### DIFF
--- a/apps/background/package.json
+++ b/apps/background/package.json
@@ -19,6 +19,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "catalog:",
     "@cloudflare/workers-types": "catalog:",
     "@effect/vitest": "catalog:",
     "@react-email/render": "catalog:",

--- a/apps/background/src/export-consumer.pool.test.ts
+++ b/apps/background/src/export-consumer.pool.test.ts
@@ -1,0 +1,148 @@
+import { type WorkspaceExportQueueMessage } from '@b2b-saas-starter/capabilities/governance/workspace-export'
+import { workspaceExportQueueName } from '../../../infra/bindings.ts'
+import { env } from 'cloudflare:workers'
+import { Effect } from 'effect'
+import { beforeAll, beforeEach, describe, expect, it } from 'vite-plus/test'
+
+import { applyPoolMigrations, consume, db, row, rows } from './test-pool.ts'
+
+// The export consumer's queue-runtime contract (ADR 0055), inside workerd
+// through `@cloudflare/vitest-pool-workers`: real D1 (the committed
+// migrations), the real R2 bucket from `wrangler.jsonc`, and real acks —
+// asserted with `getQueueResult()`. Exports have no dead-letter queue: the
+// row is the record, so both a completed and a failed build end in an ack,
+// with the row carrying the outcome. No async functions on purpose — the
+// Effect lint rules ban them, so promise steps ride `Effect.promise` inside
+// `Effect.runPromise`, like the live suites in `packages/auth`.
+
+const WORKSPACE_ID = 'ws_export'
+const WORKSPACE_SLUG = 'pool-exports'
+const EXPORT_ID = 'wexp_pool'
+const OBJECT_KEY = `workspaces/${WORKSPACE_ID}/${EXPORT_ID}.json.gz`
+
+/** The R2 binding the pool provisioned from `wrangler.jsonc`; always present under the pool. */
+function bucket() {
+  const binding = env.WORKSPACE_EXPORT_BUCKET
+  if (binding === undefined) {
+    throw new Error('expected the workers pool to provision the bucket binding')
+  }
+  return binding
+}
+
+/** One export job message, addressed by the slug the consumer must re-resolve. */
+function exportMessage(
+  slug: string
+): ServiceBindingQueueMessage<WorkspaceExportQueueMessage> {
+  return {
+    id: EXPORT_ID,
+    // The platform's message shape carries a plain Date; `DateTime` has no
+    // place in a value vitest serializes into the batch.
+    // oxlint-disable-next-line effect/noGlobals -- platform message field, not application time
+    timestamp: new Date(1000),
+    attempts: 1,
+    body: {
+      exportId: EXPORT_ID,
+      workspaceId: WORKSPACE_ID,
+      workspaceSlug: slug
+    }
+  }
+}
+
+/** Clears the tables the export touches and seeds one workspace with a pending export row. */
+function seedPendingExport(): Promise<void> {
+  return db()
+    .batch([
+      db().prepare('delete from workspace_exports'),
+      db().prepare('delete from webhook_deliveries'),
+      db().prepare('delete from audit_events'),
+      db().prepare('delete from notifications'),
+      db().prepare('delete from webhook_endpoints'),
+      db().prepare('delete from api_tokens'),
+      db().prepare('delete from workspace_invitations'),
+      db().prepare('delete from workspace_members'),
+      db().prepare('delete from workspaces'),
+      db()
+        .prepare('insert into workspaces (id, name, slug) values (?, ?, ?)')
+        .bind(WORKSPACE_ID, 'Pool Exports', WORKSPACE_SLUG),
+      db()
+        .prepare(
+          `insert into workspace_exports
+           (id, workspace_id, status, download_secret, created_at)
+         values (?, ?, ?, ?, ?)`
+        )
+        .bind(
+          EXPORT_ID,
+          WORKSPACE_ID,
+          'pending',
+          'wsec_pool',
+          '2026-09-06T00:00:00.000Z'
+        )
+    ])
+    .then(() => undefined)
+}
+
+describe('workspace export consumer (workers pool)', () => {
+  // oxlint-disable-next-line effect/noTestLifecycleHooks -- applies the committed migrations to the pool's D1
+  beforeAll(() => applyPoolMigrations())
+  // oxlint-disable-next-line effect/noTestLifecycleHooks -- resets D1 between outcomes
+  beforeEach(() => seedPendingExport())
+
+  it('acks a finished export after storing the archive and flipping the row ready', () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- promise-interop port: bridges vitest-pool-workers createMessageBatch/getQueueResult into Effect
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const result = yield* Effect.promise(() =>
+          consume(workspaceExportQueueName, [exportMessage(WORKSPACE_SLUG)])
+        )
+        expect(result.explicitAcks).toStrictEqual([EXPORT_ID])
+        expect(result.retryMessages).toStrictEqual([])
+        const exportRow = yield* Effect.promise(() =>
+          row('select * from workspace_exports where id = ?', EXPORT_ID)
+        )
+        expect(exportRow?.workspace_id).toBe(WORKSPACE_ID)
+        expect(exportRow?.status).toBe('ready')
+        expect(exportRow?.object_key).toBe(OBJECT_KEY)
+        expect(exportRow?.completed_at).not.toBeNull()
+        const sizeBytes = exportRow?.size_bytes
+        expect(sizeBytes).toBeGreaterThan(0)
+        // The bytes the row points at exist in the bucket the pool bound.
+        const object = yield* Effect.promise(() => bucket().get(OBJECT_KEY))
+        expect(object).not.toBeNull()
+        expect(object?.size).toBe(sizeBytes)
+        // The completion is audited beside the row flip.
+        const audit = yield* Effect.promise(() =>
+          rows(
+            'select * from audit_events where event_type = ?',
+            'workspace.export_completed'
+          )
+        )
+        expect(audit).toHaveLength(1)
+        expect(audit[0]?.workspace_id).toBe(WORKSPACE_ID)
+        expect(audit[0]?.target_type).toBe('workspace_export')
+        expect(audit[0]?.target_id).toBe(EXPORT_ID)
+      })
+    ))
+
+  it('acks an export whose slug no longer resolves, marking the row failed', () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- promise-interop port: bridges vitest-pool-workers createMessageBatch/getQueueResult into Effect
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const result = yield* Effect.promise(() =>
+          consume(workspaceExportQueueName, [exportMessage('deleted-slug')])
+        )
+        // No dead-letter queue for exports: a build that cannot even start
+        // still acks, and the row carries the outcome.
+        expect(result.explicitAcks).toStrictEqual([EXPORT_ID])
+        expect(result.retryMessages).toStrictEqual([])
+        const exportRow = yield* Effect.promise(() =>
+          row('select * from workspace_exports where id = ?', EXPORT_ID)
+        )
+        expect(exportRow?.status).toBe('failed')
+        expect(exportRow?.failure_reason).toBe('workspace_not_found')
+        expect(exportRow?.object_key).toBeNull()
+        expect(exportRow?.completed_at).toBeNull()
+        // The row points at no archive: nothing was ever built or stored for
+        // this export (the ready test above proves the write path works).
+      })
+    ))
+})

--- a/apps/background/src/pool-tests.d.ts
+++ b/apps/background/src/pool-tests.d.ts
@@ -1,0 +1,27 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+/// <reference types="@cloudflare/workers-types/experimental" />
+
+// Ambient types for the workers-pool tests (`src/*.pool.test.ts`). The two
+// references above pull in `cloudflare:test` (createMessageBatch,
+// getQueueResult, applyD1Migrations, ...) and the service-binding queue
+// result shapes (FetcherQueueResult, ServiceBindingQueueMessage) that live
+// in the experimental subset of @cloudflare/workers-types — ambient modules
+// and globals, so there is nothing to import explicitly.
+
+// The pool's env: the background worker's own `Env` plus the test-only
+// migration binding `vitest.config.ts` installs. Inline `import()` types are
+// load-bearing — a top-level import would turn this file into a module and
+// the `Cloudflare.Env` merge below would stop reaching the `env` binding
+// from `cloudflare:workers` (same discipline as `apps/web/src/worker-env.d.ts`:
+// the intersection is named once, then merged as an interface).
+type PoolEnv = {
+  readonly TEST_MIGRATIONS: Array<{
+    readonly name: string
+    readonly queries: Array<string>
+  }>
+} & import('./queue-consumer.ts').Env
+
+// Types the `env` binding from `cloudflare:workers` for the pool tests.
+declare namespace Cloudflare {
+  interface Env extends PoolEnv {}
+}

--- a/apps/background/src/test-pool.ts
+++ b/apps/background/src/test-pool.ts
@@ -1,0 +1,90 @@
+import {
+  applyD1Migrations,
+  createExecutionContext,
+  createMessageBatch,
+  getQueueResult
+} from 'cloudflare:test'
+import { env } from 'cloudflare:workers'
+
+import worker from './index.ts'
+import { type Env } from './queue-consumer.ts'
+
+/**
+ * The scaffolding every `*.pool.test.ts` suite shares, so the next pool test
+ * starts at `consume` instead of re-deriving the handler wiring: the worker's
+ * real `queue` handler invoked the way the runtime invokes it (batch, env,
+ * ctx), the D1 binding the pool provisioned from `wrangler.jsonc`, and the
+ * committed migrations (a plain-data binding, installed by `vitest.config.ts`)
+ * applied to that D1. Queue-specific fixtures — message builders, table
+ * seeds — stay beside their suite.
+ */
+
+// SAFETY: `Sentry.withSentry` types the wrapped `queue` handler as
+// (batch, env), but its queue instrumentation reads the runtime's third
+// argument (`ctx.waitUntil`, instrumentQueue.ts), and production always
+// passes one — the cast only restores the ExportedHandlerQueueHandler
+// contract the wrapper's own type dropped, and the bind keeps the method's
+// own receiver. No value changes hands.
+// oxlint-disable-next-line effect/noAs -- see SAFETY above
+const queueHandler = worker.queue.bind(worker) as ExportedHandlerQueueHandler<Env>
+
+/** D1 hands text and integer columns back as strings, numbers, or null. */
+export type PoolRow = Readonly<Record<string, string | number | null>>
+
+/** The D1 binding the pool provisioned from `wrangler.jsonc`; always present under the pool. */
+export function db(): D1Database {
+  const binding = env.DB
+  if (binding === undefined) {
+    // oxlint-disable-next-line effect/noThrowStatement, effect/noNewError -- a missing binding means the pool never started (wrangler.jsonc unreadable); there is no Effect channel to defect into from a promise-based helper, and no test could run past this
+    throw new Error('expected the workers pool to provision the DB binding')
+  }
+  return binding
+}
+
+/** Runs one batch through the real `queue` handler and reports the runtime's ack/retry decision. */
+// The pool's queue API is promise-based end to end (createMessageBatch, the
+// handler, getQueueResult); suites wrap this in Effect.promise at the
+// boundary, like every other promise step in the pool tests.
+// oxlint-disable effect/noAsyncFunction
+export async function consume<M>(
+  queueName: string,
+  messages: ReadonlyArray<ServiceBindingQueueMessage<M>>
+): Promise<FetcherQueueResult> {
+  const batch = createMessageBatch(queueName, [...messages])
+  const ctx = createExecutionContext()
+  await queueHandler(batch, env, ctx)
+  return getQueueResult(batch, ctx)
+}
+// oxlint-enable effect/noAsyncFunction
+
+/** Every row a query matches, in the store's own order. */
+export function rows(
+  query: string,
+  ...params: ReadonlyArray<string>
+): Promise<Array<PoolRow>> {
+  return db()
+    .prepare(query)
+    .bind(...params)
+    .all<PoolRow>()
+    .then((result) => result.results)
+}
+
+/** The first row a query matches, or null — the one-row lookups suites assert on. */
+export function row(
+  query: string,
+  ...params: ReadonlyArray<string>
+): Promise<PoolRow | null> {
+  return db()
+    .prepare(query)
+    .bind(...params)
+    .first<PoolRow>()
+}
+
+/**
+ * Applies the committed migrations to the pool's D1. Per-test-file storage
+ * isolation gives each suite a fresh D1, so once per file is exactly right;
+ * `applyD1Migrations` skips already-applied ones regardless.
+ */
+export function applyPoolMigrations(): Promise<void> {
+  return applyD1Migrations(db(), env.TEST_MIGRATIONS).then(() => undefined)
+}

--- a/apps/background/src/webhook-consumer.pool.test.ts
+++ b/apps/background/src/webhook-consumer.pool.test.ts
@@ -1,0 +1,374 @@
+import { backoffSeconds } from '@b2b-saas-starter/capabilities/developer-platform/webhook-delivery-plan'
+import { type WebhookQueueMessage } from '@b2b-saas-starter/capabilities/developer-platform/webhook-publisher'
+import {
+  webhookDeadLetterQueueName,
+  webhookQueueName
+} from '../../../infra/bindings.ts'
+import { DateTime, Effect, Schema } from 'effect'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vite-plus/test'
+
+import {
+  applyPoolMigrations,
+  consume,
+  db,
+  row,
+  rows,
+  type PoolRow
+} from './test-pool.ts'
+
+// The queue-runtime half of the webhook consumer, exercised inside workerd
+// through `@cloudflare/vitest-pool-workers`: real D1 (the committed
+// migrations), the real batch loop in `queue-consumer.ts`, and real
+// `ack`/`retry` calls — asserted with `getQueueResult()` against what the
+// runtime actually did with each message. Only the receiver endpoint is
+// stubbed: the outbound delivery POST is the one genuinely external thing on
+// this path. The decision logic itself (`classifyResponseStatus`,
+// `planDeliveryAttempt`) keeps its cases beside the capability, and the
+// fake-based suites in `index.test.ts` stay the orchestration tests. No
+// async functions on purpose — the Effect lint rules ban them, so promise
+// steps ride `Effect.promise` inside `Effect.runPromise`, like the live
+// suites in `packages/auth`.
+
+const WORKSPACE_ID = 'ws_pool'
+const ENDPOINT_ID = 'wh_pool'
+const ENDPOINT_URL = 'https://receiver.example.test/hook'
+const SIGNING_SECRET = 'whsec_pool'
+
+/** A `mode: 'json'` text column, parsed; a null column stays null. */
+const JsonColumn = Schema.NullOr(Schema.fromJsonString(Schema.Json))
+const readJsonColumn = Schema.decodeUnknownSync(JsonColumn)
+
+/** One outbound delivery the consumer dispatched, as the receiver saw it. */
+type OutboundDelivery = {
+  readonly url: string
+  readonly body: string
+  readonly headers: Record<string, string>
+}
+
+const outbound: Array<OutboundDelivery> = []
+
+// What the stubbed receiver answers with — or throws on, for a network
+// failure. Swapped per test; the fetch stub itself stays one function for
+// the whole file, because the isolate's Effect runtime resolves
+// `globalThis.fetch` once into its `Fetch` reference (`Context.Reference`
+// default) and then keeps using that value, so re-stubbing per test would
+// leave the consumer posting through the first test's stub.
+let answer: (delivery: OutboundDelivery) => Response = okAnswer
+
+function okAnswer(): Response {
+  return new Response('ok', { status: 200 })
+}
+
+function stubbedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const request = new Request(input, init)
+  return request.text().then((body) => {
+    const delivery = {
+      url: request.url,
+      body,
+      headers: Object.fromEntries(request.headers)
+    }
+    outbound.push(delivery)
+    // An `answer` that throws rejects this promise — a network failure.
+    return answer(delivery)
+  })
+}
+
+/** Points the stubbed receiver at a new answer. */
+function stubReceiver(respond: (delivery: OutboundDelivery) => Response): void {
+  answer = respond
+}
+
+/** Simulates a network failure: the POST never gets a response at all. */
+function dropConnection(): void {
+  answer = () => {
+    throw new Error('pool: connection reset')
+  }
+}
+
+/** One webhook queue message for the fixture endpoint. */
+function webhookMessage(
+  id: string,
+  attempts = 1
+): ServiceBindingQueueMessage<WebhookQueueMessage> {
+  return {
+    id,
+    // The platform's message shape carries a plain Date; `DateTime` has no
+    // place in a value vitest serializes into the batch.
+    // oxlint-disable-next-line effect/noGlobals -- platform message field, not application time
+    timestamp: new Date(1000),
+    attempts,
+    body: {
+      endpointId: ENDPOINT_ID,
+      workspaceId: WORKSPACE_ID,
+      eventType: 'api_token.created',
+      payload: { hello: 'world' }
+    }
+  }
+}
+
+/** Clears the tables the consumer writes and reseeds one dispatchable endpoint. */
+function seedEndpoint(): Promise<void> {
+  return db()
+    .batch([
+      db().prepare('delete from webhook_deliveries'),
+      db().prepare('delete from audit_events'),
+      db().prepare('delete from notifications'),
+      db().prepare('delete from webhook_endpoints'),
+      db().prepare('delete from workspaces'),
+      db()
+        .prepare('insert into workspaces (id, name, slug) values (?, ?, ?)')
+        .bind(WORKSPACE_ID, 'Pool Tests', 'pool-tests'),
+      db()
+        .prepare(
+          `insert into webhook_endpoints
+           (id, workspace_id, url, signing_secret, events, created_at)
+         values (?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          ENDPOINT_ID,
+          WORKSPACE_ID,
+          ENDPOINT_URL,
+          SIGNING_SECRET,
+          '["api_token.created"]',
+          '2026-09-06T00:00:00.000Z'
+        )
+    ])
+    .then(() => undefined)
+}
+
+/**
+ * The retry delay the batch loop handed the queue, read off the row the
+ * attempt wrote: `next_attempt_at` derives from the same `backoffSeconds`
+ * `message.retry` was called with, so it lands one backoff away from now.
+ * (`getQueueResult` does not surface the per-message delay itself.)
+ */
+function assertBackoffAligned(
+  attempt: PoolRow | null,
+  attempts: number
+): Effect.Effect<void> {
+  const nextAttemptAt = Date.parse(String(attempt?.next_attempt_at))
+  return Effect.gen(function* () {
+    const now = DateTime.toEpochMillis(yield* DateTime.now)
+    expect(nextAttemptAt).toBeGreaterThan(now + (backoffSeconds(attempts) - 5) * 1000)
+    expect(nextAttemptAt).toBeLessThan(now + (backoffSeconds(attempts) + 5) * 1000)
+  })
+}
+
+const realFetch = globalThis.fetch
+
+describe('webhook consumer (workers pool)', () => {
+  // The fetch stub goes in before anything can dispatch (the runtime's Fetch
+  // reference keeps the first value it resolves), and migrations run once per
+  // file (see `applyPoolMigrations`).
+  // oxlint-disable-next-line effect/noTestLifecycleHooks -- owns the pool's fetch stub and D1 schema
+  beforeAll(() => {
+    globalThis.fetch = stubbedFetch
+    return applyPoolMigrations()
+  })
+  // oxlint-disable-next-line effect/noTestLifecycleHooks -- resets D1 and the receiver stub between outcomes
+  beforeEach(() => {
+    outbound.length = 0
+    answer = okAnswer
+    return seedEndpoint()
+  })
+  // oxlint-disable-next-line effect/noTestLifecycleHooks -- restores the isolate's fetch
+  afterAll(() => {
+    globalThis.fetch = realFetch
+  })
+
+  it('acks a successful delivery and records the delivered attempt row', () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- promise-interop port: bridges vitest-pool-workers createMessageBatch/getQueueResult into Effect
+    Effect.runPromise(
+      Effect.gen(function* () {
+        stubReceiver(okAnswer)
+        const result = yield* Effect.promise(() =>
+          consume(webhookQueueName, [webhookMessage('qmsg_ok')])
+        )
+        // The runtime explicitly acked the message — per-message, with no
+        // batch-level ops riding along.
+        expect(result.ackAll).toBe(false)
+        expect(result.retryBatch.retry).toBe(false)
+        expect(result.explicitAcks).toStrictEqual(['qmsg_ok'])
+        expect(result.retryMessages).toStrictEqual([])
+        // ...and the acked attempt is the row D1 holds.
+        const delivery = yield* Effect.promise(() =>
+          row('select * from webhook_deliveries where id = ?', 'whd_qmsg_ok')
+        )
+        expect(delivery?.endpoint_id).toBe(ENDPOINT_ID)
+        expect(delivery?.event_type).toBe('api_token.created')
+        expect(delivery?.status).toBe('delivered')
+        expect(delivery?.attempts).toBe(1)
+        expect(delivery?.response_status).toBe(200)
+        expect(delivery?.next_attempt_at).toBeNull()
+        expect(readJsonColumn(delivery?.payload)).toEqual({ hello: 'world' })
+        // The POST the runtime delivered was the signed one for that row.
+        expect(outbound).toHaveLength(1)
+        expect(outbound[0]?.url).toBe(ENDPOINT_URL)
+        expect(outbound[0]?.headers['x-b2b-starter-event']).toBe('api_token.created')
+        expect(outbound[0]?.headers['x-b2b-starter-signature']).toMatch(
+          /^t=\d+,sha256=[0-9a-f]{64}$/
+        )
+        expect(readJsonColumn(delivery?.request_headers)).toMatchObject({
+          'x-b2b-starter-signature': outbound[0]?.headers['x-b2b-starter-signature']
+        })
+        expect(readJsonColumn(outbound[0]?.body)).toMatchObject({
+          deliveryId: 'whd_qmsg_ok'
+        })
+        // Delivered is not terminal: no audit event, no notification.
+        expect(
+          yield* Effect.promise(() => rows('select * from audit_events'))
+        ).toStrictEqual([])
+        expect(
+          yield* Effect.promise(() => rows('select * from notifications'))
+        ).toStrictEqual([])
+      })
+    ))
+
+  it('retries a 5xx with the backoff delay and records the failed attempt', () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- promise-interop port: bridges vitest-pool-workers createMessageBatch/getQueueResult into Effect
+    Effect.runPromise(
+      Effect.gen(function* () {
+        stubReceiver(() => new Response('boom', { status: 500 }))
+        const result = yield* Effect.promise(() =>
+          consume(webhookQueueName, [webhookMessage('qmsg_retry', 2)])
+        )
+        // Not acked: the message rides the queue's backoff.
+        expect(result.explicitAcks).toStrictEqual([])
+        expect(result.retryMessages).toStrictEqual([{ msgId: 'qmsg_retry' }])
+        const delivery = yield* Effect.promise(() =>
+          row('select * from webhook_deliveries where id = ?', 'whd_qmsg_retry')
+        )
+        expect(delivery?.status).toBe('failed')
+        expect(delivery?.attempts).toBe(2)
+        expect(delivery?.response_status).toBe(500)
+        yield* assertBackoffAligned(delivery, 2)
+        // Retryable is not terminal: no audit event yet.
+        expect(
+          yield* Effect.promise(() => rows('select * from audit_events'))
+        ).toStrictEqual([])
+      })
+    ))
+
+  it('retries a network failure with no response status to record', () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- promise-interop port: bridges vitest-pool-workers createMessageBatch/getQueueResult into Effect
+    Effect.runPromise(
+      Effect.gen(function* () {
+        dropConnection()
+        const result = yield* Effect.promise(() =>
+          consume(webhookQueueName, [webhookMessage('qmsg_net')])
+        )
+        expect(result.explicitAcks).toStrictEqual([])
+        expect(result.retryMessages).toStrictEqual([{ msgId: 'qmsg_net' }])
+        const delivery = yield* Effect.promise(() =>
+          row('select * from webhook_deliveries where id = ?', 'whd_qmsg_net')
+        )
+        expect(delivery?.status).toBe('failed')
+        expect(delivery?.attempts).toBe(1)
+        // No HTTP response happened, so none is persisted.
+        expect(delivery?.response_status).toBeNull()
+        yield* assertBackoffAligned(delivery, 1)
+      })
+    ))
+
+  it('acks a 4xx explicitly and lands the delivery row failed_permanent', () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- promise-interop port: bridges vitest-pool-workers createMessageBatch/getQueueResult into Effect
+    Effect.runPromise(
+      Effect.gen(function* () {
+        stubReceiver(() => new Response('not found', { status: 404 }))
+        const result = yield* Effect.promise(() =>
+          consume(webhookQueueName, [webhookMessage('qmsg_4xx')])
+        )
+        // A permanent failure is still an explicit ack — the queue must not
+        // redeliver it.
+        expect(result.explicitAcks).toStrictEqual(['qmsg_4xx'])
+        expect(result.retryMessages).toStrictEqual([])
+        const delivery = yield* Effect.promise(() =>
+          row('select * from webhook_deliveries where id = ?', 'whd_qmsg_4xx')
+        )
+        expect(delivery?.status).toBe('failed_permanent')
+        expect(delivery?.attempts).toBe(1)
+        expect(delivery?.response_status).toBe(404)
+        expect(delivery?.next_attempt_at).toBeNull()
+        // The terminal row batches its audit event with the attempt.
+        const audit = yield* Effect.promise(() =>
+          rows(
+            'select * from audit_events where event_type = ?',
+            'webhook.delivery_failed'
+          )
+        )
+        expect(audit).toHaveLength(1)
+        expect(audit[0]?.workspace_id).toBe(WORKSPACE_ID)
+        expect(audit[0]?.actor_user_id).toBeNull()
+        expect(audit[0]?.target_type).toBe('webhook_endpoint')
+        expect(audit[0]?.target_id).toBe(ENDPOINT_ID)
+        expect(readJsonColumn(audit[0]?.metadata)).toMatchObject({
+          deliveryId: 'whd_qmsg_4xx',
+          eventType: 'api_token.created',
+          attempts: 1
+        })
+        // And tells the workspace: one broadcast notification.
+        const notified = yield* Effect.promise(() =>
+          rows('select * from notifications where kind = ?', 'webhook.delivery_failed')
+        )
+        expect(notified).toHaveLength(1)
+        expect(notified[0]?.workspace_id).toBe(WORKSPACE_ID)
+        expect(notified[0]?.user_id).toBeNull()
+      })
+    ))
+
+  it('acks a dead letter after recording the terminal dead_lettered row', () =>
+    // oxlint-disable-next-line starter/no-run-promise-in-tests -- promise-interop port: bridges vitest-pool-workers createMessageBatch/getQueueResult into Effect
+    Effect.runPromise(
+      Effect.gen(function* () {
+        stubReceiver(okAnswer)
+        // A message that exhausted the primary queue's retries: the DLQ
+        // consumer only records evidence, it never dispatches.
+        const result = yield* Effect.promise(() =>
+          consume(webhookDeadLetterQueueName, [webhookMessage('qmsg_dead', 7)])
+        )
+        expect(result.explicitAcks).toStrictEqual(['qmsg_dead'])
+        expect(result.retryMessages).toStrictEqual([])
+        expect(outbound).toHaveLength(0)
+        // The terminal row cannot be addressed by `whd_qmsg_dead` today:
+        // `recordTerminalDeliveryAttempt` receives `deliveryId` (its own
+        // interface documents it resolving the message's row) but both
+        // adapters spread it into internal `recordAttempt`, which reads
+        // `id` — so the row is written under a freshly minted id. Asserted
+        // by its terminal status until that mismatch is fixed; its recorded
+        // payload keeps it replayable either way.
+        const terminal = yield* Effect.promise(() =>
+          rows('select * from webhook_deliveries where status = ?', 'dead_lettered')
+        )
+        expect(terminal).toHaveLength(1)
+        expect(terminal[0]?.endpoint_id).toBe(ENDPOINT_ID)
+        expect(terminal[0]?.event_type).toBe('api_token.created')
+        expect(terminal[0]?.attempts).toBe(7)
+        expect(terminal[0]?.response_status).toBeNull()
+        expect(terminal[0]?.next_attempt_at).toBeNull()
+        expect(readJsonColumn(terminal[0]?.payload)).toEqual({ hello: 'world' })
+        const audit = yield* Effect.promise(() =>
+          rows(
+            'select * from audit_events where event_type = ?',
+            'webhook.delivery_dead_lettered'
+          )
+        )
+        expect(audit).toHaveLength(1)
+        expect(audit[0]?.workspace_id).toBe(WORKSPACE_ID)
+        expect(audit[0]?.target_id).toBe(ENDPOINT_ID)
+        // The dead letter tells the workspace twice today — once from the
+        // capability's `notifyDeadLetter` (endpoint URL in the message) and
+        // once from the consumer's `notifyDeliveryGaveUp` — both kind
+        // `webhook.delivery_failed`. The duplicate is a defect in the
+        // existing capability/consumer pair, named in this item's review;
+        // this pins the current shape so the fix has to update it.
+        const notified = yield* Effect.promise(() =>
+          rows('select * from notifications where kind = ?', 'webhook.delivery_failed')
+        )
+        expect(notified).toHaveLength(2)
+        expect(notified[0]?.workspace_id).toBe(WORKSPACE_ID)
+        expect(notified[1]?.workspace_id).toBe(WORKSPACE_ID)
+        expect(notified[0]?.user_id).toBeNull()
+        expect(notified[1]?.user_id).toBeNull()
+      })
+    ))
+})

--- a/apps/background/vitest.config.ts
+++ b/apps/background/vitest.config.ts
@@ -1,0 +1,57 @@
+import { cloudflareTest } from '@cloudflare/vitest-pool-workers'
+import { configDefaults, defineConfig } from 'vite-plus'
+
+import { listMigrations } from '../../packages/db/src/migrations-fs.ts'
+
+// Two projects, one file set each: the existing `*.test.ts` suites keep the
+// plain Node runner they run under today, and only the `*.pool.test.ts`
+// suites move into the workers pool (`@cloudflare/vitest-pool-workers`), so
+// the pool's workerd startup cost never touches the rest of the suite.
+//
+// D1 state inside the pool comes from the real migrations: the pool cannot
+// read them itself (`readD1Migrations` understands wrangler's flat
+// `<n>_*.sql` layout, drizzle-kit writes `<timestamp>_<name>/migration.sql`),
+// so the folder walk is the db package's own single source (`listMigrations`,
+// shared with `scripts/migrate.ts` and `packages/db/src/testing.ts`) and only
+// the statement split is repeated here — the same `--> statement-breakpoint`
+// split those two apply. The migrations are read here at config time (Node)
+// and handed to the pool as a plain-data binding; the test files apply them
+// with `applyD1Migrations` inside workerd.
+const migrations = listMigrations().map(({ name, sql }) => ({
+  name,
+  queries: sql
+    .split('--> statement-breakpoint')
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0)
+}))
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'background',
+          include: ['src/**/*.test.ts'],
+          exclude: ['src/**/*.pool.test.ts', ...configDefaults.exclude]
+        }
+      },
+      {
+        plugins: [
+          cloudflareTest({
+            // The generated wrangler config is the bindings source: the same
+            // D1 database, queue producers, and compatibility flags the
+            // worker deploys with, simulated by miniflare.
+            wrangler: { configPath: './wrangler.jsonc' },
+            miniflare: {
+              bindings: { TEST_MIGRATIONS: migrations }
+            }
+          })
+        ],
+        test: {
+          name: 'background-pool',
+          include: ['src/**/*.pool.test.ts']
+        }
+      }
+    ]
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@better-auth/sso':
       specifier: 1.7.2
       version: 1.7.2
+    '@cloudflare/vitest-pool-workers':
+      specifier: 0.22.0
+      version: 0.22.0
     '@cloudflare/workers-types':
       specifier: 5.20260903.1
       version: 5.20260903.1
@@ -432,6 +435,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-rc.112
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: 'catalog:'
+        version: 0.22.0(@cloudflare/workers-types@5.20260903.1)(@types/node@26.4.0)(@vitest/runner@4.1.11)(@vitest/snapshot@4.1.11)(vitest@4.1.11)
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260903.1
@@ -1645,8 +1651,21 @@ packages:
       workerd:
         optional: true
 
+  '@cloudflare/vitest-pool-workers@0.22.0':
+    resolution: {integrity: sha512-OJv/qikkOgxnKxJ5xrLS7zuOLZhc/6iziU+llqZm4tiQf2CJUYwlMuXN68VaWIQebORd1AUx4w6A0oy8XRbuaQ==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: 4.1.11
+
   '@cloudflare/workerd-darwin-64@1.20260704.1':
     resolution: {integrity: sha512-XO+vvdhhTNZSsIWCkZ+JaE/JrFUmQAB0H0y/sVkAf32xa2TYBRvFUMwjSqf6WxtlxcKPQvmbLfpO/UQ0l/q4eQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260815.1':
+    resolution: {integrity: sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -1663,6 +1682,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-arm64@1.20260815.1':
+    resolution: {integrity: sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20260831.1':
     resolution: {integrity: sha512-s6Go53KPnoXZ1sTGBZ3en3otfHDuMPJhiwXMYWU21JkJQkpoeRt6HFUwM0GPhK3YhXWm+8baGMvCGZYS/KA9eA==}
     engines: {node: '>=16'}
@@ -1671,6 +1696,12 @@ packages:
 
   '@cloudflare/workerd-linux-64@1.20260704.1':
     resolution: {integrity: sha512-3mT0YHtxT7eLjghu3hKSJDUQoz+AYv8FM43nLPYhM0YiHOxr8OlmvnCb2Lp7v/U3bwd3Gnx7WEqjSppR583mGg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260815.1':
+    resolution: {integrity: sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -1687,6 +1718,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260815.1':
+    resolution: {integrity: sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20260831.1':
     resolution: {integrity: sha512-JTF9+9clUT3gaCq7Xnmd+Q/wEMaitpngSTOec/Ffb/r3xexA9XwNJVFSOKfk6q61flHGjAYJ4H9B7Mu5Qur49w==}
     engines: {node: '>=16'}
@@ -1695,6 +1732,12 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20260704.1':
     resolution: {integrity: sha512-a97Ecnzhy04x3U052VKPCNp863F7Wf00WY7Ga5P0SbtYvaO1PDzylsHrvFMPKeiDFcOwqiredawmJ+v6bhIgeQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260815.1':
+    resolution: {integrity: sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -5961,6 +6004,9 @@ packages:
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -7852,6 +7898,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  miniflare@5.20260815.0-alpha:
+    resolution: {integrity: sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==}
+    engines: {node: '>=22.0.0'}
+
   miniflare@5.20260831.0-alpha:
     resolution: {integrity: sha512-Hwgh1VDUiPCPGQKODQfUmy7hRAje1D55icB+9png3ueiM64rlSM87nSrtqpxAD+DlLWI4ehnYBuECaXV43zGmQ==}
     engines: {node: '>=22.0.0'}
@@ -9301,10 +9351,25 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260815.1:
+    resolution: {integrity: sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   workerd@1.20260831.1:
     resolution: {integrity: sha512-A2LwrkBel/FnKABPfeBAMiL6v70+rugnunqQRfWsWZjlhsTZoBScWUVunMy/xLCGLjWCQL2zp39AVR6aO0jurQ==}
     engines: {node: '>=16'}
     hasBin: true
+
+  wrangler@4.124.0:
+    resolution: {integrity: sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260815.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
 
   wrangler@4.128.0:
     resolution: {integrity: sha512-jNXy9e8/pbx8iqTzXPiuflnitKJZoAfEUSUUDLW87bwyeMvJ7kb3yQMSbxEcfNdfHqJW38KRcKaLljOYV4N/4w==}
@@ -9437,6 +9502,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
@@ -10156,13 +10224,38 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260704.1
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260815.1
+
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
       workerd: 1.20260831.1
 
+  '@cloudflare/vitest-pool-workers@0.22.0(@cloudflare/workers-types@5.20260903.1)(@types/node@26.4.0)(@vitest/runner@4.1.11)(@vitest/snapshot@4.1.11)(vitest@4.1.11)':
+    dependencies:
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.28.1
+      miniflare: 5.20260815.0-alpha(@types/node@26.4.0)
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/browser-preview@4.1.11)(@vitest/coverage-v8@4.1.11)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(jsdom@30.0.1(@noble/hashes@2.4.0))
+      wrangler: 4.124.0(@cloudflare/workers-types@5.20260903.1)(@types/node@26.4.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@types/node'
+      - bufferutil
+      - utf-8-validate
+
   '@cloudflare/workerd-darwin-64@1.20260704.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260815.1':
     optional: true
 
   '@cloudflare/workerd-darwin-64@1.20260831.1':
@@ -10171,10 +10264,16 @@ snapshots:
   '@cloudflare/workerd-darwin-arm64@1.20260704.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-arm64@1.20260815.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260831.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260704.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260815.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260831.1':
@@ -10183,10 +10282,16 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20260704.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260815.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260831.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260704.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260815.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260831.1':
@@ -13590,6 +13695,8 @@ snapshots:
 
   citty@0.2.2: {}
 
+  cjs-module-lexer@1.2.3: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -15724,6 +15831,19 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  miniflare@5.20260815.0-alpha(@types/node@26.4.0):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.3(@types/node@26.4.0)
+      undici: 7.29.0
+      workerd: 1.20260815.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - utf-8-validate
+
   miniflare@5.20260831.0-alpha(@types/node@26.4.0):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -17538,6 +17658,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260704.1
       '@cloudflare/workerd-windows-64': 1.20260704.1
 
+  workerd@1.20260815.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260815.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260815.1
+      '@cloudflare/workerd-linux-64': 1.20260815.1
+      '@cloudflare/workerd-linux-arm64': 1.20260815.1
+      '@cloudflare/workerd-windows-64': 1.20260815.1
+
   workerd@1.20260831.1:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20260831.1
@@ -17545,6 +17673,24 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20260831.1
       '@cloudflare/workerd-linux-arm64': 1.20260831.1
       '@cloudflare/workerd-windows-64': 1.20260831.1
+
+  wrangler@4.124.0(@cloudflare/workers-types@5.20260903.1)(@types/node@26.4.0):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260815.0-alpha(@types/node@26.4.0)
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260815.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260903.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - utf-8-validate
 
   wrangler@4.128.0(@cloudflare/workers-types@5.20260903.1)(@types/node@26.4.0):
     dependencies:
@@ -17697,6 +17843,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zod@4.5.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   '@better-auth/passkey': 1.7.2
   '@better-auth/sso': 1.7.2
   '@cloudflare/workers-types': 5.20260903.1
+  '@cloudflare/vitest-pool-workers': 0.22.0
   '@effect/platform-node': 4.0.0-rc.112
   '@effect/sql-d1': 4.0.0-rc.112
   '@effect/vitest': 4.0.0-rc.112


### PR DESCRIPTION
## What

Queue consumer tests with real ack/retry semantics (backlog item 2). Until now the `apps/background` consumer tests ran against hand-rolled fakes that assert decision logic (`retry`, `failed_permanent`) but never the ack/retry/DLQ semantics of the actual queue runtime.

- Adopts `@cloudflare/vitest-pool-workers` (catalog-sourced, `0.22.0`; no other dependency versions moved).
- A scoped two-project config in `apps/background`: existing `*.test.ts` suites keep the plain Node runner; only the new `*.pool.test.ts` suites run in the workers pool, so workerd startup cost never touches the rest of the suite. `pnpm run check` runs both projects.
- Pool tests assert what the runtime actually did via `createMessageBatch()` / `getQueueResult()`: successful delivery acks; 5xx and network failures retry (the network case with no status to record); 4xx acks explicitly and lands `failed_permanent`; the dead-letter path records the terminal `dead_lettered` row; exports ack ready/failed flips. Only the outbound receiver `fetch` is stubbed.
- D1 state inside the pool comes from the real migrations — fed through `listMigrations` from `packages/db`, since `readD1Migrations` cannot read drizzle's folder layout — and applied with `applyD1Migrations` inside workerd.
- The `Effect.runPromise` bridges carry `oxlint-disable` naming the promise-interop port, per the `no-run-promise-in-tests` rule's own escape.

## Verification

- `pnpm run check` green — typecheck, type-aware lint, format, dead-code, and the full test suite including both pool projects (rebased onto master after #271; lockfile regenerated).
- Second-pass quality review applied: shared `test-pool.ts` fixtures module extracted, both pool test files consolidated, ambient `pool-tests.d.ts` reduced to the justified minimum.