### PR TITLE
feat(audit): record actor type on audit events

### DIFF
--- a/apps/api/src/audit-actor.test.ts
+++ b/apps/api/src/audit-actor.test.ts
@@ -4,8 +4,9 @@ import {
   SeedAuditEventLog
 } from '@b2b-saas-starter/capabilities/governance/audit-event-log'
 import { seedWorkspaceRecord } from '@b2b-saas-starter/capabilities/seed-fixture'
+import { it } from '@effect/vitest'
 import { Effect } from 'effect'
-import { describe, expect, test } from 'vite-plus/test'
+import { describe, expect } from 'vite-plus/test'
 import {
   mcpCallerActor,
   mcpCallerActorType,
@@ -41,10 +42,10 @@ describe('MCP audit provenance', () => {
     }
   ]
 
-  test.each(cases)(
-    '$caller.kind retains provenance through workspace resolution and recording',
-    ({ caller, actorType }) =>
-      Effect.runPromise(
+  for (const { caller, actorType } of cases) {
+    it.effect(
+      `${caller.kind} retains provenance through workspace resolution and recording`,
+      () =>
         provideWorkspace(
           {},
           workspace.workspaceSlug,
@@ -62,6 +63,6 @@ describe('MCP audit provenance', () => {
           mcpCallerActor(caller),
           mcpCallerActorType(caller)
         ).pipe(Effect.provide(SeedAuditEventLog([])))
-      )
-  )
+    )
+  }
 })

--- a/apps/api/src/audit-actor.test.ts
+++ b/apps/api/src/audit-actor.test.ts
@@ -1,0 +1,67 @@
+import {
+  AuditEventLog,
+  recordInWorkspace,
+  SeedAuditEventLog
+} from '@b2b-saas-starter/capabilities/governance/audit-event-log'
+import { seedWorkspaceRecord } from '@b2b-saas-starter/capabilities/seed-fixture'
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vite-plus/test'
+import {
+  mcpCallerActor,
+  mcpCallerActorType,
+  provideWorkspace,
+  type McpCaller
+} from './request-guards.ts'
+
+const workspace = {
+  workspaceId: seedWorkspaceRecord.id,
+  workspaceSlug: seedWorkspaceRecord.slug
+}
+
+describe('MCP audit provenance', () => {
+  const cases: ReadonlyArray<{ caller: McpCaller; actorType: string }> = [
+    {
+      caller: {
+        kind: 'token',
+        token: { ...workspace, id: 'tok_ci', scopes: ['read'] }
+      },
+      actorType: 'api_token'
+    },
+    {
+      caller: {
+        kind: 'oauth',
+        token: {
+          ...workspace,
+          userId: 'usr_demo',
+          workspaceRole: 'owner',
+          scopes: ['mcp:read']
+        }
+      },
+      actorType: 'user'
+    }
+  ]
+
+  test.each(cases)(
+    '$caller.kind retains provenance through workspace resolution and recording',
+    ({ caller, actorType }) =>
+      Effect.runPromise(
+        provideWorkspace(
+          {},
+          workspace.workspaceSlug,
+          Effect.gen(function* () {
+            const audit = yield* AuditEventLog
+            yield* recordInWorkspace(audit, {
+              eventType: 'api_token.created',
+              targetType: 'api_token',
+              targetId: 'tok_created'
+            })
+            const page = yield* audit.list()
+            expect(page.items).toHaveLength(1)
+            expect(page.items[0]?.actorType).toBe(actorType)
+          }),
+          mcpCallerActor(caller),
+          mcpCallerActorType(caller)
+        ).pipe(Effect.provide(SeedAuditEventLog([])))
+      )
+  )
+})

--- a/apps/api/src/handlers.ts
+++ b/apps/api/src/handlers.ts
@@ -42,6 +42,10 @@ const WEBHOOK_DELETED = {
  * capability call. The event name is passed whole — reads sit under
  * `workspace.*` (see `workspaceRead`), writes name themselves
  * (`api-tokens.create`).
+ *
+ * Every REST workspace operation rides a bearer token, so the workspace layer
+ * the body runs against carries the `api_token` caller kind — the label a
+ * mutating capability's audit row then records.
  */
 function workspaceOperation<A, E, R>(
   env: ApiEnv,
@@ -58,7 +62,7 @@ function workspaceOperation<A, E, R>(
     { workspaceSlug: slug },
     Effect.gen(function* () {
       yield* enforcePermission(permission, slug)
-      return yield* provideWorkspace(env, slug, body)
+      return yield* provideWorkspace(env, slug, body, undefined, 'api_token')
     })
   )
 }

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -19,6 +19,7 @@ const OverviewBody = Schema.Struct({
   notifications: Schema.Array(Schema.Unknown)
 })
 const CreatedTokenBody = Schema.Struct({
+  id: Schema.String,
   token: Schema.String,
   scopes: Schema.Array(Schema.String)
 })
@@ -197,6 +198,24 @@ describe('contract-served routes', () => {
       const body = yield* jsonBody(res, CreatedTokenBody)
       expect(body.token).toBeTruthy()
       expect(body.scopes).toEqual(['read'])
+      const auditResponse = yield* send(
+        get('/workspaces/starter-lab/audit-events?eventType=api_token.created', bearer)
+      )
+      expect(auditResponse.status).toBe(200)
+      const audit = yield* jsonBody(
+        auditResponse,
+        Schema.Struct({
+          items: Schema.Array(
+            Schema.Struct({
+              targetId: Schema.NullOr(Schema.String),
+              actorType: Schema.String
+            })
+          )
+        })
+      )
+      expect(audit.items.find((event) => event.targetId === body.id)?.actorType).toBe(
+        'api_token'
+      )
     })
   )
 

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -38,6 +38,7 @@ import {
   authenticateMcpCaller,
   enforceRateLimit,
   mcpCallerActor,
+  mcpCallerActorType,
   observed,
   provideWorkspace,
   webRequest,
@@ -317,7 +318,13 @@ function bridgedRead(
   >
 ): Effect.Effect<ToolOutcome, never, CapabilityReadServices> {
   return Effect.result(
-    provideWorkspace(env, caller.token.workspaceSlug, body, mcpCallerActor(caller))
+    provideWorkspace(
+      env,
+      caller.token.workspaceSlug,
+      body,
+      mcpCallerActor(caller),
+      mcpCallerActorType(caller)
+    )
   )
 }
 

--- a/apps/api/src/request-guards.ts
+++ b/apps/api/src/request-guards.ts
@@ -1,6 +1,7 @@
 import { withHttpInvocation } from '@b2b-saas-starter/logger'
 import { requirePermission } from '@b2b-saas-starter/authz/guard'
 import { tokenPrincipal, type PermissionRequest } from '@b2b-saas-starter/authz/client'
+import { type AuditActorTypeValue } from '@b2b-saas-starter/db/enums'
 import { ApiTokenRegistry } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
 import { CapabilityUnavailable } from '@b2b-saas-starter/capabilities/errors'
 import { selectWorkspaceContextLayer } from '@b2b-saas-starter/capabilities/runtime'
@@ -131,6 +132,17 @@ export function mcpCallerActor(caller: McpCaller): ActorRef | undefined {
     return undefined
   }
   return { userId: caller.token.userId }
+}
+
+/**
+ * The caller kind that same workspace layer should carry: an API Token names
+ * itself; OAuth acts on behalf of the authenticated user.
+ */
+export function mcpCallerActorType(caller: McpCaller): AuditActorTypeValue {
+  if (caller.kind === 'token') {
+    return 'api_token'
+  }
+  return 'user'
 }
 
 /**
@@ -270,15 +282,21 @@ export function webRequest(request: HttpServerRequest.HttpServerRequest): Reques
  * request-independent and lives on the isolate-level layer `http.ts` hands to
  * `HttpRouter.provideRequest`, so a request pays for the workspace lookup and
  * nothing else.
+ *
+ * `actorType` names what kind of caller made the request — it is what the
+ * audit writes a mutating capability performs read to label their rows. The
+ * REST groups are bearer-token-only, so they pass `'api_token'`; the MCP
+ * route's token callers do the same while its OAuth callers pass `'user'`.
  */
 export function provideWorkspace<A, E, R>(
   env: ApiEnv,
   slug: string,
   body: Effect.Effect<A, E, R>,
-  actor?: ActorRef
+  actor: ActorRef | undefined,
+  actorType: AuditActorTypeValue
 ) {
   return body.pipe(
-    Effect.provide(selectWorkspaceContextLayer(starterEnv(env), slug, actor))
+    Effect.provide(selectWorkspaceContextLayer(starterEnv(env), slug, actor, actorType))
   )
 }
 

--- a/apps/background/src/export-consumer.ts
+++ b/apps/background/src/export-consumer.ts
@@ -191,7 +191,7 @@ export function buildWorkspaceExport(
     delivery,
     onFailure: 'retry',
     program: processWorkspaceExportMessage(delivery, (slug) =>
-      selectWorkspaceContextLayer(capabilitiesEnv, slug)
+      selectWorkspaceContextLayer(capabilitiesEnv, slug, undefined, 'system')
     ).pipe(Effect.provide(selectCapabilitiesLayer(capabilitiesEnv)))
   })
 }

--- a/apps/web/src/components/workspace-audit-page.test.tsx
+++ b/apps/web/src/components/workspace-audit-page.test.tsx
@@ -18,6 +18,7 @@ const payload: WorkspaceAuditPayload = {
   events: [
     {
       id: 'evt_1',
+      actorType: 'api_token',
       eventType: 'api_token.created',
       targetType: 'api_token',
       targetId: 'tok_1',
@@ -44,6 +45,12 @@ async function renderPage(overrides: Partial<WorkspaceAuditPayload> = {}) {
 }
 
 describe('WorkspaceAuditPage', () => {
+  it('shows credential provenance beside the actor name', async () => {
+    await renderPage()
+    const cell = screen.getByRole('cell', { name: 'Demo Owner API token' })
+    expect(cell).toBeTruthy()
+  })
+
   it('keeps the actor filter when turning to the next page', async () => {
     // Regression: the page used to spread the payload's `actorUserId`-keyed
     // filters into an `actor`-keyed search update, so the actor vanished on

--- a/apps/web/src/components/workspace-audit-page.tsx
+++ b/apps/web/src/components/workspace-audit-page.tsx
@@ -20,9 +20,15 @@ import {
 import { PageHeader } from '@/components/page/page-header'
 import { Panel } from '@/components/page/panel'
 import { WorkspaceCrumb } from '@/components/page/workspace-crumb'
+import { Badge } from '@/components/ui/badge'
 import { DataTable, type DataTableColumnDef } from '@/components/data-table'
 import { WorkspaceShell } from '@/components/workspace-shell'
-import { AUDIT_EVENT_FILTER_OPTIONS, auditEventLabel } from '@/lib/audit-labels'
+import {
+  AUDIT_EVENT_FILTER_OPTIONS,
+  auditActorTypeLabel,
+  auditEventLabel
+} from '@/lib/audit-labels'
+import { auditActorTypeVariant } from '@/lib/badge-variants'
 import {
   auditSearchFromFilters,
   compact,
@@ -85,7 +91,17 @@ const auditColumns: Array<DataTableColumnDef<AuditEvent>> = [
     accessorKey: 'actor',
     header: 'Actor',
     enableSorting: true,
-    cell: ({ row }) => <span className="break-words">{row.original.actor}</span>
+    // The joined display name alone cannot tell "the platform did this"
+    // from "an API token did" — both render as `system` when no user row
+    // joins — so the actor type rides beside it as a badge.
+    cell: ({ row }) => (
+      <span className="flex flex-wrap items-center gap-1.5 break-words">
+        {row.original.actor}{' '}
+        <Badge variant={auditActorTypeVariant(row.original.actorType)}>
+          {auditActorTypeLabel(row.original.actorType)}
+        </Badge>
+      </span>
+    )
   }
 ]
 

--- a/apps/web/src/lib/attention.test.ts
+++ b/apps/web/src/lib/attention.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { attentionItems } from './attention'
+
+describe('dashboard audit provenance', () => {
+  it('distinguishes an API token from a system job without a joined user', () => {
+    const event = {
+      eventType: 'api_token.created',
+      targetType: 'api_token',
+      targetId: null,
+      actor: 'system',
+      createdAt: '2026-09-06T12:00:00.000Z'
+    }
+    const items = attentionItems({
+      invitations: null,
+      apiTokens: null,
+      webhooks: null,
+      auditEvents: [
+        { ...event, id: 'token', actorType: 'api_token' },
+        { ...event, id: 'job', actorType: 'system' }
+      ]
+    })
+    expect(items[0]?.description).toContain('API token')
+    expect(items[1]?.description).toContain('System')
+    expect(items[0]?.title).toBe(items[1]?.title)
+  })
+})

--- a/apps/web/src/lib/attention.ts
+++ b/apps/web/src/lib/attention.ts
@@ -1,5 +1,5 @@
 import { type Invitation } from '@b2b-saas-starter/capabilities/governance/workspace-invitations'
-import { auditEventLabel } from '@/lib/audit-labels'
+import { auditActorTypeLabel, auditEventLabel } from '@/lib/audit-labels'
 import { formatDateTime } from '@/lib/format-date'
 import { type AuditEvent } from '@b2b-saas-starter/capabilities/governance/audit-event-log'
 import { type ApiToken } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
@@ -102,7 +102,7 @@ export function attentionItems({
         id: `event-${event.id}`,
         severity: 'info',
         title: auditEventLabel(event.eventType),
-        description: `${event.actor} · ${formatDateTime(event.createdAt)}`,
+        description: `${event.actor} · ${auditActorTypeLabel(event.actorType)} · ${formatDateTime(event.createdAt)}`,
         to: '/workspaces/$workspaceSlug/audit',
         linkLabel: 'Open the audit trail'
       })

--- a/apps/web/src/lib/audit-labels.ts
+++ b/apps/web/src/lib/audit-labels.ts
@@ -104,6 +104,23 @@ export function auditEventLabel(eventType: string): string {
   return known ?? prettify(eventType)
 }
 
+/** The human label map for audit actor types, same ownership as the event labels. */
+const ACTOR_TYPE_LABELS: Readonly<Record<string, string>> = Object.freeze({
+  user: 'User',
+  system: 'System',
+  api_token: 'API token'
+})
+
+/** Who performed one audited event: a session user, the platform, or an API token. */
+export function auditActorTypeLabel(actorType: string): string {
+  const known = Object.hasOwn(ACTOR_TYPE_LABELS, actorType)
+    ? ACTOR_TYPE_LABELS[actorType]
+    : undefined
+  // Unknown values (a producer newer than this map) prettify from their
+  // snake_case spelling rather than breaking the page.
+  return known ?? prettify(actorType)
+}
+
 /**
  * The dropdown options for the event-type filter: every known type, sorted,
  * with their human labels.

--- a/apps/web/src/lib/badge-variants.ts
+++ b/apps/web/src/lib/badge-variants.ts
@@ -64,3 +64,21 @@ export function workspaceExportStatusVariant(
   }
   return 'destructive'
 }
+
+/**
+ * Audit actor type → badge variant. Like a role, an actor type is identity,
+ * not a state — no status hue and no emphasis: a session user is the common
+ * case in neutral, the platform acted alone in `info` (the informational
+ * hue), and a machine credential takes the bordered `outline` pill, visible
+ * without claiming a state. Unknown values (a row newer than the vocabulary)
+ * fall back to `outline`, the badge vocabulary's home for exactly that.
+ */
+export function auditActorTypeVariant(actorType: string): BadgeVariant {
+  if (actorType === 'user') {
+    return 'neutral'
+  }
+  if (actorType === 'system') {
+    return 'info'
+  }
+  return 'outline'
+}

--- a/apps/web/src/lib/capabilities.ts
+++ b/apps/web/src/lib/capabilities.ts
@@ -143,7 +143,12 @@ export async function runWorkspaceCapabilities<A, E>(
       },
       Effect.provide(
         effect,
-        selectWorkspaceLayer({ ...starterEnv, ...bindings }, workspaceSlug, actor)
+        selectWorkspaceLayer(
+          { ...starterEnv, ...bindings },
+          workspaceSlug,
+          actor,
+          'user'
+        )
       )
     )
   )

--- a/apps/web/src/lib/server/auth-audit/auth-audit.test.ts
+++ b/apps/web/src/lib/server/auth-audit/auth-audit.test.ts
@@ -153,6 +153,7 @@ describe('authAuditInput', () => {
     })
     expect(input).toEqual({
       workspaceId: null,
+      actorType: 'user',
       actorUserId: 'usr_demo',
       eventType: 'auth.sign_in',
       targetType: 'session',
@@ -216,6 +217,7 @@ describe('authAuditInput', () => {
     })
     expect(known).toEqual({
       workspaceId: null,
+      actorType: 'user',
       actorUserId: null,
       eventType: 'auth.password_reset_requested',
       targetType: 'user',
@@ -528,6 +530,7 @@ describe('email-otp exchanges', () => {
       authAuditInput({ ...signInOtp, status: 200, actorUserId: 'usr_demo' })
     ).toEqual({
       workspaceId: null,
+      actorType: 'user',
       actorUserId: 'usr_demo',
       eventType: 'auth.sign_in',
       targetType: 'session',
@@ -856,6 +859,7 @@ describe('authAuditInput for the admin rows', () => {
       })
     ).toEqual({
       workspaceId: null,
+      actorType: 'user',
       actorUserId: 'usr_martin',
       eventType: 'system_admin.user_role_changed',
       targetType: 'user',

--- a/apps/web/src/lib/server/auth-audit/record.ts
+++ b/apps/web/src/lib/server/auth-audit/record.ts
@@ -51,6 +51,9 @@ export function authAuditInput(
   const input: RecordAuditEventInput = {
     workspaceId: null,
     actorUserId,
+    // Every exchange this table maps is a human at an auth endpoint —
+    // attributed or not, the actor type is `user`.
+    actorType: 'user',
     eventType,
     // Sign-in's target is the session it opens (the established shape); the
     // lifecycle and admin events target the account they change.

--- a/apps/web/src/lib/server/auth-audit/sso-sign-in.ts
+++ b/apps/web/src/lib/server/auth-audit/sso-sign-in.ts
@@ -96,6 +96,7 @@ export function recordSsoSignInAudit(
       yield* writeAndReport(run, {
         workspaceId,
         actorUserId: null,
+        actorType: 'user',
         eventType: 'auth.sso_sign_in_failed',
         targetType: 'session',
         targetId: null,
@@ -116,6 +117,7 @@ export function recordSsoSignInAudit(
     yield* writeAndReport(run, {
       workspaceId,
       actorUserId: attributed.userId,
+      actorType: 'user',
       eventType: 'auth.sso_sign_in',
       targetType: 'session',
       targetId: attributed.sessionId,

--- a/apps/web/src/lib/server/social-account-audit.test.ts
+++ b/apps/web/src/lib/server/social-account-audit.test.ts
@@ -93,6 +93,7 @@ describe('accountAuditInput', () => {
       })
     ).toEqual({
       workspaceId: null,
+      actorType: 'user',
       actorUserId: 'usr_demo',
       eventType: 'auth.account_linked',
       targetType: 'user',

--- a/apps/web/src/lib/server/social-account-audit.ts
+++ b/apps/web/src/lib/server/social-account-audit.ts
@@ -41,6 +41,7 @@ export function accountAuditInput(
   return {
     workspaceId: null,
     actorUserId: account.userId,
+    actorType: 'user',
     eventType,
     targetType: 'user',
     targetId: account.userId,

--- a/apps/web/src/lib/server/workspace-sso.effects.test.ts
+++ b/apps/web/src/lib/server/workspace-sso.effects.test.ts
@@ -214,7 +214,11 @@ describe('notifyOwnersOfFailedTest — the owner fan-out rule', () => {
         return yield* Effect.scoped(
           Effect.gen(function* () {
             yield* notifyOwnersOfFailedTest(connection, REASON).pipe(
-              Effect.provideService(WorkspaceContext, { workspace, actor: null })
+              Effect.provideService(WorkspaceContext, {
+                workspace,
+                actor: null,
+                actorType: 'user'
+              })
             )
             const counts: Record<string, number> = {}
             const samples: Record<string, string | undefined> = {}
@@ -225,6 +229,7 @@ describe('notifyOwnersOfFailedTest — the owner fan-out rule', () => {
               ).pipe(
                 Effect.provideService(WorkspaceContext, {
                   workspace,
+                  actorType: 'user',
                   actor: { userId: member.id, role: member.role, systemRole: 'user' }
                 })
               )

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -12,6 +12,8 @@ import { WorkspaceShell } from '@/components/workspace-shell'
 import { Badge } from '@/components/ui/badge'
 import { RoutePending } from '@/components/route-pending'
 import { formatDateTime } from '@/lib/format-date'
+import { auditActorTypeLabel } from '@/lib/audit-labels'
+import { auditActorTypeVariant } from '@/lib/badge-variants'
 import {
   listSystemUsersServerFn,
   loadAdminAuditEventsServerFn,
@@ -64,7 +66,19 @@ const userColumns: Array<DataTableColumnDef<SystemUser>> = [
 const auditColumns: Array<DataTableColumnDef<AuditEvent>> = [
   { accessorKey: 'eventType', header: 'Event', enableSorting: true },
   { accessorKey: 'targetType', header: 'Target', enableSorting: true },
-  { accessorKey: 'actor', header: 'Actor', enableSorting: true },
+  {
+    accessorKey: 'actor',
+    header: 'Actor',
+    enableSorting: true,
+    cell: ({ row }) => (
+      <span className="flex flex-wrap items-center gap-1.5 break-words">
+        {row.original.actor}{' '}
+        <Badge variant={auditActorTypeVariant(row.original.actorType)}>
+          {auditActorTypeLabel(row.original.actorType)}
+        </Badge>
+      </span>
+    )
+  },
   {
     accessorKey: 'createdAt',
     header: 'Created',

--- a/packages/capabilities/src/billing/billing.live.ts
+++ b/packages/capabilities/src/billing/billing.live.ts
@@ -187,6 +187,7 @@ export function LiveBilling(
             yield* audit.record({
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'billing.checkout_started',
               targetType: 'workspace',
               targetId: ctx.workspace.id,
@@ -218,6 +219,7 @@ export function LiveBilling(
             yield* audit.record({
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'billing.portal_opened',
               targetType: 'workspace',
               targetId: ctx.workspace.id,
@@ -246,6 +248,7 @@ export function LiveBilling(
                 // A system event: the actor is the provider webhook, not a user.
                 workspaceId: input.workspaceId,
                 actorUserId: null,
+                actorType: 'system',
                 eventType: 'billing.plan_changed',
                 targetType: 'workspace',
                 targetId: input.workspaceId,
@@ -315,6 +318,7 @@ export function LiveBilling(
               auditEvent: {
                 workspaceId: input.workspaceId,
                 actorUserId: null,
+                actorType: 'system',
                 eventType: 'billing.seats_changed',
                 targetType: 'workspace',
                 targetId: input.workspaceId,
@@ -358,6 +362,7 @@ export function LiveBilling(
               auditEvent: {
                 workspaceId: input.workspaceId,
                 actorUserId: null,
+                actorType: 'system',
                 eventType: 'billing.seats_changed',
                 targetType: 'workspace',
                 targetId: input.workspaceId,

--- a/packages/capabilities/src/billing/billing.seed.ts
+++ b/packages/capabilities/src/billing/billing.seed.ts
@@ -100,6 +100,7 @@ export function SeedBilling(options?: {
             yield* audit.record({
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'billing.checkout_started',
               targetType: 'workspace',
               targetId: ctx.workspace.id,
@@ -130,6 +131,7 @@ export function SeedBilling(options?: {
             yield* audit.record({
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'billing.portal_opened',
               targetType: 'workspace',
               targetId: ctx.workspace.id,
@@ -154,6 +156,7 @@ export function SeedBilling(options?: {
               // A system event: the actor is the provider webhook, not a user.
               workspaceId: input.workspaceId,
               actorUserId: null,
+              actorType: 'system',
               eventType: 'billing.plan_changed',
               targetType: 'workspace',
               targetId: input.workspaceId,
@@ -180,6 +183,7 @@ export function SeedBilling(options?: {
               yield* audit.record({
                 workspaceId: input.workspaceId,
                 actorUserId: null,
+                actorType: 'system',
                 eventType: 'billing.seats_changed',
                 targetType: 'workspace',
                 targetId: input.workspaceId,
@@ -215,6 +219,7 @@ export function SeedBilling(options?: {
             yield* audit.record({
               workspaceId: input.workspaceId,
               actorUserId: null,
+              actorType: 'system',
               eventType: 'billing.seats_changed',
               targetType: 'workspace',
               targetId: input.workspaceId,

--- a/packages/capabilities/src/developer-platform/api-token-registry.live.ts
+++ b/packages/capabilities/src/developer-platform/api-token-registry.live.ts
@@ -161,6 +161,7 @@ export const LiveApiTokenRegistry: Layer.Layer<
             auditEvent: {
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'api_token.created',
               targetType: 'api_token',
               targetId: row.id,
@@ -194,6 +195,7 @@ export const LiveApiTokenRegistry: Layer.Layer<
             auditEvent: {
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'api_token.revoked',
               targetType: 'api_token',
               targetId: input.tokenId,

--- a/packages/capabilities/src/developer-platform/api-token-registry.seed.ts
+++ b/packages/capabilities/src/developer-platform/api-token-registry.seed.ts
@@ -112,6 +112,7 @@ export function SeedApiTokenRegistry(
           yield* audit.record({
             workspaceId: ctx.workspace.id,
             actorUserId: ctx.actor?.userId ?? null,
+            actorType: ctx.actorType,
             eventType: 'api_token.created',
             targetType: 'api_token',
             targetId: id,
@@ -142,6 +143,7 @@ export function SeedApiTokenRegistry(
             yield* audit.record({
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'api_token.revoked',
               targetType: 'api_token',
               targetId: input.tokenId,

--- a/packages/capabilities/src/developer-platform/developer-platform.contract.ts
+++ b/packages/capabilities/src/developer-platform/developer-platform.contract.ts
@@ -1,4 +1,5 @@
 import { Effect, Exit } from 'effect'
+import { type AuditActorTypeValue } from '@b2b-saas-starter/db/enums'
 import { type ContractExpect } from '../governance/contract-expect.ts'
 import { failureTag } from '../internal/failure-tag.ts'
 import { type CapabilityUnavailable, type PlanLimitExceeded } from '../errors.ts'
@@ -62,6 +63,42 @@ export function developerPlatformContractCases(
   expect: ContractExpect
 ): ReadonlyArray<DeveloperPlatformContractCase> {
   return [
+    {
+      name: 'the same token mutation records the invocation actor in both adapters',
+      assert: Effect.gen(function* () {
+        const tokens = yield* ApiTokenRegistry
+        const audit = yield* AuditEventLog
+        const ctx = yield* WorkspaceContext
+        const actors: ReadonlyArray<AuditActorTypeValue> = [
+          'user',
+          'api_token',
+          'system'
+        ]
+        for (const actorType of actors) {
+          let actor = ctx.actor
+          if (actorType !== 'user') {
+            actor = null
+          }
+          const created = yield* tokens
+            .create({ name: `provenance-${actorType}`, scopes: ['read'] })
+            .pipe(
+              Effect.provideService(WorkspaceContext, {
+                ...ctx,
+                actor,
+                actorType
+              })
+            )
+          expect((yield* tokens.list).some((token) => token.id === created.id)).toBe(
+            true
+          )
+          const events = yield* audit.list({ eventType: 'api_token.created' })
+          expect(
+            events.items.find((event) => event.targetId === created.id)?.actorType
+          ).toBe(actorType)
+          yield* tokens.revoke({ tokenId: created.id })
+        }
+      })
+    },
     {
       name: 'created token lists back and disappears after revoke',
       assert: Effect.gen(function* () {
@@ -229,6 +266,9 @@ export function developerPlatformContractCases(
         // The delivery-attempt suites dead-letter their own endpoints too, so
         // scope to this one instead of assuming the newest event is ours.
         expect(events.items.some((event) => event.targetId === endpoint.id)).toBe(true)
+        expect(
+          events.items.find((event) => event.targetId === endpoint.id)?.actorType
+        ).toBe('system')
         // The audit metadata points back at the row it committed with, and the
         // row itself is listable through the same interface.
         const rows = yield* webhooks.listDeliveries({ endpointId: endpoint.id })
@@ -328,6 +368,9 @@ export function developerPlatformContractCases(
           eventType: 'webhook_endpoint.auto_disabled'
         })
         expect(events.items.some((event) => event.targetId === endpoint.id)).toBe(true)
+        expect(
+          events.items.find((event) => event.targetId === endpoint.id)?.actorType
+        ).toBe('system')
 
         // Already disabled matches nothing: no second write, no phantom audit.
         yield* webhooks.autoDisableEndpoint({

--- a/packages/capabilities/src/developer-platform/mcp-client-connections.ts
+++ b/packages/capabilities/src/developer-platform/mcp-client-connections.ts
@@ -68,6 +68,7 @@ export function consentGrantedAuditEvent(
   return {
     workspaceId: input.workspaceId,
     actorUserId: input.userId,
+    actorType: 'user',
     eventType: 'mcp_client.consent_granted',
     targetType: 'mcp_client',
     targetId: input.clientId,
@@ -85,6 +86,7 @@ export function consentRevokedAuditEvent(input: {
   return {
     workspaceId: input.workspaceId,
     actorUserId: input.userId,
+    actorType: 'user',
     eventType: 'mcp_client.consent_revoked',
     targetType: 'mcp_client',
     targetId: input.clientId,

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.live.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.live.ts
@@ -347,6 +347,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
           auditEvent: {
             workspaceId: input.workspaceId,
             actorUserId: null,
+            actorType: 'system',
             eventType: auditEventType,
             targetType: 'webhook_endpoint',
             targetId: input.endpointId,
@@ -495,6 +496,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
             auditEvent: {
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'webhook_endpoint.created',
               targetType: 'webhook_endpoint',
               targetId: endpoint.id,
@@ -578,6 +580,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
             auditEvent: {
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'webhook_endpoint.updated',
               targetType: 'webhook_endpoint',
               targetId: input.endpointId,
@@ -624,6 +627,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
             auditEvent: {
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'webhook_endpoint.deleted',
               targetType: 'webhook_endpoint',
               targetId: input.endpointId,
@@ -695,6 +699,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
             auditEvent: {
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'webhook.delivery_replayed',
               targetType: 'webhook_endpoint',
               targetId: source.endpointId,
@@ -776,6 +781,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
             auditEvent: {
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'webhook_endpoint.secret_rotated',
               targetType: 'webhook_endpoint',
               targetId: input.endpointId,
@@ -839,6 +845,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
             auditEvent: {
               workspaceId: input.workspaceId,
               actorUserId: null,
+              actorType: 'system',
               eventType: 'webhook_endpoint.auto_disabled',
               targetType: 'webhook_endpoint',
               targetId: input.endpointId,

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.seed.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.seed.ts
@@ -205,6 +205,7 @@ export function SeedWebhookEndpoints(
           yield* audit.record({
             workspaceId: row.workspaceId,
             actorUserId: null,
+            actorType: 'system',
             eventType: auditEventType,
             targetType: 'webhook_endpoint',
             targetId: row.endpointId,
@@ -335,6 +336,7 @@ export function SeedWebhookEndpoints(
           yield* audit.record({
             workspaceId: input.workspaceId,
             actorUserId: (yield* WorkspaceContext).actor?.userId ?? null,
+            actorType: (yield* WorkspaceContext).actorType,
             eventType: input.auditEventType,
             targetType: 'webhook_endpoint',
             targetId: input.plan.endpointId,
@@ -404,6 +406,7 @@ export function SeedWebhookEndpoints(
           yield* audit.record({
             workspaceId: ctx.workspace.id,
             actorUserId: ctx.actor?.userId ?? null,
+            actorType: ctx.actorType,
             eventType: 'webhook_endpoint.created',
             targetType: 'webhook_endpoint',
             targetId: endpoint.id,
@@ -489,6 +492,7 @@ export function SeedWebhookEndpoints(
             yield* audit.record({
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'webhook_endpoint.updated',
               targetType: 'webhook_endpoint',
               targetId: endpoint.id,
@@ -515,6 +519,7 @@ export function SeedWebhookEndpoints(
             yield* audit.record({
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'webhook_endpoint.deleted',
               targetType: 'webhook_endpoint',
               targetId: endpoint.id,
@@ -629,6 +634,7 @@ export function SeedWebhookEndpoints(
             yield* audit.record({
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'webhook_endpoint.secret_rotated',
               targetType: 'webhook_endpoint',
               targetId: endpoint.id,
@@ -670,6 +676,7 @@ export function SeedWebhookEndpoints(
             yield* audit.record({
               workspaceId: input.workspaceId,
               actorUserId: null,
+              actorType: 'system',
               eventType: 'webhook_endpoint.auto_disabled',
               targetType: 'webhook_endpoint',
               targetId: endpoint.id,

--- a/packages/capabilities/src/governance/account-lifecycle.live.test.ts
+++ b/packages/capabilities/src/governance/account-lifecycle.live.test.ts
@@ -178,6 +178,7 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live account lifecycle', (
             id: 'aud_mixed_owned',
             workspaceId: 'wrk_mixed_shared',
             actorUserId: 'usr_mixed',
+            actorType: 'user',
             eventType: 'workspace_member.added',
             targetType: 'workspace_member',
             targetId: 'usr_co_owner',

--- a/packages/capabilities/src/governance/account-lifecycle.live.ts
+++ b/packages/capabilities/src/governance/account-lifecycle.live.ts
@@ -140,6 +140,7 @@ export function LiveAccountLifecycle(
             yield* audit.record({
               workspaceId: null,
               actorUserId: userId,
+              actorType: 'user',
               eventType: 'workspace.deleted',
               targetType: 'workspace',
               targetId: workspaceId,
@@ -158,6 +159,7 @@ export function LiveAccountLifecycle(
             yield* audit.record({
               workspaceId,
               actorUserId: userId,
+              actorType: 'user',
               eventType: 'workspace_member.removed',
               targetType: 'workspace_member',
               targetId: userId,
@@ -194,8 +196,10 @@ export function LiveAccountLifecycle(
           workspaceId: null,
           // Actorless on purpose: `audit_events.actor_user_id` restricts on
           // `user.id`, and the actor row is gone by the time this runs — the
-          // event names the account in `targetId` instead.
+          // event names the account in `targetId` instead. The actor type
+          // stays `user`: the account deleted itself.
           actorUserId: null,
+          actorType: 'user',
           eventType: 'account.deleted',
           targetType: 'user',
           targetId: input.userId,

--- a/packages/capabilities/src/governance/account-lifecycle.seed.ts
+++ b/packages/capabilities/src/governance/account-lifecycle.seed.ts
@@ -73,6 +73,7 @@ export function SeedAccountLifecycle(options: {
             yield* audit.record({
               workspaceId: null,
               actorUserId: userId,
+              actorType: 'user',
               eventType: 'workspace.deleted',
               targetType: 'workspace',
               targetId: step.workspace.id,
@@ -85,6 +86,7 @@ export function SeedAccountLifecycle(options: {
             yield* audit.record({
               workspaceId: step.workspace.id,
               actorUserId: userId,
+              actorType: 'user',
               eventType: 'workspace_member.removed',
               targetType: 'workspace_member',
               targetId: userId,
@@ -102,6 +104,7 @@ export function SeedAccountLifecycle(options: {
         return audit.record({
           workspaceId: null,
           actorUserId: null,
+          actorType: 'user',
           eventType: 'account.deleted',
           targetType: 'user',
           targetId: input.userId,

--- a/packages/capabilities/src/governance/audit-event-log.contract.ts
+++ b/packages/capabilities/src/governance/audit-event-log.contract.ts
@@ -43,6 +43,7 @@ export function auditEventContractDataset(
       id: 'aud_c_old',
       workspaceId,
       actorUserId: 'usr_alice',
+      actorType: 'user',
       eventType: 'api_token.created',
       targetType: 'api_token',
       targetId: 'tok_a',
@@ -54,6 +55,7 @@ export function auditEventContractDataset(
       id: 'aud_c_tie_b',
       workspaceId,
       actorUserId: 'usr_bob',
+      actorType: 'user',
       eventType: 'api_token.created',
       targetType: 'api_token',
       targetId: null,
@@ -64,6 +66,7 @@ export function auditEventContractDataset(
       id: 'aud_c_tie_a',
       workspaceId,
       actorUserId: 'usr_alice',
+      actorType: 'user',
       eventType: 'webhook_endpoint.created',
       targetType: 'webhook_endpoint',
       targetId: 'wh_a',
@@ -84,6 +87,24 @@ export function auditEventLogContractCases(
   expect: ContractExpect
 ): ReadonlyArray<AuditEventLogContractCase> {
   return [
+    {
+      name: 'missing provenance fails before recording or preparing a write',
+      assert: Effect.gen(function* () {
+        const audit = yield* AuditEventLog
+        const ctx = yield* WorkspaceContext
+        const input = {
+          workspaceId: ctx.workspace.id,
+          eventType: 'api_token.created',
+          targetType: 'api_token'
+        }
+        const before = (yield* list()).items.length
+        // @ts-expect-error Deliberately exercise an untyped caller omitting actorType.
+        expect((yield* Effect.exit(audit.record(input)))._tag).toBe('Failure')
+        // @ts-expect-error The atomic-write preparer must reject the same malformed input.
+        expect((yield* Effect.exit(audit.prepareRecord(input)))._tag).toBe('Failure')
+        expect((yield* list()).items.length).toBe(before)
+      })
+    },
     {
       name: 'lists events most-recent-first with ties broken by id',
       assert: Effect.gen(function* () {
@@ -178,6 +199,7 @@ export function auditEventLogContractCases(
         yield* audit.record({
           workspaceId: ctx.workspace.id,
           actorUserId: 'usr_alice',
+          actorType: 'user',
           eventType: 'api_token.created',
           targetType: 'api_token',
           targetId: 'tok_inserted'
@@ -204,6 +226,70 @@ export function auditEventLogContractCases(
         }
         expect(fresh.items).toHaveLength(4)
         expect(originalIds).toEqual(['aud_c_tie_b', 'aud_c_tie_a', 'aud_c_old'])
+      })
+    },
+    {
+      // Records into the shared dataset; keep after pagination assertions.
+      name: 'exposes the recorded actor type on the wire',
+      assert: Effect.gen(function* () {
+        const audit = yield* AuditEventLog
+        const ctx = yield* WorkspaceContext
+        yield* audit.record({
+          workspaceId: ctx.workspace.id,
+          actorUserId: null,
+          actorType: 'api_token',
+          eventType: 'api_token.created',
+          targetType: 'api_token',
+          targetId: 'tok_rest'
+        })
+        // The same operation can run as a system job.
+        yield* audit.record({
+          workspaceId: ctx.workspace.id,
+          actorUserId: null,
+          actorType: 'system',
+          eventType: 'api_token.created',
+          targetType: 'api_token',
+          targetId: 'tok_system'
+        })
+        const page = yield* list({ limit: 10 })
+        const byTarget = new Map(
+          page.items.map((event) => [event.targetId ?? '', event])
+        )
+        expect(byTarget.get('tok_rest')?.actorType).toBe('api_token')
+        expect(byTarget.get('tok_rest')?.actor).toBe('system')
+        expect(byTarget.get('tok_system')?.actorType).toBe('system')
+        expect(byTarget.get('tok_a')?.actorType).toBe('user')
+      })
+    },
+    {
+      name: 'does not infer provenance from event taxonomy or user attribution',
+      assert: Effect.gen(function* () {
+        const audit = yield* AuditEventLog
+        const ctx = yield* WorkspaceContext
+        yield* audit.record({
+          workspaceId: ctx.workspace.id,
+          actorType: 'system',
+          eventType: 'workspace.created',
+          targetType: 'workspace',
+          targetId: 'automated_workspace'
+        })
+        yield* audit.record({
+          workspaceId: ctx.workspace.id,
+          actorUserId: null,
+          actorType: 'user',
+          eventType: 'workspace.created',
+          targetType: 'workspace',
+          targetId: 'interactive_workspace'
+        })
+        const page = yield* list({ eventType: 'workspace.created' })
+        expect(
+          page.items.find((event) => event.targetId === 'automated_workspace')
+            ?.actorType
+        ).toBe('system')
+        expect(
+          page.items.find((event) => event.targetId === 'interactive_workspace')
+            ?.actorType
+        ).toBe('user')
       })
     }
   ]

--- a/packages/capabilities/src/governance/audit-event-log.live.test.ts
+++ b/packages/capabilities/src/governance/audit-event-log.live.test.ts
@@ -29,18 +29,23 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live audit event log', (it
     function insertPage(start: number, rowCount: number) {
       return Effect.gen(function* () {
         const db = yield* Database
-        const rows = Array.from({ length: rowCount }, (_, index) => ({
-          id: `aud_pg_${String(start + index).padStart(4, '0')}`,
-          workspaceId: 'wrk_audit_pages',
-          eventType: 'page.filler',
-          targetType: 'test',
-          targetId: null,
-          metadata: {},
-          // Fixed literal base, not a clock read.
-          createdAt: DateTime.formatIso(
-            DateTime.makeUnsafe(Date.UTC(2026, 5, 10, 0, index * 2))
-          )
-        }))
+        const rows = Array.from(
+          { length: rowCount },
+          (_, index) =>
+            ({
+              id: `aud_pg_${String(start + index).padStart(4, '0')}`,
+              workspaceId: 'wrk_audit_pages',
+              actorType: 'system',
+              eventType: 'page.filler',
+              targetType: 'test',
+              targetId: null,
+              metadata: {},
+              // Fixed literal base, not a clock read.
+              createdAt: DateTime.formatIso(
+                DateTime.makeUnsafe(Date.UTC(2026, 5, 10, 0, index * 2))
+              )
+            }) satisfies typeof auditEvents.$inferInsert
+        )
         // D1 binds at most 100 parameters per statement (8 per row here).
         for (let i = 0; i < rows.length; i += 10) {
           yield* db.insert(auditEvents).values(rows.slice(i, i + 10))
@@ -84,6 +89,7 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live audit event log', (it
             const audit = yield* AuditEventLog
             yield* audit.record({
               workspaceId: 'wrk_other',
+              actorType: 'user',
               eventType: 'workspace.created',
               targetType: 'workspace'
             })

--- a/packages/capabilities/src/governance/audit-event-log.live.ts
+++ b/packages/capabilities/src/governance/audit-event-log.live.ts
@@ -5,6 +5,7 @@ import { and, desc, eq, gte, lte, type SQL } from 'drizzle-orm'
 
 import {
   auditEventPosition,
+  assertAuditActorType,
   AuditEventLog,
   type AuditEvent,
   AUDIT_EVENT_PAGE_SIZE,
@@ -36,6 +37,7 @@ function toWireRow(row: AuditRow): AuditEvent {
     targetType: row.event.targetType,
     targetId: row.event.targetId ?? null,
     actor: row.actor?.name ?? 'system',
+    actorType: row.event.actorType,
     createdAt: row.event.createdAt
   }
 }
@@ -114,12 +116,14 @@ export const LiveAuditEventLog: Layer.Layer<AuditEventLog, never, Database> =
       ).pipe(Effect.map((rows) => rows.map(toWireRow)))
 
       const insertFor = Effect.fnUntraced(function* (input: RecordAuditEventInput) {
+        yield* assertAuditActorType(input)
         const id = yield* newCapabilityId('aud')
         const createdAt = yield* DateTime.now
         return db.insert(auditEvents).values({
           id,
           workspaceId: input.workspaceId ?? null,
           actorUserId: input.actorUserId ?? null,
+          actorType: input.actorType,
           eventType: input.eventType,
           targetType: input.targetType,
           targetId: input.targetId ?? null,

--- a/packages/capabilities/src/governance/audit-event-log.ts
+++ b/packages/capabilities/src/governance/audit-event-log.ts
@@ -1,4 +1,5 @@
 import { type JsonObject } from '@b2b-saas-starter/db/schema'
+import { auditActorTypes, type AuditActorTypeValue } from '@b2b-saas-starter/db/enums'
 import { type BatchStatement } from '@b2b-saas-starter/db/service'
 import { Context, DateTime, Effect, Layer, Schema } from 'effect'
 
@@ -18,6 +19,9 @@ export const AuditEvent = Schema.Struct({
   targetType: Schema.String,
   targetId: Schema.NullOr(Schema.String),
   actor: Schema.String,
+  // Lenient like `eventType`: the read never breaks on a row the taxonomy
+  // has not met, and the UI's label map prettifies the unknown.
+  actorType: Schema.String,
   createdAt: Schema.String
 })
 export type AuditEvent = typeof AuditEvent.Type
@@ -73,6 +77,7 @@ export const AUDIT_EVENT_PAGE_SIZE = 100
  * can answer the same server-side filters as Live without reaching into D1.
  */
 export type SeedAuditEventRow = AuditEvent & {
+  readonly actorType: AuditActorTypeValue
   readonly workspaceId?: string | null
   readonly actorUserId?: string | null
 }
@@ -80,6 +85,11 @@ export type SeedAuditEventRow = AuditEvent & {
 export type RecordAuditEventInput = {
   readonly workspaceId?: string | null
   readonly actorUserId?: string | null
+  /**
+   * Who the actor was: a session user, the platform, or a bearer API token.
+   * Required invocation provenance, independent of the event's taxonomy.
+   */
+  readonly actorType: AuditActorTypeValue
   /**
    * From the taxonomy module — the write boundary is where the vocabulary is
    * enforced. The read path stays a lenient `Schema.String`.
@@ -93,6 +103,21 @@ export type RecordAuditEventInput = {
    * `audit_events.metadata` JSON column.
    */
   readonly metadata?: JsonObject
+}
+
+/**
+ * Reject missing or invalid provenance even for untyped callers. Event names
+ * do not constrain who can perform an action.
+ */
+const decodeAuditActorType = Schema.decodeUnknownEffect(
+  Schema.Literals(auditActorTypes)
+)
+
+export function assertAuditActorType(
+  input: RecordAuditEventInput
+): Effect.Effect<void> {
+  // oxlint-disable-next-line no-restricted-properties -- missing internal invocation provenance is a caller defect, not a retryable store failure
+  return decodeAuditActorType(input.actorType).pipe(Effect.orDie, Effect.asVoid)
 }
 
 export type AuditEventLogInterface = {
@@ -125,8 +150,8 @@ export class AuditEventLog extends Context.Service<
  * in context. The plugin-backed mutations (`WorkspaceMembership`,
  * `WorkspaceInvitations`, `WorkspaceLifecycle.rename`) all end the same way —
  * call the binding, read the row back, audit it — and this is that last step,
- * reading `workspaceId` and `actorUserId` off `WorkspaceContext` instead of
- * having each call site restate them.
+ * reading `workspaceId`, `actorUserId`, and the caller's actor type off
+ * `WorkspaceContext` instead of having each call site restate them.
  *
  * The audit row is deliberately NOT atomic with the write it follows, and it
  * cannot be: D1 rejects an explicit BEGIN, and a plugin write that happens over
@@ -137,14 +162,15 @@ export class AuditEventLog extends Context.Service<
  */
 export function recordInWorkspace(
   audit: AuditEventLogInterface,
-  event: Omit<RecordAuditEventInput, 'workspaceId' | 'actorUserId'>
+  event: Omit<RecordAuditEventInput, 'workspaceId' | 'actorUserId' | 'actorType'>
 ): Effect.Effect<void, CapabilityUnavailable, WorkspaceContext> {
   return Effect.gen(function* () {
     const ctx = yield* WorkspaceContext
     yield* audit.record({
       ...event,
       workspaceId: ctx.workspace.id,
-      actorUserId: ctx.actor?.userId ?? null
+      actorUserId: ctx.actor?.userId ?? null,
+      actorType: ctx.actorType
     })
   })
 }
@@ -160,6 +186,7 @@ function toSeedWire(row: SeedAuditEventRow): AuditEvent {
     targetType: row.targetType,
     targetId: row.targetId ?? null,
     actor: row.actor,
+    actorType: row.actorType,
     createdAt: row.createdAt
   }
 }
@@ -238,6 +265,7 @@ export function SeedAuditEventLog(
     listGlobal: Effect.sync(() => rows.map(toSeedWire)),
     record: (input) =>
       Effect.gen(function* () {
+        yield* assertAuditActorType(input)
         // Appends into this instance's store so recorded events read back
         // through `list`/`listGlobal` exactly as Live's inserts do —
         // mutating-capability Seeds depend on this to satisfy the same
@@ -248,12 +276,13 @@ export function SeedAuditEventLog(
           targetType: input.targetType,
           targetId: input.targetId ?? null,
           actor: seedActorName(actors, input.actorUserId),
+          actorType: input.actorType,
           actorUserId: input.actorUserId ?? null,
           workspaceId: input.workspaceId ?? null,
           createdAt: DateTime.formatIso(yield* DateTime.now)
         }
         rows.push(row)
       }),
-    prepareRecord: () => Effect.succeed(noopStatement)
+    prepareRecord: (input) => assertAuditActorType(input).pipe(Effect.as(noopStatement))
   })
 }

--- a/packages/capabilities/src/governance/platform-user-admin.live.ts
+++ b/packages/capabilities/src/governance/platform-user-admin.live.ts
@@ -87,6 +87,7 @@ export function LivePlatformUserAdmin(
             )
             yield* audit.record({
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.user_banned',
               targetType: 'user',
               targetId: input.userId
@@ -100,6 +101,7 @@ export function LivePlatformUserAdmin(
             )
             yield* audit.record({
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.user_unbanned',
               targetType: 'user',
               targetId: input.userId
@@ -129,6 +131,7 @@ export function LivePlatformUserAdmin(
             yield* audit.record({
               workspaceId: input.workspaceId,
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.user_role_changed',
               targetType: 'workspace_member',
               targetId: input.userId,
@@ -146,6 +149,7 @@ export function LivePlatformUserAdmin(
             )
             yield* audit.record({
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.impersonation_started',
               targetType: 'user',
               targetId: input.userId,
@@ -165,6 +169,7 @@ export function LivePlatformUserAdmin(
             yield* callBinding(binding, (bound) => bound.stopImpersonating())
             yield* audit.record({
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.impersonation_stopped',
               targetType: 'user',
               targetId: input.userId

--- a/packages/capabilities/src/governance/platform-user-admin.seed.ts
+++ b/packages/capabilities/src/governance/platform-user-admin.seed.ts
@@ -76,6 +76,7 @@ export function SeedPlatformUserAdmin(
             // Same events as Live, recorded after the in-memory write.
             yield* audit.record({
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.user_banned',
               targetType: 'user',
               targetId: input.userId
@@ -87,6 +88,7 @@ export function SeedPlatformUserAdmin(
             yield* setBanned(input.userId, false)
             yield* audit.record({
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.user_unbanned',
               targetType: 'user',
               targetId: input.userId
@@ -114,6 +116,7 @@ export function SeedPlatformUserAdmin(
             yield* audit.record({
               workspaceId: input.workspaceId,
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.user_role_changed',
               targetType: 'workspace_member',
               targetId: input.userId,
@@ -129,6 +132,7 @@ export function SeedPlatformUserAdmin(
             yield* Ref.set(impersonating, input.userId)
             yield* audit.record({
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.impersonation_started',
               targetType: 'user',
               targetId: input.userId,
@@ -155,6 +159,7 @@ export function SeedPlatformUserAdmin(
             yield* Ref.set(impersonating, null)
             yield* audit.record({
               actorUserId: input.actorUserId,
+              actorType: 'user',
               eventType: 'system_admin.impersonation_stopped',
               targetType: 'user',
               targetId: input.userId

--- a/packages/capabilities/src/governance/workspace-export-archive.test.ts
+++ b/packages/capabilities/src/governance/workspace-export-archive.test.ts
@@ -73,6 +73,7 @@ const snapshot: WorkspaceExportSnapshot = {
   auditEvents: [
     {
       id: 'aud_1',
+      actorType: 'user',
       eventType: 'api_token.created',
       targetType: 'api_token',
       targetId: 'tok_1',

--- a/packages/capabilities/src/governance/workspace-export.live.test.ts
+++ b/packages/capabilities/src/governance/workspace-export.live.test.ts
@@ -233,6 +233,20 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live workspace exports', (
           'workspace.export_downloaded',
           'workspace.export_requested'
         ])
+        expect(
+          events.items.find(
+            (event) =>
+              event.targetId === requested.id &&
+              event.eventType === 'workspace.export_completed'
+          )?.actorType
+        ).toBe('system')
+        expect(
+          events.items.find(
+            (event) =>
+              event.targetId === requested.id &&
+              event.eventType === 'workspace.export_downloaded'
+          )?.actorType
+        ).toBe('user')
       })
     )
 

--- a/packages/capabilities/src/governance/workspace-export.live.ts
+++ b/packages/capabilities/src/governance/workspace-export.live.ts
@@ -190,6 +190,7 @@ export function LiveWorkspaceExports(
             auditEvent: {
               workspaceId: ctx.workspace.id,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'workspace.export_requested',
               targetType: 'workspace_export',
               targetId: id,
@@ -256,6 +257,7 @@ export function LiveWorkspaceExports(
               auditEvent: {
                 workspaceId: input.workspaceId,
                 actorUserId: null,
+                actorType: 'system',
                 eventType: 'workspace.export_completed',
                 targetType: 'workspace_export',
                 targetId: input.exportId,
@@ -340,6 +342,8 @@ export function LiveWorkspaceExports(
             yield* audit.record({
               workspaceId: found.row.workspaceId,
               actorUserId: null,
+              // The signed-link holder initiated this request, not a background job.
+              actorType: 'user',
               eventType: 'workspace.export_downloaded',
               targetType: 'workspace_export',
               targetId: found.row.id,

--- a/packages/capabilities/src/governance/workspace-export.seed.ts
+++ b/packages/capabilities/src/governance/workspace-export.seed.ts
@@ -140,7 +140,7 @@ export function SeedWorkspaceExports(options: {
         // for every other capability.
         const built = yield* Effect.result(
           buildArchive(options.fixture.id, completedAt).pipe(
-            Effect.provide(testWorkspaceContext(options.workspace))
+            Effect.provide(testWorkspaceContext(options.workspace, null, 'system'))
           )
         )
         const base = {
@@ -224,6 +224,7 @@ export function SeedWorkspaceExports(options: {
           yield* audit.record({
             workspaceId: ctx.workspace.id,
             actorUserId: ctx.actor?.userId ?? null,
+            actorType: ctx.actorType,
             eventType: 'workspace.export_requested',
             targetType: 'workspace_export',
             targetId: id,
@@ -298,6 +299,7 @@ export function SeedWorkspaceExports(options: {
             yield* audit.record({
               workspaceId: row.workspaceId,
               actorUserId: null,
+              actorType: 'user',
               eventType: 'workspace.export_downloaded',
               targetType: 'workspace_export',
               targetId: row.record.id,
@@ -335,6 +337,7 @@ function completeRow(
     yield* audit.record({
       workspaceId: row.workspaceId,
       actorUserId: null,
+      actorType: 'system',
       eventType: 'workspace.export_completed',
       targetType: 'workspace_export',
       targetId: row.record.id,

--- a/packages/capabilities/src/governance/workspace-export.test.ts
+++ b/packages/capabilities/src/governance/workspace-export.test.ts
@@ -152,6 +152,9 @@ describe('SeedWorkspaceExports', () => {
         (event) => event.eventType === 'workspace.export_downloaded'
       )
       expect(events.some((event) => event.targetId === created.id)).toBe(true)
+      expect(events.find((event) => event.targetId === created.id)?.actorType).toBe(
+        'user'
+      )
     }).pipe(Effect.provide(ownerLayer))
   )
 
@@ -336,6 +339,7 @@ describe('collectWorkspaceExportSnapshot — the audit walk bound', () => {
   function auditRows(count: number): ReadonlyArray<SeedAuditEventRow> {
     return Array.from({ length: count }, (_, index) => ({
       id: `evt_${String(index).padStart(5, '0')}`,
+      actorType: 'user',
       eventType: 'workspace.renamed',
       targetType: 'workspace',
       targetId: seedWorkspaceRecord.id,

--- a/packages/capabilities/src/governance/workspace-invitations.live.ts
+++ b/packages/capabilities/src/governance/workspace-invitations.live.ts
@@ -205,6 +205,7 @@ export function LiveWorkspaceInvitations(
             yield* audit.record({
               workspaceId: row.workspace.id,
               actorUserId: input.userId,
+              actorType: 'user',
               eventType: 'workspace_invitation.accepted',
               targetType: 'workspace_invitation',
               targetId: input.invitationId,

--- a/packages/capabilities/src/governance/workspace-invitations.seed.ts
+++ b/packages/capabilities/src/governance/workspace-invitations.seed.ts
@@ -167,6 +167,7 @@ export function SeedWorkspaceInvitations(options: {
               yield* audit.value.record({
                 workspaceId: options.workspace.id,
                 actorUserId: input.userId,
+                actorType: 'user',
                 eventType: 'workspace_invitation.accepted',
                 targetType: 'workspace_invitation',
                 targetId: input.invitationId,

--- a/packages/capabilities/src/governance/workspace-lifecycle.contract.ts
+++ b/packages/capabilities/src/governance/workspace-lifecycle.contract.ts
@@ -108,6 +108,9 @@ export function workspaceLifecycleContractCases(
         )
         expect(createdEvents.length).toBe(createdBefore + 1)
         expect(
+          createdEvents.find((event) => event.targetId === created.id)?.actorType
+        ).toBe('user')
+        expect(
           createdEvents.some(
             (event) => event.targetId === created.id && event.targetType === 'workspace'
           )
@@ -119,6 +122,10 @@ export function workspaceLifecycleContractCases(
         yield* lifecycle.rename({ name: 'Audited Lab II' })
         const renamedPage = yield* log.list({ eventType: 'workspace.renamed' })
         expect(renamedPage.items.length).toBe(renamedBefore + 1)
+        expect(
+          renamedPage.items.find((event) => event.targetId === ctx.workspace.id)
+            ?.actorType
+        ).toBe(ctx.actorType)
         expect(
           renamedPage.items.some(
             (event) =>

--- a/packages/capabilities/src/governance/workspace-lifecycle.ts
+++ b/packages/capabilities/src/governance/workspace-lifecycle.ts
@@ -157,6 +157,7 @@ export function SeedWorkspaceLifecycle(options: {
               yield* audit.value.record({
                 workspaceId: workspace.id,
                 actorUserId: input.userId,
+                actorType: 'user',
                 eventType: 'workspace.created',
                 targetType: 'workspace',
                 targetId: workspace.id,
@@ -199,13 +200,15 @@ export function SeedWorkspaceLifecycle(options: {
           yield* Ref.update(created, (rows) =>
             rows.filter((each) => each.id !== ctx.workspace.id)
           )
-          // A system event on purpose, matching Live: the trail stays readable
-          // after the workspace it describes is gone.
+          // Unscoped on purpose, matching Live: the trail stays readable
+          // after the workspace it describes is gone. The actor stays the
+          // deleting user — only the workspace attribution is dropped.
           const audit = yield* Effect.serviceOption(AuditEventLog)
           if (Option.isSome(audit)) {
             yield* audit.value.record({
               workspaceId: null,
               actorUserId: ctx.actor?.userId ?? null,
+              actorType: ctx.actorType,
               eventType: 'workspace.deleted',
               targetType: 'workspace',
               targetId: removed.id,
@@ -254,6 +257,7 @@ export function LiveWorkspaceLifecycle(
             yield* audit.record({
               workspaceId: workspace.id,
               actorUserId: input.userId,
+              actorType: 'user',
               eventType: 'workspace.created',
               targetType: 'workspace',
               targetId: workspace.id,
@@ -300,12 +304,14 @@ export function LiveWorkspaceLifecycle(
           yield* callBinding(binding, (bound) =>
             bound.remove({ workspaceId: ctx.workspace.id })
           )
-          // A system event on purpose: `audit_events.workspace_id` cascades from
+          // Unscoped on purpose: `audit_events.workspace_id` cascades from
           // `workspaces.id`, so attributing this row to the deleted workspace
-          // would delete it alongside the thing it describes.
+          // would delete it alongside the thing it describes. The actor stays
+          // the deleting user — only the workspace attribution is dropped.
           yield* audit.record({
             workspaceId: null,
             actorUserId: ctx.actor?.userId ?? null,
+            actorType: ctx.actorType,
             eventType: 'workspace.deleted',
             targetType: 'workspace',
             targetId: removed.id,

--- a/packages/capabilities/src/governance/workspace-onboarding.ts
+++ b/packages/capabilities/src/governance/workspace-onboarding.ts
@@ -101,6 +101,7 @@ export function SeedWorkspaceOnboarding(
           yield* audit.record({
             workspaceId: ctx.workspace.id,
             actorUserId: ctx.actor?.userId ?? null,
+            actorType: ctx.actorType,
             eventType: 'workspace.onboarding_dismissed',
             targetType: 'workspace',
             targetId: ctx.workspace.id,
@@ -180,6 +181,7 @@ export const LiveWorkspaceOnboarding: Layer.Layer<
           auditEvent: {
             workspaceId: ctx.workspace.id,
             actorUserId: ctx.actor?.userId ?? null,
+            actorType: ctx.actorType,
             eventType: 'workspace.onboarding_dismissed',
             targetType: 'workspace',
             targetId: ctx.workspace.id,

--- a/packages/capabilities/src/index.test.ts
+++ b/packages/capabilities/src/index.test.ts
@@ -327,9 +327,14 @@ describe('layer selection without D1', () => {
       expect(notifications.length).toBeGreaterThan(0)
     }).pipe(
       Effect.provide(
-        selectWorkspaceLayer({}, seedWorkspaceRecord.slug, {
-          userId: 'usr_demo'
-        })
+        selectWorkspaceLayer(
+          {},
+          seedWorkspaceRecord.slug,
+          {
+            userId: 'usr_demo'
+          },
+          'user'
+        )
       )
     )
   )

--- a/packages/capabilities/src/notifications/notification-email.live.test.ts
+++ b/packages/capabilities/src/notifications/notification-email.live.test.ts
@@ -116,7 +116,7 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live notification feed', (
           Effect.flatMap(NotificationFeed, (feed) => feed.list),
           Layer.merge(
             feedLayer([]),
-            liveWorkspaceContext('live-lab', { userId: 'usr_owner' })
+            liveWorkspaceContext('live-lab', { userId: 'usr_owner' }, 'user')
           )
         )
         expect(listed.map((row) => row.id)).toContain(created.id)

--- a/packages/capabilities/src/notifications/notification-feed.seed.test.ts
+++ b/packages/capabilities/src/notifications/notification-feed.seed.test.ts
@@ -255,7 +255,8 @@ describe('seed notification feed: notifyWorkspaceOwners', () => {
           return feed.list.pipe(
             Effect.provideService(WorkspaceContext, {
               workspace: seedWorkspaceRecord,
-              actor
+              actor,
+              actorType: 'user'
             })
           )
         }

--- a/packages/capabilities/src/notifications/notification-preferences.ts
+++ b/packages/capabilities/src/notifications/notification-preferences.ts
@@ -104,6 +104,7 @@ function preferenceChangeEvent(
 ): RecordAuditEventInput {
   return {
     actorUserId: input.userId,
+    actorType: 'user',
     eventType: 'notification_preference.changed',
     targetType: 'user',
     targetId: input.userId,

--- a/packages/capabilities/src/runtime.live.test.ts
+++ b/packages/capabilities/src/runtime.live.test.ts
@@ -35,9 +35,14 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })(
                 role: 'member'
               })
             ),
-            selectWorkspaceLayer({ DB: d1, invitationBinding: binding }, 'live-lab', {
-              userId: 'usr_owner'
-            })
+            selectWorkspaceLayer(
+              { DB: d1, invitationBinding: binding },
+              'live-lab',
+              {
+                userId: 'usr_owner'
+              },
+              'user'
+            )
           )
 
           expect(created.email).toBe('selected@live-invite.test')

--- a/packages/capabilities/src/runtime.ts
+++ b/packages/capabilities/src/runtime.ts
@@ -1,4 +1,5 @@
 import { layerFromD1 } from '@b2b-saas-starter/db/service'
+import { type AuditActorTypeValue } from '@b2b-saas-starter/db/enums'
 import { Layer } from 'effect'
 import { type SeatSyncQueueBinding } from './billing/seat-sync.ts'
 import { type WebhookQueueBinding } from './developer-platform/webhook-publisher.ts'
@@ -125,14 +126,23 @@ export function selectCapabilitiesLayer(env: StarterEnv): CapabilitiesLayer {
 export function selectWorkspaceContextLayer(
   env: StarterEnv,
   slug: string,
-  actor?: ActorRef
+  actor: ActorRef | undefined,
+  actorType: AuditActorTypeValue
 ): Layer.Layer<WorkspaceContext, WorkspaceNotFound | CapabilityUnavailable> {
   if (env.DB === undefined) {
     // Passing `seedMembers` makes the seed path enforce the same actor
     // membership semantics as the live path (fixture members allowed).
-    return seedWorkspaceContext(seedWorkspaceRecord, slug, actor, seedMembers)
+    return seedWorkspaceContext(
+      seedWorkspaceRecord,
+      slug,
+      actor,
+      seedMembers,
+      actorType
+    )
   }
-  return liveWorkspaceContext(slug, actor).pipe(Layer.provide(layerFromD1(env.DB)))
+  return liveWorkspaceContext(slug, actor, actorType).pipe(
+    Layer.provide(layerFromD1(env.DB))
+  )
 }
 
 /**
@@ -144,7 +154,8 @@ export function selectWorkspaceContextLayer(
 export function selectWorkspaceLayer(
   env: StarterEnv,
   slug: string,
-  actor?: ActorRef
+  actor: ActorRef | undefined,
+  actorType: AuditActorTypeValue
 ): Layer.Layer<
   CapabilityServices | WorkspaceContext,
   WorkspaceNotFound | CapabilityUnavailable
@@ -154,11 +165,11 @@ export function selectWorkspaceLayer(
     // membership semantics as the live path (fixture members allowed).
     return Layer.merge(
       SeedLayer,
-      seedWorkspaceContext(seedWorkspaceRecord, slug, actor, seedMembers)
+      seedWorkspaceContext(seedWorkspaceRecord, slug, actor, seedMembers, actorType)
     )
   }
   return Layer.mergeAll(
     makeLiveCapabilitiesLayer(liveCapabilitiesOptions(env)),
-    liveWorkspaceContext(slug, actor)
+    liveWorkspaceContext(slug, actor, actorType)
   ).pipe(Layer.provide(layerFromD1(env.DB)))
 }

--- a/packages/capabilities/src/seed-fixture.ts
+++ b/packages/capabilities/src/seed-fixture.ts
@@ -227,6 +227,7 @@ export const seedDeliveries: ReadonlyArray<SeedWebhookDeliveryFixture> = [
 export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   {
     id: 'aud_admin',
+    actorType: 'user',
     eventType: 'system_admin.user_role_changed',
     targetType: 'user',
     targetId: 'usr_dev',
@@ -238,6 +239,7 @@ export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   // showcase show the start/stop pair against the same admin and target.
   {
     id: 'aud_impersonation_started',
+    actorType: 'user',
     eventType: 'system_admin.impersonation_started',
     targetType: 'user',
     targetId: 'usr_dev',
@@ -247,6 +249,7 @@ export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   },
   {
     id: 'aud_impersonation_stopped',
+    actorType: 'user',
     eventType: 'system_admin.impersonation_stopped',
     targetType: 'user',
     targetId: 'usr_dev',
@@ -258,6 +261,7 @@ export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   // account security, not workspace activity, so it carries no workspace.
   {
     id: 'aud_passkey',
+    actorType: 'user',
     eventType: 'auth.passkey_added',
     targetType: 'user',
     targetId: 'usr_demo',
@@ -267,6 +271,7 @@ export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   },
   {
     id: 'aud_token',
+    actorType: 'user',
     eventType: 'api_token.created',
     targetType: 'api_token',
     targetId: 'tok_ops',
@@ -279,6 +284,7 @@ export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   },
   {
     id: 'aud_mcp_consent',
+    actorType: 'user',
     eventType: 'mcp_client.consent_granted',
     targetType: 'mcp_client',
     targetId: 'https://mcp-client.example.com/oauth/client-metadata.json',
@@ -289,6 +295,7 @@ export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   },
   {
     id: 'aud_export',
+    actorType: 'system',
     eventType: 'workspace.export_completed',
     targetType: 'workspace_export',
     targetId: 'exp_seed_ready',
@@ -299,6 +306,7 @@ export const seedAuditEvents: ReadonlyArray<SeedAuditEventRow> = [
   },
   {
     id: 'aud_magic_link',
+    actorType: 'user',
     eventType: 'auth.sign_in',
     targetType: 'session',
     // A session the magic link opened; no fixture row exists for it.

--- a/packages/capabilities/src/testing/live-harness.ts
+++ b/packages/capabilities/src/testing/live-harness.ts
@@ -120,6 +120,7 @@ const insertFixtureRows = Effect.gen(function* () {
       id: row.id,
       workspaceId: row.workspaceId ?? null,
       actorUserId: row.actorUserId ?? null,
+      actorType: row.actorType,
       eventType: row.eventType,
       targetType: row.targetType,
       targetId: row.targetId ?? null,
@@ -294,7 +295,10 @@ export function inWorkspace<A, E>(
 ): Effect.Effect<A, E | WorkspaceNotFound | CapabilityUnavailable, Database | RawD1> {
   return Effect.provide(
     effect,
-    Layer.merge(makeLiveCapabilitiesLayer(bindings), liveWorkspaceContext(slug, actor))
+    Layer.merge(
+      makeLiveCapabilitiesLayer(bindings),
+      liveWorkspaceContext(slug, actor, 'user')
+    )
   )
 }
 

--- a/packages/capabilities/src/workspace-context.ts
+++ b/packages/capabilities/src/workspace-context.ts
@@ -1,3 +1,4 @@
+import { type AuditActorTypeValue } from '@b2b-saas-starter/db/enums'
 import { Database } from '@b2b-saas-starter/db/service'
 import { workspaces } from '@b2b-saas-starter/db/schema'
 import { Context, Effect, Layer, Schema } from 'effect'
@@ -43,6 +44,13 @@ export function memberToActor(member: Member): Actor {
 export type WorkspaceContextInterface = {
   readonly workspace: Workspace
   readonly actor: Actor | null
+  /**
+   * What kind of caller made the request, read by the audit writes a
+   * mutating capability performs: a session user, the platform, or a bearer
+   * API token driving the REST/MCP surface. Independent of whether a user
+   * identity is available; the request boundary must supply provenance.
+   */
+  readonly actorType: AuditActorTypeValue
 }
 
 export class WorkspaceContext extends Context.Service<
@@ -52,7 +60,8 @@ export class WorkspaceContext extends Context.Service<
 
 export function liveWorkspaceContext(
   slug: string,
-  actor?: ActorRef
+  actor: ActorRef | undefined,
+  actorType: AuditActorTypeValue
 ): Layer.Layer<WorkspaceContext, WorkspaceNotFound | CapabilityUnavailable, Database> {
   return Layer.effect(WorkspaceContext)(
     Effect.gen(function* () {
@@ -78,7 +87,8 @@ export function liveWorkspaceContext(
       }
       return {
         workspace: toWorkspace(row),
-        actor: resolvedActor
+        actor: resolvedActor,
+        actorType
       }
     })
   )
@@ -96,8 +106,9 @@ export function liveWorkspaceContext(
 export function seedWorkspaceContext(
   seedWorkspace: Workspace,
   slug: string,
-  actor?: ActorRef,
-  members: ReadonlyArray<Member> = []
+  actor: ActorRef | undefined,
+  members: ReadonlyArray<Member>,
+  actorType: AuditActorTypeValue
 ): Layer.Layer<WorkspaceContext, WorkspaceNotFound> {
   return Layer.effect(WorkspaceContext)(
     Effect.suspend((): Effect.Effect<WorkspaceContextInterface, WorkspaceNotFound> => {
@@ -105,13 +116,22 @@ export function seedWorkspaceContext(
         return Effect.fail(new WorkspaceNotFound({ slug }))
       }
       if (!actor) {
-        return Effect.succeed({ workspace: seedWorkspace, actor: null })
+        return Effect.succeed({
+          workspace: seedWorkspace,
+          actor: null,
+          actorType
+        })
       }
       const member = members.find((candidate) => candidate.id === actor.userId)
       if (!member) {
         return Effect.fail(new WorkspaceNotFound({ slug }))
       }
-      return Effect.succeed({ workspace: seedWorkspace, actor: memberToActor(member) })
+      const resolved = memberToActor(member)
+      return Effect.succeed({
+        workspace: seedWorkspace,
+        actor: resolved,
+        actorType
+      })
     })
   )
 }
@@ -119,7 +139,12 @@ export function seedWorkspaceContext(
 /** Test injection: a context built from already-resolved values, no membership checks. */
 export function testWorkspaceContext(
   workspace: Workspace,
-  actor: Actor | null = null
+  actor: Actor | null = null,
+  actorType: AuditActorTypeValue = 'user'
 ): Layer.Layer<WorkspaceContext> {
-  return Layer.succeed(WorkspaceContext)({ workspace, actor })
+  return Layer.succeed(WorkspaceContext)({
+    workspace,
+    actor,
+    actorType
+  })
 }

--- a/packages/capabilities/src/workspace-projections.ts
+++ b/packages/capabilities/src/workspace-projections.ts
@@ -113,7 +113,10 @@ export function listWorkspacesForUser(
           Effect.provide(
             Layer.succeed(WorkspaceContext)({
               workspace,
-              actor: memberToActor(member)
+              actor: memberToActor(member),
+              // The membership row this projection already proved *is* the
+              // session user — there is no other caller kind here.
+              actorType: 'user'
             })
           )
         ),

--- a/packages/db/migrations/20260906114130_foamy_daimon_hellstrom/migration.sql
+++ b/packages/db/migrations/20260906114130_foamy_daimon_hellstrom/migration.sql
@@ -1,0 +1,4 @@
+-- Pre-production reset: old rows contain no invocation provenance. Do not
+-- fabricate it from event names or the presence of a user foreign key.
+DELETE FROM `audit_events`;--> statement-breakpoint
+ALTER TABLE `audit_events` ADD `actor_type` text NOT NULL;

--- a/packages/db/migrations/20260906114130_foamy_daimon_hellstrom/snapshot.json
+++ b/packages/db/migrations/20260906114130_foamy_daimon_hellstrom/snapshot.json
@@ -1,0 +1,4089 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "0216768d-5b7d-4522-9536-8eadb44bd7f4",
+  "prevIds": ["3c421b35-29b4-482a-9d51-47171475d4ec"],
+  "ddl": [
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "api_tokens",
+      "entityType": "tables"
+    },
+    {
+      "name": "audit_events",
+      "entityType": "tables"
+    },
+    {
+      "name": "jwks",
+      "entityType": "tables"
+    },
+    {
+      "name": "notification_preferences",
+      "entityType": "tables"
+    },
+    {
+      "name": "notifications",
+      "entityType": "tables"
+    },
+    {
+      "name": "oauth_access_token",
+      "entityType": "tables"
+    },
+    {
+      "name": "oauth_client",
+      "entityType": "tables"
+    },
+    {
+      "name": "oauth_client_assertion",
+      "entityType": "tables"
+    },
+    {
+      "name": "oauth_client_resource",
+      "entityType": "tables"
+    },
+    {
+      "name": "oauth_consent",
+      "entityType": "tables"
+    },
+    {
+      "name": "oauth_refresh_token",
+      "entityType": "tables"
+    },
+    {
+      "name": "oauth_resource",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkey",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "two_factor",
+      "entityType": "tables"
+    },
+    {
+      "name": "user",
+      "entityType": "tables"
+    },
+    {
+      "name": "verification",
+      "entityType": "tables"
+    },
+    {
+      "name": "webhook_deliveries",
+      "entityType": "tables"
+    },
+    {
+      "name": "webhook_endpoints",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace_exports",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace_invitations",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace_members",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace_sso_connections",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace_subscriptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspaces",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accountId",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "providerId",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issuer",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accessToken",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refreshToken",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "idToken",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accessTokenExpiresAt",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refreshTokenExpiresAt",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_prefix",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "table": "api_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "actor_user_id",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "actor_type",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_type",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_id",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "audit_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "jwks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "publicKey",
+      "entityType": "columns",
+      "table": "jwks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "privateKey",
+      "entityType": "columns",
+      "table": "jwks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "jwks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "table": "jwks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "alg",
+      "entityType": "columns",
+      "table": "jwks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "crv",
+      "entityType": "columns",
+      "table": "jwks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "notification_preferences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "notification_preferences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "notification_preferences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "channel",
+      "entityType": "columns",
+      "table": "notification_preferences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "notification_preferences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'announcement'",
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "read_at",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "clientId",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sessionId",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "referenceId",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "authorizationCodeId",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "resources",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "requestedUserInfoClaims",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refreshId",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revoked",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "confirmation",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "table": "oauth_access_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "clientId",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "clientSecret",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "clientDiscoveryId",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "disabled",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "skipConsent",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "enableEndSession",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "subjectType",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "clientCredentialsScopes",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "uri",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "contacts",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tos",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "policy",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "softwareId",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "softwareVersion",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "softwareStatement",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redirectUris",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "postLogoutRedirectUris",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backchannelLogoutUri",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backchannelLogoutSessionRequired",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tokenEndpointAuthMethod",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "applicationType",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "jwks",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "jwksUri",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "grantTypes",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "responseTypes",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "requirePKCE",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "dpopBoundAccessTokens",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "referenceId",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "oauth_client"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "oauth_client_assertion"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "table": "oauth_client_assertion"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "oauth_client_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "clientId",
+      "entityType": "columns",
+      "table": "oauth_client_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "resourceId",
+      "entityType": "columns",
+      "table": "oauth_client_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "oauth_client_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "oauth_client_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "clientId",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "referenceId",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "resources",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "requestedUserInfoClaims",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "oauth_consent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "clientId",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sessionId",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "referenceId",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "authorizationCodeId",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "resources",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "requestedUserInfoClaims",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revoked",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rotatedAt",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rotationReplayResponse",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rotationReplayExpiresAt",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "authTime",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "confirmation",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accessTokenTtl",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refreshTokenTtl",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "signingAlgorithm",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "signingKeyId",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "allowedScopes",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "customClaims",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "dpopBoundAccessTokensRequired",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "disabled",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "policyVersion",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "oauth_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "publicKey",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credentialID",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "deviceType",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backedUp",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ipAddress",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userAgent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "impersonatedBy",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activeOrganizationId",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "secret",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backupCodes",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "verified",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "failedVerificationCount",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lockedUntil",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "two_factor"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "username",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "displayUsername",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "emailVerified",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'user'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "banned",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "banReason",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "banExpires",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "twoFactorEnabled",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "endpoint_id",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "attempts",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_attempt_at",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "next_attempt_at",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "response_status",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "payload",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "request_headers",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "response_body",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "replayed_from",
+      "entityType": "columns",
+      "table": "webhook_deliveries"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "signing_secret",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "previous_signing_secret",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "previous_secret_expires_at",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "consecutive_failures",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "events",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "webhook_endpoints"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "requested_by_user_id",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "object_key",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "size_bytes",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "download_secret",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_reason",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "workspace_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "table": "workspace_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "workspace_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "workspace_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "workspace_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "table": "workspace_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "workspace_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "inviterId",
+      "entityType": "columns",
+      "table": "workspace_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "table": "workspace_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "workspace_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "workspace_members"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "workspace_members"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issuer",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "oidcConfig",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "samlConfig",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "providerId",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "domain",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "requireSso",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "defaultWorkspaceRole",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "workspace_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "table": "workspace_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_subscription_id",
+      "entityType": "columns",
+      "table": "workspace_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_subscription_item_id",
+      "entityType": "columns",
+      "table": "workspace_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "seat_quantity",
+      "entityType": "columns",
+      "table": "workspace_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "workspace_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "logo",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'starter'",
+      "generated": null,
+      "name": "planId",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "onboardingDismissedAt",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(unixepoch())",
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "workspaces"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_account_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "account"
+    },
+    {
+      "columns": ["workspace_id"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_api_tokens_workspace_id_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "api_tokens"
+    },
+    {
+      "columns": ["created_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_api_tokens_created_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "api_tokens"
+    },
+    {
+      "columns": ["workspace_id"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_audit_events_workspace_id_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "audit_events"
+    },
+    {
+      "columns": ["actor_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_audit_events_actor_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "audit_events"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_notification_preferences_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "notification_preferences"
+    },
+    {
+      "columns": ["workspace_id"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_notifications_workspace_id_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "notifications"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_notifications_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "notifications"
+    },
+    {
+      "columns": ["clientId"],
+      "tableTo": "oauth_client",
+      "columnsTo": ["clientId"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_oauth_access_token_clientId_oauth_client_clientId_fk",
+      "entityType": "fks",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": ["sessionId"],
+      "tableTo": "session",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_oauth_access_token_sessionId_session_id_fk",
+      "entityType": "fks",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_oauth_access_token_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": ["refreshId"],
+      "tableTo": "oauth_refresh_token",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_oauth_access_token_refreshId_oauth_refresh_token_id_fk",
+      "entityType": "fks",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_oauth_client_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "oauth_client"
+    },
+    {
+      "columns": ["clientId"],
+      "tableTo": "oauth_client",
+      "columnsTo": ["clientId"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_oauth_client_resource_clientId_oauth_client_clientId_fk",
+      "entityType": "fks",
+      "table": "oauth_client_resource"
+    },
+    {
+      "columns": ["resourceId"],
+      "tableTo": "oauth_resource",
+      "columnsTo": ["identifier"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_oauth_client_resource_resourceId_oauth_resource_identifier_fk",
+      "entityType": "fks",
+      "table": "oauth_client_resource"
+    },
+    {
+      "columns": ["clientId"],
+      "tableTo": "oauth_client",
+      "columnsTo": ["clientId"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_oauth_consent_clientId_oauth_client_clientId_fk",
+      "entityType": "fks",
+      "table": "oauth_consent"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_oauth_consent_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "oauth_consent"
+    },
+    {
+      "columns": ["clientId"],
+      "tableTo": "oauth_client",
+      "columnsTo": ["clientId"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_oauth_refresh_token_clientId_oauth_client_clientId_fk",
+      "entityType": "fks",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "columns": ["sessionId"],
+      "tableTo": "session",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_oauth_refresh_token_sessionId_session_id_fk",
+      "entityType": "fks",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_oauth_refresh_token_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_passkey_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "passkey"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_two_factor_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "two_factor"
+    },
+    {
+      "columns": ["endpoint_id"],
+      "tableTo": "webhook_endpoints",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+      "entityType": "fks",
+      "table": "webhook_deliveries"
+    },
+    {
+      "columns": ["workspace_id"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_webhook_endpoints_workspace_id_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "webhook_endpoints"
+    },
+    {
+      "columns": ["workspace_id"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_exports_workspace_id_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "workspace_exports"
+    },
+    {
+      "columns": ["requested_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_workspace_exports_requested_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "workspace_exports"
+    },
+    {
+      "columns": ["workspaceId"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_invitations_workspaceId_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "workspace_invitations"
+    },
+    {
+      "columns": ["inviterId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_invitations_inviterId_user_id_fk",
+      "entityType": "fks",
+      "table": "workspace_invitations"
+    },
+    {
+      "columns": ["workspaceId"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_members_workspaceId_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "workspace_members"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_members_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "workspace_members"
+    },
+    {
+      "columns": ["userId"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_sso_connections_userId_user_id_fk",
+      "entityType": "fks",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "columns": ["workspaceId"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_sso_connections_workspaceId_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "columns": ["workspace_id"],
+      "tableTo": "workspaces",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_subscriptions_workspace_id_workspaces_id_fk",
+      "entityType": "fks",
+      "table": "workspace_subscriptions"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "api_tokens_pk",
+      "table": "api_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "audit_events_pk",
+      "table": "audit_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "jwks_pk",
+      "table": "jwks",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "notification_preferences_pk",
+      "table": "notification_preferences",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "notifications_pk",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "oauth_access_token_pk",
+      "table": "oauth_access_token",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "oauth_client_pk",
+      "table": "oauth_client",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "oauth_client_assertion_pk",
+      "table": "oauth_client_assertion",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "oauth_client_resource_pk",
+      "table": "oauth_client_resource",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "oauth_consent_pk",
+      "table": "oauth_consent",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "oauth_refresh_token_pk",
+      "table": "oauth_refresh_token",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "oauth_resource_pk",
+      "table": "oauth_resource",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "passkey_pk",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "two_factor_pk",
+      "table": "two_factor",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "user_pk",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verification_pk",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "webhook_deliveries_pk",
+      "table": "webhook_deliveries",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "webhook_endpoints_pk",
+      "table": "webhook_endpoints",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "workspace_exports_pk",
+      "table": "workspace_exports",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "workspace_invitations_pk",
+      "table": "workspace_invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "workspace_members_pk",
+      "table": "workspace_members",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "workspace_sso_connections_pk",
+      "table": "workspace_sso_connections",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["workspace_id"],
+      "nameExplicit": false,
+      "name": "workspace_subscriptions_pk",
+      "table": "workspace_subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "workspaces_pk",
+      "table": "workspaces",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "account_user_id_idx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "issuer",
+          "isExpression": false
+        },
+        {
+          "value": "accountId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "account_issuer_accountId_uidx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "api_tokens_workspace_id_idx",
+      "entityType": "indexes",
+      "table": "api_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "api_tokens_created_by_user_id_idx",
+      "entityType": "indexes",
+      "table": "api_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "audit_events_workspace_created_at_idx",
+      "entityType": "indexes",
+      "table": "audit_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "actor_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "audit_events_actor_user_id_idx",
+      "entityType": "indexes",
+      "table": "audit_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "kind",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "notification_preferences_user_kind_idx",
+      "entityType": "indexes",
+      "table": "notification_preferences"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "notifications_workspace_id_idx",
+      "entityType": "indexes",
+      "table": "notifications"
+    },
+    {
+      "columns": [
+        {
+          "value": "clientId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_access_token_client_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "sessionId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_access_token_session_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_access_token_user_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "authorizationCodeId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_access_token_authorization_code_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "refreshId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_access_token_refresh_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_client_user_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_client"
+    },
+    {
+      "columns": [
+        {
+          "value": "clientId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_client_resource_client_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_client_resource"
+    },
+    {
+      "columns": [
+        {
+          "value": "resourceId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_client_resource_resource_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_client_resource"
+    },
+    {
+      "columns": [
+        {
+          "value": "clientId",
+          "isExpression": false
+        },
+        {
+          "value": "resourceId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_client_resource_client_resource_idx",
+      "entityType": "indexes",
+      "table": "oauth_client_resource"
+    },
+    {
+      "columns": [
+        {
+          "value": "clientId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_consent_client_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_consent"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_consent_user_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_consent"
+    },
+    {
+      "columns": [
+        {
+          "value": "clientId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_refresh_token_client_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "sessionId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_refresh_token_session_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_refresh_token_user_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "authorizationCodeId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "oauth_refresh_token_authorization_code_id_idx",
+      "entityType": "indexes",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_user_id_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "credentialID",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_credential_id_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_user_id_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "two_factor_user_id_idx",
+      "entityType": "indexes",
+      "table": "two_factor"
+    },
+    {
+      "columns": [
+        {
+          "value": "secret",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "two_factor_secret_idx",
+      "entityType": "indexes",
+      "table": "two_factor"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "table": "verification"
+    },
+    {
+      "columns": [
+        {
+          "value": "endpoint_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "webhook_deliveries_endpoint_id_idx",
+      "entityType": "indexes",
+      "table": "webhook_deliveries"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "webhook_endpoints_workspace_id_idx",
+      "entityType": "indexes",
+      "table": "webhook_endpoints"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_exports_workspace_id_idx",
+      "entityType": "indexes",
+      "table": "workspace_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "requested_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_exports_requested_by_user_id_idx",
+      "entityType": "indexes",
+      "table": "workspace_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_invitations_workspace_id_idx",
+      "entityType": "indexes",
+      "table": "workspace_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_invitations_email_idx",
+      "entityType": "indexes",
+      "table": "workspace_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "inviterId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_invitations_inviter_id_idx",
+      "entityType": "indexes",
+      "table": "workspace_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false
+        },
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_members_workspace_id_user_id_idx",
+      "entityType": "indexes",
+      "table": "workspace_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_members_user_idx",
+      "entityType": "indexes",
+      "table": "workspace_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_sso_connections_workspace_id_idx",
+      "entityType": "indexes",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workspace_sso_connections_domain_idx",
+      "entityType": "indexes",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "columns": ["token_hash"],
+      "nameExplicit": false,
+      "name": "api_tokens_token_hash_unique",
+      "entityType": "uniques",
+      "table": "api_tokens"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "oauth_access_token_token_unique",
+      "entityType": "uniques",
+      "table": "oauth_access_token"
+    },
+    {
+      "columns": ["clientId"],
+      "nameExplicit": false,
+      "name": "oauth_client_clientId_unique",
+      "entityType": "uniques",
+      "table": "oauth_client"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "oauth_refresh_token_token_unique",
+      "entityType": "uniques",
+      "table": "oauth_refresh_token"
+    },
+    {
+      "columns": ["identifier"],
+      "nameExplicit": false,
+      "name": "oauth_resource_identifier_unique",
+      "entityType": "uniques",
+      "table": "oauth_resource"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "session_token_unique",
+      "entityType": "uniques",
+      "table": "session"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "columns": ["username"],
+      "nameExplicit": false,
+      "name": "user_username_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "columns": ["providerId"],
+      "nameExplicit": false,
+      "name": "workspace_sso_connections_providerId_unique",
+      "entityType": "uniques",
+      "table": "workspace_sso_connections"
+    },
+    {
+      "columns": ["slug"],
+      "nameExplicit": false,
+      "name": "workspaces_slug_unique",
+      "entityType": "uniques",
+      "table": "workspaces"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/enums.ts
+++ b/packages/db/src/enums.ts
@@ -132,6 +132,17 @@ export const securityNotificationKinds = [
 ] as const satisfies ReadonlyArray<NotificationKind>
 
 /**
+ * Who performed an audited action, stored in `audit_events.actorType`: a
+ * signed-in session user, the platform itself (background worker or a
+ * lifecycle step no human initiated), or a bearer API token driving the
+ * REST/MCP surface. Independent of `actorUserId`: a user action can remain
+ * unattributed, and a credential can act on behalf of a known user.
+ */
+// oxlint-disable-next-line effect/noAs -- `as const`, not a type assertion
+export const auditActorTypes = ['user', 'system', 'api_token'] as const
+export type AuditActorTypeValue = (typeof auditActorTypes)[number]
+
+/**
  * How a user receives one kind of Notification by email: not at all, one
  * email per Notification as it is created, or folded into the daily digest.
  * The in-app feed is unaffected by the choice.

--- a/packages/db/src/live-d1.test.ts
+++ b/packages/db/src/live-d1.test.ts
@@ -65,6 +65,26 @@ const createdAtFixture = new Date('2026-08-15T09:00:00.000Z')
 const expiresAtFixture = new Date('2026-08-17T09:00:00.000Z')
 
 describe('migrations', () => {
+  it.live('rejects audit inserts that omit invocation provenance', () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        expect(
+          test.d1
+            .prepare(
+              "INSERT INTO audit_events (id, event_type, target_type, created_at) VALUES ('aud_missing_actor', 'api_token.created', 'api_token', '2026-09-06T12:00:00.000Z')"
+            )
+            .run()
+        ).rejects.toThrow('NOT NULL constraint failed: audit_events.actor_type')
+      )
+      const row = yield* Effect.promise(() =>
+        test.d1
+          .prepare("SELECT id FROM audit_events WHERE id = 'aud_missing_actor'")
+          .first()
+      )
+      expect(row).toBeNull()
+    })
+  )
+
   it.live('create every table the schema declares', () =>
     Effect.gen(function* () {
       const rows = yield* Effect.promise(() =>

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,5 @@
 import {
+  auditActorTypes,
   deliveryStatuses,
   invitationStatuses,
   notificationChannels,
@@ -22,6 +23,7 @@ import {
 export {
   adminSystemRole,
   apiTokenScopes,
+  auditActorTypes,
   deliveryStatuses,
   invitationStatuses,
   notificationChannels,
@@ -32,6 +34,7 @@ export {
   workspaceExportStatuses,
   workspaceRoles,
   type ApiTokenScopeValue,
+  type AuditActorTypeValue,
   type DeliveryStatus,
   type NotificationChannel,
   type NotificationKind,
@@ -514,6 +517,7 @@ export const auditEvents = sqliteTable(
     id: id(),
     workspaceId: workspaceRefNullable(),
     actorUserId: text('actor_user_id').references(() => user.id),
+    actorType: text('actor_type', { enum: auditActorTypes }).notNull(),
     eventType: text('event_type').notNull(),
     targetType: text('target_type').notNull(),
     targetId: text('target_id'),

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -375,6 +375,7 @@ function auditRows(): ReadonlyArray<string> {
       // workspace trail.
       workspaceId: event.workspaceId ?? null,
       actorUserId: event.actorUserId ?? null,
+      actorType: event.actorType,
       eventType: event.eventType,
       targetType: event.targetType,
       targetId: event.targetId,


### PR DESCRIPTION
## Summary

- Record required invocation-provenance actorType on audit events: user, system, or api_token. Do not infer it from event names or the presence of a user foreign key, and do not constrain event/actor combinations with an allowlist.
- Propagate truthful provenance through web sessions, background jobs, REST API tokens, and MCP token versus OAuth callers. Keep Seed and Live adapters equivalent and expose actor type in audit views and exports.
- Reject missing provenance at the write boundary and in D1, with no silent database user default.

## Review and integration

Independent thermo-nuclear maintainability and Effect reviews were completed before integration, as recorded in the coordinator handoff. The reviewed fixes are preserved.

Fetched origin and rebased only item commit 126110f1541c67f31ab8dbb86c9af37789f99c97 onto master at a900f2c8. No old base commits were replayed. Resolved two test-only conflicts by retaining master's Effect test runners and the reviewed audit assertions. Updated the new MCP provenance tests to actual @effect/vitest cases without lint suppressions. No additional workers or reviews were started.

## Validation

- pnpm run check: passed, true exit status 0. Includes typecheck, lint, formatting, dead-code checks, and all unit/integration tests with capability coverage thresholds.
- pnpm run build: passed, including the client-bundle boundary check.
- pnpm run infra:wrangler followed by git diff --exit-code: passed, no generated config drift.
- pnpm run db:generate: passed with no schema changes and no new migration output.
- git diff --check: passed.
- Browser E2E was not run locally; the repository CI runs it.

Full validation logs are retained outside the repository. No lockfile upgrades, backlog documents, briefs, or logs are included.

## Destructive preproduction migration

The migration intentionally DELETEs all existing audit_events rows before adding the required actor_type column. Old audit history lacks invocation provenance and cannot be truthfully backfilled. This is a destructive preproduction audit-history reset, not a compatibility migration. All previous audit history is lost when this migration runs; other application data is not reset.