### PR TITLE
refactor(api): derive REST handlers and MCP tools from one operation catalog

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -6,21 +6,23 @@ Cloudflare Worker for external REST clients and MCP. Serves the `StarterApi` con
 
 ## Entry Points & Contracts
 
-- `src/operations.ts` is the one table of workspace reads: REST handlers, MCP tools, the discovery document and the permission matrix derive from it.
+- `src/operations.ts` catalogs workspace reads and mutations. REST handlers and the permission matrix use both; MCP tools and discovery use explicitly opted-in rows (ADR 0072).
 - `src/request-guards.ts` holds every guard; compose these instead of a second auth path.
 
 ## Usage Patterns
 
 - Change the contract in `packages/api` first, then the handler. An endpoint's error channel stays a subset of its contract errors.
+- Yield stable capability services once in the handler layer. Resolve `WorkspaceContext`, actor, request origin, and log scope per request. Translate expected domain errors at the route boundary; let contract schemas encode declared failures.
 - A handler is `observed(...)` around `enforcePermission(permission, slug)` plus one capability call. Auth and the bucket come from `BearerAuth`, so no handler reads `Authorization`.
 - Endpoints name permissions, never scopes. [`authz`](../../packages/authz/AGENTS.md) owns the scope-to-permission map, so a token and a web session resolve through one `authorize()`.
 - `provideWorkspace` builds the only request-scoped service, `WorkspaceContext`; the rest are isolate-level, reached through `HttpRouter.provideRequest`.
-- Two credentials open `/mcp` (ADR 0068): a JWT goes to the OAuth verifier, anything else to the API Token path. A token authorizes as its scopes, an OAuth caller as the Member re-resolved per call, so removals and role changes apply at once. Both draw the `mcp` bucket and reject via `guardFailureResponse`. The gate is route-scoped router middleware around Effect `McpServer.layerHttp`'s routes (`mcp.ts`), because the transport owns the handlers; the verified caller travels to tool handlers as the `CurrentMcpCaller` reference, which Effect's RPC plumbing merges into every invocation from the request fiber.
+- MCP JWTs use OAuth verification; other credentials use API Token verification (ADR 0068). Tokens authorize by scopes, OAuth by Member re-resolved per call. Both use the `mcp` bucket and `guardFailureResponse`. Router middleware gates the transport; `CurrentMcpCaller` travels through Effect RPC request-fiber context to each tool. Preserve `api_token` versus OAuth `user` audit provenance.
 
 ## Anti-patterns
 
 - No hand-rolled validation; tighten the schema. No minted trace ids; read `currentTraceId`.
 - Do not accept a JWT on a REST route; OAuth is the interactive surface only.
+- A mutation's presence in the catalog never exposes an MCP tool. Opt-in requires reviewed input/output schemas, per-tool permission enforcement, and truthful read-only, destructive, idempotent, and open-world annotations (ADR 0072).
 - Do not add a membership or invitation endpoint: Better Auth `organization` writes are `requireHeaders: true` and a bearer token is no session (ARCHITECTURE.md, #64). That surface stays in `apps/web`, so this worker wires no `EmailDispatcher` and no `EMAIL` binding.
 - No OTLP exporter at isolate level (ADR 0050): a Worker may not do I/O for a request that already ended. `withHttpInvocation` builds it per request; only `WideEventLoggerLive` is isolate-level.
 
@@ -31,9 +33,9 @@ Cloudflare Worker for external REST clients and MCP. Serves the `StarterApi` con
 
 ## Patterns & Pitfalls
 
-- The capability layer value is `HttpRouter.provideRequest`ed **and** `Layer.provide`d to the api layer, because `BearerAuth` resolves services from the group layers' build context. One value, one build, one shared instance. The gate runs before the handler body, so rejections emit their own wide event.
+- Provide the same capability layer through both `HttpRouter.provideRequest` and `Layer.provide`: `BearerAuth` and handler construction need the build context. Gate rejections emit their own wide event before the handler runs.
 - A gated group with no bucket row fails closed with 503; `permission-matrix.test.ts` asserts none is missing.
-- `POST /mcp` has no route-level permission check by design: every minted credential clears `mcp:read`, so a gate could never deny. Enforcement is per tool. The transport is sessionful (initialize mints an `mcp-session-id`; sessions live in isolate memory), `GET /mcp` answers 405, and the REST discovery document the contract serves is at `GET /mcp/discovery`.
+- `POST /mcp` has no route permission: every credential clears `mcp:read`; enforce per tool. Keep sessions in isolate memory, initialization's `mcp-session-id`, `GET /mcp` 405, and discovery at `GET /mcp/discovery`.
 - `CurrentMcpCaller` is a `Context.Reference` with an `undefined` default, not a required service: absence is caught by `requireCaller` and answered with `InternalError`, so a gate-ordering mistake is a typed failure, not a defect on the model-facing surface.
 - `makeOAuthTokenVerifierLayer` throws before returning its error-free layer for a non-`https:` production JWKS URL; this synchronous factory has no typed error channel, so it refuses initialization on the first request, matching `apps/web`'s env gate. Unset OAuth env leaves the verifier inactive.
 - Export-download refusals are all one 404 (ADR 0055), rate-limited by client IP so signatures cannot be brute-forced.

--- a/apps/api/src/handlers.ts
+++ b/apps/api/src/handlers.ts
@@ -1,38 +1,29 @@
 import { type PermissionRequest } from '@b2b-saas-starter/authz/client'
-import { ApiTokenRegistry } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
-import {
-  type UpdateWebhookEndpointInput,
-  WebhookEndpoints
-} from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
-import { WorkspaceExports } from '@b2b-saas-starter/capabilities/governance/workspace-export'
 import { type ListPageInput } from '@b2b-saas-starter/capabilities/internal/keyset-cursor'
-import { StarterApi, type QueuedDeliveryResponse } from '@b2b-saas-starter/api'
-import { WorkspaceExportNotDownloadable } from '@b2b-saas-starter/api/errors'
+import { ApiTokenRegistry } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
+import { WebhookEndpoints } from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
+import { WorkspaceExports } from '@b2b-saas-starter/capabilities/governance/workspace-export'
+import { StarterApi } from '@b2b-saas-starter/api'
 import { AssistantService, isAssistantConfigured } from '@b2b-saas-starter/ai'
-import { Effect, Option } from 'effect'
-import { HttpServerRequest } from 'effect/unstable/http'
+import { Context, Effect } from 'effect'
+import { type HttpServerRequest } from 'effect/unstable/http'
 import { HttpApiBuilder } from 'effect/unstable/httpapi'
 
 import { type ApiEnv } from './env.ts'
-import {
-  enforcePermission,
-  observed,
-  provideWorkspace,
-  webRequest
-} from './request-guards.ts'
+import { enforcePermission, observed, provideWorkspace } from './request-guards.ts'
 import { mcpDiscoveryDocument } from './mcp.ts'
-import { READ_OPERATIONS, type ReadOperationEndpoint } from './operations.ts'
+import {
+  type MutationRequestOptions,
+  MUTATION_OPERATIONS,
+  READ_OPERATIONS
+} from './operations.ts'
 
 /**
- * Contract response literals. Each is declared with the literal type the
- * `StarterApi` success schema pins down, so the value is *checked* against the
- * contract instead of asserted with `as const`.
+ * Contract response literal. Declared with the literal type the `StarterApi`
+ * success schema pins down, so the value is *checked* against the contract
+ * instead of asserted with `as const`.
  */
 const HEALTH_OK = { status: 'ok' } satisfies { readonly status: 'ok' }
-const TOKEN_REVOKED = { status: 'revoked' } satisfies { readonly status: 'revoked' }
-const WEBHOOK_DELETED = {
-  status: 'deleted'
-} satisfies { readonly status: 'deleted' }
 
 /**
  * The one wrapper every workspace-scoped handler composes — reads and writes
@@ -40,8 +31,8 @@ const WEBHOOK_DELETED = {
  * wide event. Bearer auth and the group's rate-limit bucket are the contract's
  * `BearerAuth` middleware's job, so a handler composes only this and the
  * capability call. The event name is passed whole — reads sit under
- * `workspace.*` (see `workspaceRead`), writes name themselves
- * (`api-tokens.create`).
+ * `workspace.*` (see `workspaceRead`), a write's table key is its event
+ * (`api-tokens.create`, see `workspaceWrite`).
  *
  * Every REST workspace operation rides a bearer token, so the workspace layer
  * the body runs against carries the `api_token` caller kind — the label a
@@ -77,23 +68,12 @@ export function healthGroup(env: ApiEnv) {
 
 export function workspaceGroup(env: ApiEnv) {
   return HttpApiBuilder.group(StarterApi, 'workspace', (handlers) => {
-    /**
-     * Generic in the row, not in the key: the call site hands over the table
-     * entry itself, so `A`/`E`/`R` are inferred from that row's own capability
-     * read. That is what lets the contract's success and error schemas check
-     * the handler — a row whose read stopped answering what its endpoint
-     * declares fails here, at compile time, with no channel widening in
-     * between. (Taking the key and indexing `READ_OPERATIONS` inside the body
-     * cannot work: within the generic body the index resolves to the union of
-     * all six rows, and TypeScript rejects the union against any one
-     * endpoint's schema.) The key rides along as `event` — the table's key is
-     * the wide-event name under `workspace.` — and the row's own `read`
-     * signature dictates whether `params` must carry `endpointId` — a
-     * parameterized row requires it.
-     */
+    // Infer each concrete row's input, success, errors, and requirements rather
+    // than widening to the union of reads. HttpApiBuilder checks the result
+    // against that endpoint's contract. Parameterized reads require endpointId.
     function workspaceRead<Args extends { readonly endpointId?: string }, A, E, R>(
-      event: ReadOperationEndpoint,
       op: {
+        readonly endpoint: { readonly identifier: string }
         readonly permission: PermissionRequest
         readonly read: (
           page: ListPageInput | undefined,
@@ -110,7 +90,7 @@ export function workspaceGroup(env: ApiEnv) {
       // same way the write handlers annotate ids below.
       return workspaceOperation(
         env,
-        `workspace.${event}`,
+        `workspace.${op.endpoint.identifier}`,
         op.permission,
         params.slug,
         request,
@@ -128,220 +108,91 @@ export function workspaceGroup(env: ApiEnv) {
     // so the two Capability Interfaces cannot disagree about permissions.
     return handlers
       .handle('overview', ({ params, request }) =>
-        workspaceRead('overview', READ_OPERATIONS.overview, params, undefined, request)
+        workspaceRead(READ_OPERATIONS.overview, params, undefined, request)
       )
       .handle('members', ({ params, query, request }) =>
-        workspaceRead('members', READ_OPERATIONS.members, params, query, request)
+        workspaceRead(READ_OPERATIONS.members, params, query, request)
       )
       .handle('notifications', ({ params, query, request }) =>
-        workspaceRead(
-          'notifications',
-          READ_OPERATIONS.notifications,
-          params,
-          query,
-          request
-        )
+        workspaceRead(READ_OPERATIONS.notifications, params, query, request)
       )
       .handle('api-tokens', ({ params, query, request }) =>
-        workspaceRead(
-          'api-tokens',
-          READ_OPERATIONS['api-tokens'],
-          params,
-          query,
-          request
-        )
+        workspaceRead(READ_OPERATIONS['api-tokens'], params, query, request)
       )
       .handle('webhooks', ({ params, query, request }) =>
-        workspaceRead('webhooks', READ_OPERATIONS.webhooks, params, query, request)
+        workspaceRead(READ_OPERATIONS.webhooks, params, query, request)
       )
       .handle('webhook-deliveries', ({ params, request }) =>
-        workspaceRead(
-          'webhook-deliveries',
-          READ_OPERATIONS['webhook-deliveries'],
-          params,
-          undefined,
-          request
-        )
+        workspaceRead(READ_OPERATIONS['webhook-deliveries'], params, undefined, request)
       )
       .handle('audit-events', ({ params, query, request }) =>
-        workspaceRead(
-          'audit-events',
-          READ_OPERATIONS['audit-events'],
-          params,
-          query,
-          request
-        )
+        workspaceRead(READ_OPERATIONS['audit-events'], params, query, request)
       )
   })
 }
 
+/** Preserve each row's input, result and errors through contract registration. */
+function workspaceWrites<Services>(
+  env: ApiEnv,
+  services: Context.Context<Services>,
+  eventPrefix: string
+) {
+  return function workspaceWrite<Options extends MutationRequestOptions, A, E, R>(op: {
+    readonly endpoint: { readonly identifier: string }
+    readonly permission: PermissionRequest
+    readonly run: (options: Options) => Effect.Effect<A, E, R>
+  }) {
+    return (
+      options: Options & { readonly request: HttpServerRequest.HttpServerRequest }
+    ) =>
+      workspaceOperation(
+        env,
+        `${eventPrefix}.${op.endpoint.identifier}`,
+        op.permission,
+        options.params.slug,
+        options.request,
+        Effect.suspend(() => op.run(options)).pipe(Effect.provide(services))
+      )
+  }
+}
+
+// Explicit endpoint bindings preserve HttpApiBuilder's per-endpoint schema
+// checks. Permissions, calls and response/error shaping belong to the rows.
 export function apiTokenGroup(env: ApiEnv) {
   return HttpApiBuilder.group(StarterApi, 'api-token-registry', (handlers) =>
-    handlers
-      .handle('create', ({ params, payload, request }) =>
-        workspaceOperation(
-          env,
-          'api-tokens.create',
-          { apiToken: ['create'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const tokens = yield* ApiTokenRegistry
-            // The entitlement gate and the webhook fan-out live inside the
-            // capability, below the interface — identical for every surface.
-            const created = yield* tokens.create({
-              name: payload.name,
-              scopes: payload.scopes
-            })
-            yield* Effect.annotateLogsScoped({
-              tokenId: created.id,
-              tokenScopes: created.scopes
-            })
-            return created
-          })
-        )
+    Effect.gen(function* () {
+      const tokens = yield* ApiTokenRegistry
+      const write = workspaceWrites(
+        env,
+        Context.make(ApiTokenRegistry, tokens),
+        'api-tokens'
       )
-      .handle('delete', ({ params, request }) =>
-        workspaceOperation(
-          env,
-          'api-tokens.delete',
-          { apiToken: ['revoke'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const tokens = yield* ApiTokenRegistry
-            yield* tokens.revoke({ tokenId: params.tokenId })
-            return TOKEN_REVOKED
-          })
-        )
-      )
+      return handlers.handleAll({
+        create: write(MUTATION_OPERATIONS['api-tokens.create']),
+        delete: write(MUTATION_OPERATIONS['api-tokens.delete'])
+      })
+    })
   )
 }
 
 export function webhookGroup(env: ApiEnv) {
   return HttpApiBuilder.group(StarterApi, 'webhook-endpoints', (handlers) =>
-    handlers
-      .handle('create', ({ params, payload, request }) =>
-        workspaceOperation(
-          env,
-          'webhooks.create',
-          { webhook: ['create'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const webhooks = yield* WebhookEndpoints
-            const created = yield* webhooks.create({
-              url: payload.url,
-              events: payload.events,
-              description: payload.description
-            })
-            yield* Effect.annotateLogsScoped({ webhookEndpointId: created.endpoint.id })
-            return created.endpoint
-          })
-        )
+    Effect.gen(function* () {
+      const webhooks = yield* WebhookEndpoints
+      const write = workspaceWrites(
+        env,
+        Context.make(WebhookEndpoints, webhooks),
+        'webhooks'
       )
-      .handle('update', ({ params, payload, request }) =>
-        workspaceOperation(
-          env,
-          'webhooks.update',
-          { webhook: ['update'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const webhooks = yield* WebhookEndpoints
-            const patch: UpdateWebhookEndpointInput = {
-              endpointId: params.endpointId
-            }
-            if (payload.url !== undefined) {
-              patch.url = payload.url
-            }
-            if (payload.events !== undefined) {
-              patch.events = payload.events
-            }
-            if (payload.enabled !== undefined) {
-              patch.enabled = payload.enabled
-            }
-            const updated = yield* webhooks.update(patch)
-            yield* Effect.annotateLogsScoped({ webhookEndpointId: updated.id })
-            return updated
-          })
-        )
-      )
-      .handle('delete', ({ params, request }) =>
-        workspaceOperation(
-          env,
-          'webhooks.delete',
-          { webhook: ['delete'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const webhooks = yield* WebhookEndpoints
-            // A no-match delete fails the capability's typed 404 — the same
-            // `WebhookEndpointNotFound` the contract declares.
-            yield* webhooks.delete({ endpointId: params.endpointId })
-            return WEBHOOK_DELETED
-          })
-        )
-      )
-      .handle('rotate-secret', ({ params, request }) =>
-        workspaceOperation(
-          env,
-          'webhooks.rotate-secret',
-          { webhook: ['rotateSecret'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const webhooks = yield* WebhookEndpoints
-            // The new secret rides this one response only — the same one-time
-            // reveal the web surface gives the operator.
-            const rotated = yield* webhooks.rotateSecret({
-              endpointId: params.endpointId
-            })
-            yield* Effect.annotateLogsScoped({ webhookEndpointId: params.endpointId })
-            return { signingSecret: rotated.signingSecret }
-          })
-        )
-      )
-      .handle('test-event', ({ params, request }) =>
-        workspaceOperation(
-          env,
-          'webhooks.test-event',
-          { webhook: ['test'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const webhooks = yield* WebhookEndpoints
-            const sent = yield* webhooks.sendTestEvent({
-              endpointId: params.endpointId
-            })
-            yield* Effect.annotateLogsScoped({ deliveryId: sent.deliveryId })
-            return {
-              status: 'queued',
-              deliveryId: sent.deliveryId
-            } satisfies QueuedDeliveryResponse
-          })
-        )
-      )
-      .handle('replay-delivery', ({ params, request }) =>
-        workspaceOperation(
-          env,
-          'webhooks.replay-delivery',
-          { webhook: ['replay'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const webhooks = yield* WebhookEndpoints
-            const replayed = yield* webhooks.replayDelivery({
-              deliveryId: params.deliveryId
-            })
-            yield* Effect.annotateLogsScoped({ deliveryId: replayed.deliveryId })
-            return {
-              status: 'queued',
-              deliveryId: replayed.deliveryId
-            } satisfies QueuedDeliveryResponse
-          })
-        )
-      )
+      return handlers.handleAll({
+        create: write(MUTATION_OPERATIONS['webhooks.create']),
+        update: write(MUTATION_OPERATIONS['webhooks.update']),
+        delete: write(MUTATION_OPERATIONS['webhooks.delete']),
+        'rotate-secret': write(MUTATION_OPERATIONS['webhooks.rotate-secret']),
+        'test-event': write(MUTATION_OPERATIONS['webhooks.test-event']),
+        'replay-delivery': write(MUTATION_OPERATIONS['webhooks.replay-delivery'])
+      })
+    })
   )
 }
 
@@ -388,62 +239,25 @@ export function mcpGroup(env: ApiEnv) {
 }
 
 /**
- * Workspace data export over the REST surface (ADR 0055). `request` enqueues
- * the job; `download-link` mints the signed URL, re-checking the permission on
- * the way — the link then points at the public signed route on this worker,
- * so it is prefixed with this request's own origin.
+ * Workspace data export over the REST surface (ADR 0055): `request` enqueues
+ * the job; `download-link` mints the signed URL, re-checking the permission
+ * on the way — the link then points at the public signed route on this worker,
+ * so it is prefixed with this request's own origin (the one request-derived
+ * success in the table; see the download-link row).
  */
 export function workspaceExportGroup(env: ApiEnv) {
   return HttpApiBuilder.group(StarterApi, 'workspace-exports', (handlers) =>
-    handlers
-      .handle('request', ({ params, request }) =>
-        workspaceOperation(
-          env,
-          'workspace-exports.request',
-          { workspaceExport: ['request'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const exports = yield* WorkspaceExports
-            const created = yield* exports.request
-            yield* Effect.annotateLogsScoped({ exportId: created.id })
-            return created
-          })
-        )
+    Effect.gen(function* () {
+      const exports = yield* WorkspaceExports
+      const write = workspaceWrites(
+        env,
+        Context.make(WorkspaceExports, exports),
+        'workspace-exports'
       )
-      .handle('download-link', ({ params, request }) =>
-        workspaceOperation(
-          env,
-          'workspace-exports.download-link',
-          { workspaceExport: ['download'] },
-          params.slug,
-          request,
-          Effect.gen(function* () {
-            const exports = yield* WorkspaceExports
-            const link = yield* exports.issueDownloadLink({ exportId: params.exportId })
-            if (Option.isNone(link)) {
-              return yield* new WorkspaceExportNotDownloadable({
-                exportId: params.exportId
-              })
-            }
-            const origin = yield* requestOrigin
-            yield* Effect.annotateLogsScoped({ exportId: params.exportId })
-            return {
-              url: `${origin}${link.value.path}`,
-              expiresAt: link.value.expiresAt
-            }
-          })
-        )
-      )
+      return handlers.handleAll({
+        request: write(MUTATION_OPERATIONS['workspace-exports.request']),
+        'download-link': write(MUTATION_OPERATIONS['workspace-exports.download-link'])
+      })
+    })
   )
 }
-
-/**
- * This request's own origin — where the signed download route lives — read off
- * the worker's `Request` behind the router's request, the same `webRequest`
- * conversion `observed` uses (as the `/mcp` challenge header does).
- */
-const requestOrigin = Effect.map(
-  HttpServerRequest.HttpServerRequest,
-  (request) => new URL(webRequest(request).url).origin
-)

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -219,6 +219,72 @@ describe('contract-served routes', () => {
     })
   )
 
+  it.effect(
+    'revoking removes the token projection and repeated revocation still succeeds',
+    () =>
+      Effect.gen(function* () {
+        const created = yield* send(
+          post(
+            '/workspaces/starter-lab/api-tokens',
+            {
+              name: 'Revocation test',
+              scopes: ['read']
+            },
+            bearer
+          )
+        )
+        expect(created.status).toBe(201)
+        const token = yield* jsonBody(created, CreatedTokenBody)
+        const TokenPage = Schema.Struct({
+          items: Schema.Array(Schema.Struct({ id: Schema.String }))
+        })
+        const before = yield* send(get('/workspaces/starter-lab/api-tokens', bearer))
+        expect(
+          (yield* jsonBody(before, TokenPage)).items.some(
+            (item) => item.id === token.id
+          )
+        ).toBe(true)
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          const revoked = yield* send(
+            new Request(
+              `https://api.test/workspaces/starter-lab/api-tokens/${token.id}`,
+              {
+                method: 'DELETE',
+                headers: bearer
+              }
+            )
+          )
+          expect(revoked.status).toBe(200)
+          expect(
+            yield* jsonBody(
+              revoked,
+              Schema.Struct({ status: Schema.Literal('revoked') })
+            )
+          ).toEqual({ status: 'revoked' })
+        }
+        const after = yield* send(get('/workspaces/starter-lab/api-tokens', bearer))
+        expect(
+          (yield* jsonBody(after, TokenPage)).items.some((item) => item.id === token.id)
+        ).toBe(false)
+      })
+  )
+
+  for (const route of [
+    { path: 'webhooks/wh_absent/rotate-secret', tag: 'WebhookEndpointNotFound' },
+    { path: 'webhooks/wh_absent/test-event', tag: 'WebhookEndpointNotFound' },
+    { path: 'webhooks/deliveries/whd_absent/replay', tag: 'WebhookDeliveryNotFound' }
+  ]) {
+    it.effect(`${route.path} preserves the typed 404`, () =>
+      Effect.gen(function* () {
+        const response = yield* send(
+          post(`/workspaces/starter-lab/${route.path}`, {}, bearer)
+        )
+        expect(response.status).toBe(404)
+        expect((yield* jsonBody(response, ErrorBody))._tag).toBe(route.tag)
+      })
+    )
+  }
+
   it.effect('POST create webhook rejects invalid destinations', () =>
     Effect.gen(function* () {
       const res = yield* send(
@@ -610,6 +676,22 @@ describe('workspace exports (ADR 0055)', () => {
       const bytes = new Uint8Array(yield* Effect.promise(() => download.arrayBuffer()))
       // Gzip magic bytes: 0x1f 0x8b.
       expect([...bytes.subarray(0, 2)]).toEqual([0x1f, 0x8b])
+    })
+  )
+
+  it.effect('download-link resolves origin per request on the same handler', () =>
+    Effect.gen(function* () {
+      for (const origin of ['https://first.api.test', 'https://second.api.test']) {
+        const response = yield* send(
+          new Request(
+            `${origin}/workspaces/starter-lab/exports/${seedWorkspaceExportFixture.id}/download-link`,
+            { method: 'POST', headers: bearer }
+          )
+        )
+        expect(response.status).toBe(200)
+        const link = yield* jsonBody(response, DownloadLinkBody)
+        expect(new URL(link.url).origin).toBe(origin)
+      }
     })
   )
 

--- a/apps/api/src/mcp.test.ts
+++ b/apps/api/src/mcp.test.ts
@@ -24,7 +24,7 @@ describe('mcp ↔ rest operation mirror', () => {
     for (const [index, operation] of readOperations().entries()) {
       const tool = mcpDiscoveryDocument().tools[index]
       expect(tool?.description).toContain(
-        `Mirrors GET /${mirroredRestPath(operation.path)}.`
+        `Mirrors GET /${mirroredRestPath(operation.endpoint.path)}.`
       )
     }
   })
@@ -113,7 +113,12 @@ function Ok<Result extends Schema.Top>(result: Result) {
 }
 
 const ToolListResult = Schema.Struct({
-  tools: Schema.Array(Schema.Struct({ name: Schema.String }))
+  tools: Schema.Array(
+    Schema.Struct({
+      name: Schema.String,
+      annotations: Schema.Struct({ readOnlyHint: Schema.Boolean })
+    })
+  )
 })
 const CallToolResult = Schema.Struct({
   content: Schema.Array(Schema.Struct({ type: Schema.String, text: Schema.String })),
@@ -138,6 +143,30 @@ const GuardFailureBody = Schema.Struct({
 })
 
 describe('POST /mcp protocol', () => {
+  it.effect(
+    'admin credentials expose only read tools, with read-only annotations',
+    () =>
+      Effect.gen(function* () {
+        const client = mcpClient(handler, bearer.authorization)
+        yield* Effect.promise(() => client.initialize())
+        const response = yield* Effect.promise(() => client.rpc('tools/list', {}))
+        const body = yield* jsonBody(response, Ok(ToolListResult))
+        // This is the permitted public tool contract, independent of catalog rows.
+        expect(body.result.tools.map((tool) => tool.name).toSorted()).toEqual([
+          'get_workspace_overview',
+          'list_api_tokens',
+          'list_audit_events',
+          'list_members',
+          'list_notifications',
+          'list_webhook_deliveries',
+          'list_webhooks'
+        ])
+        expect(body.result.tools.every((tool) => tool.annotations.readOnlyHint)).toBe(
+          true
+        )
+      })
+  )
+
   it.effect('a session-initialized client lists tools and calls them', () =>
     Effect.gen(function* () {
       const client = mcpClient(handler, bearer.authorization)

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -7,7 +7,7 @@ import { requirePermission } from '@b2b-saas-starter/authz/guard'
 import {
   mirroredRestPath,
   READ_OPERATIONS,
-  readOperations,
+  mcpToolOperations,
   type CapabilityRead,
   type CapabilityReadError,
   type CapabilityReadServices,
@@ -78,7 +78,10 @@ import {
  *
  * `GET /mcp/discovery` remains the REST discovery document served by the
  * contract group; it advertises exactly what this module registers. (`GET
- * /mcp` itself is `layerHttp`'s: 405, no SSE stream to open.)
+ * /mcp` itself is `layerHttp`'s: 405, no SSE stream to open.) The registered
+ * tools are the operation table's tool-projecting rows — every read, no
+ * mutation; the write-tool boundary is a per-row decision recorded in
+ * ADR 0072.
  *
  * Two credentials open the route (ADR 0068): a workspace API Token, or an
  * OAuth access token the web worker minted for a signed-in Member after the
@@ -181,11 +184,13 @@ function toolInput(operation: WorkspaceReadOperation): ToolJsonSchema {
 /**
  * One tool descriptor, projected from one row of the shared operation table
  * (operations.ts) rather than hand-mirrored: same name, same permission, same
- * capability read as the REST endpoint it names. Every tool is a read over a
- * surviving capability — MCP exposes what REST exposes, nothing resurrected.
+ * capability read as the REST endpoint it names. Only rows that declare a
+ * tool projection reach here — every read today, no mutation (ADR 0072) — so
+ * MCP exposes what REST exposes, nothing resurrected and nothing destructive
+ * until a row says otherwise.
  */
 function toolDescription(operation: WorkspaceReadOperation): string {
-  return `${operation.toolDescription} Mirrors GET /${mirroredRestPath(operation.path)}.`
+  return `${operation.toolDescription} Mirrors GET /${mirroredRestPath(operation.endpoint.path)}.`
 }
 
 /**
@@ -207,7 +212,7 @@ export function mcpDiscoveryDocument(): McpDiscovery {
   return {
     name: MCP_SERVER_NAME,
     resources: [OVERVIEW_RESOURCE_URI],
-    tools: readOperations().map(toolProjection)
+    tools: mcpToolOperations().map(toolProjection)
   }
 }
 
@@ -353,21 +358,23 @@ function decodeOperationInput(
   return Effect.gen(function* () {
     if (operation.param !== undefined) {
       const args = yield* decodeEndpointIdInput(payload ?? {}).pipe(invalidParams)
-      return operation.read(undefined, args)
+      return Effect.suspend(() => operation.read(undefined, args))
     }
     if (operation.paged) {
       const page = yield* decodePagedInput(payload ?? {}).pipe(invalidParams)
-      return operation.read(page)
+      return Effect.suspend(() => operation.read(page))
     }
-    return operation.read(undefined)
+    return Effect.suspend(() => operation.read(undefined))
   })
 }
 
 /**
- * Registers every read operation as an MCP tool. Each invocation re-checks
- * its own permission first — the route gate only proved the caller holds a
- * valid credential; a tool must never serve data its REST counterpart would
- * deny — and typed failures become `isError` results the model can read.
+ * Registers the tool-projecting rows of the operation table as MCP tools —
+ * today every read and no mutation, the per-row `mcpTool` decision of
+ * ADR 0072. Each invocation re-checks its own permission first — the route
+ * gate only proved the caller holds a valid credential; a tool must never
+ * serve data its REST counterpart would deny — and typed failures become
+ * `isError` results the model can read.
  */
 function registerTools(env: ApiEnv) {
   return Effect.gen(function* () {
@@ -376,7 +383,7 @@ function registerTools(env: ApiEnv) {
     // resolve them from this context rather than rebuilding any graph.
     const services = yield* Effect.context<CapabilityReadServices>()
 
-    for (const operation of readOperations()) {
+    for (const operation of mcpToolOperations()) {
       yield* registry.addTool({
         tool: new McpTool({
           ...toolProjection(operation),

--- a/apps/api/src/operation-authorization.test.ts
+++ b/apps/api/src/operation-authorization.test.ts
@@ -1,0 +1,84 @@
+import {
+  SEED_API_TOKEN,
+  SEED_READONLY_API_TOKEN
+} from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
+import { expect, it } from '@effect/vitest'
+import { Effect, Schema } from 'effect'
+import { buildWebHandler } from './http.ts'
+
+const Failure = Schema.Struct({ _tag: Schema.String })
+const encodeBody = Schema.encodeSync(Schema.fromJsonString(Schema.Json))
+
+it.effect('denied mutations leave the audit trail and token registry unchanged', () =>
+  Effect.gen(function* () {
+    const { handler } = buildWebHandler({})
+    function send(
+      method: string,
+      path: string,
+      token: string,
+      body?: typeof Schema.Json.Type
+    ) {
+      const options: RequestInit = {
+        method,
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json'
+        }
+      }
+      if (body !== undefined) {
+        options.body = encodeBody(body)
+      }
+      return Effect.promise(() =>
+        handler(new Request(`https://api.test/workspaces/starter-lab/${path}`, options))
+      )
+    }
+    const auditBefore = yield* send('GET', 'audit-events', SEED_API_TOKEN).pipe(
+      Effect.flatMap((response) => Effect.promise(() => response.json()))
+    )
+    const tokensBefore = yield* send('GET', 'api-tokens', SEED_API_TOKEN).pipe(
+      Effect.flatMap((response) => Effect.promise(() => response.json()))
+    )
+    // Independent requests, deliberately not generated from catalog fixtures.
+    // An absent target must still be denied before a capability can return 404.
+    for (const route of [
+      {
+        method: 'POST',
+        path: 'api-tokens',
+        body: { name: 'Escalation', scopes: ['admin'] }
+      },
+      { method: 'DELETE', path: 'api-tokens/tok_seed' },
+      { method: 'POST', path: 'exports' },
+      { method: 'POST', path: 'exports/exp_absent/download-link' },
+      {
+        method: 'POST',
+        path: 'webhooks',
+        body: { url: 'https://hooks.example.com/x', events: ['api_token.created'] }
+      },
+      { method: 'PATCH', path: 'webhooks/wh_absent', body: { enabled: false } },
+      { method: 'DELETE', path: 'webhooks/wh_absent' },
+      { method: 'POST', path: 'webhooks/wh_absent/rotate-secret' },
+      { method: 'POST', path: 'webhooks/wh_absent/test-event' },
+      { method: 'POST', path: 'webhooks/deliveries/whd_absent/replay' }
+    ]) {
+      const response = yield* send(
+        route.method,
+        route.path,
+        SEED_READONLY_API_TOKEN,
+        route.body
+      )
+      expect(response.status).toBe(403)
+      const failure = yield* Effect.promise(() => response.json()).pipe(
+        Effect.flatMap(Schema.decodeUnknownEffect(Failure))
+      )
+      expect(failure._tag).toBe('AuthorizationDenied')
+    }
+    for (const { path, expected } of [
+      { path: 'audit-events', expected: auditBefore },
+      { path: 'api-tokens', expected: tokensBefore }
+    ]) {
+      const response = yield* send('GET', path, SEED_API_TOKEN)
+      expect(response.status).toBe(200)
+      expect(yield* Effect.promise(() => response.json())).toEqual(expected)
+    }
+  })
+)

--- a/apps/api/src/operations.ts
+++ b/apps/api/src/operations.ts
@@ -1,33 +1,50 @@
+import {
+  ApiTokenApi,
+  WebhookApi,
+  WorkspaceApi,
+  WorkspaceExportApi,
+  type QueuedDeliveryResponse,
+  type DeletedResponse
+} from '@b2b-saas-starter/api'
+import { WorkspaceExportNotDownloadable } from '@b2b-saas-starter/api/errors'
 import { type PermissionRequest } from '@b2b-saas-starter/authz/client'
 import { type AuthorizationDenied } from '@b2b-saas-starter/authz/errors'
 import {
   type CapabilityUnavailable,
+  type PlanLimitExceeded,
   type WorkspaceNotFound
 } from '@b2b-saas-starter/capabilities/errors'
 import { type ListPageInput } from '@b2b-saas-starter/capabilities/internal/keyset-cursor'
 import { ApiTokenRegistry } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
-import { WebhookEndpoints } from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
+import {
+  type UpdateWebhookEndpointInput,
+  WebhookEndpoints,
+  type WebhookDeliveryNotFound,
+  type WebhookDispatchRejected,
+  type WebhookEndpointNotFound
+} from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
+import { type InvalidWebhookUrl } from '@b2b-saas-starter/capabilities/developer-platform/webhook-url'
 import { AuditEventLog } from '@b2b-saas-starter/capabilities/governance/audit-event-log'
+import { WorkspaceExports } from '@b2b-saas-starter/capabilities/governance/workspace-export'
 import { WorkspaceMembership } from '@b2b-saas-starter/capabilities/governance/workspace-membership'
 import { NotificationFeed } from '@b2b-saas-starter/capabilities/notifications/notification-feed'
 import { workspaceOverview } from '@b2b-saas-starter/capabilities/workspace-projections'
 import { type WorkspaceContext } from '@b2b-saas-starter/capabilities/workspace-context'
-import { Effect } from 'effect'
+import { Effect, Option, type Schema, type Scope } from 'effect'
+import { HttpServerRequest } from 'effect/unstable/http'
+import { type HttpApiEndpoint } from 'effect/unstable/httpapi'
+
+import { webRequest } from './request-guards.ts'
 
 /**
- * The one table behind both Capability Interfaces: every workspace read names
- * its permission and its capability read here, once. The REST group in
- * `handlers.ts` composes gate + read from these rows; the MCP tools in
- * `mcp.ts` are derived from them, so the two surfaces cannot disagree about
- * what a token may list or which service answers.
- *
- * Writes stay out of this table: only MCP's read-only projection is derived,
- * so a new mutation still means editing the REST group by hand — and getting
- * reviewed there — rather than appearing in MCP for free.
+ * Workspace reads and mutations share this catalog (ADR 0072). REST binds each
+ * row to its contract endpoint; the permission matrix enumerates both shapes.
+ * MCP tools and discovery select explicit opt-ins. Mutation `run` functions
+ * retain their inferred success and error channels for contract checking.
  */
 
 /**
- * Everything a table row can fail with: the guard's denial, the workspace
+ * Everything a read can fail with: the guard's denial, the workspace
  * layer's 404, and the capability layer's 503. Kept as a named union so MCP
  * can classify tool failures exhaustively instead of sniffing `_tag` off an
  * untyped promise rejection.
@@ -56,21 +73,15 @@ export type CapabilityRead = Effect.Effect<
   CapabilityReadServices | WorkspaceContext
 >
 
-export type ReadOperationEndpoint =
-  | 'overview'
-  | 'members'
-  | 'notifications'
-  | 'api-tokens'
-  | 'webhooks'
-  | 'webhook-deliveries'
-  | 'audit-events'
+type ReadOperationEndpoint = keyof typeof WorkspaceApi.endpoints
 
 /**
- * The one path parameter a read can take. Every operation is a whole-collection
- * read except the deliveries list, which addresses one endpoint.
+ * The one path parameter an operation can take besides `:slug`: a whole-
+ * collection read takes none, the deliveries read addresses one endpoint, and
+ * a mutation addresses the row its path names (`tokenId`, `endpointId`,
+ * `deliveryId`, `exportId`).
  */
-export type ReadOperationParam = {
-  readonly name: 'endpointId'
+type OperationParam = {
   /** A concrete value the permission matrix can build a real request with. */
   readonly sample: string
 }
@@ -82,13 +93,12 @@ export type ReadOperationParam = {
  * string to query with. Both REST (`handlers.ts`) and MCP (`mcp.ts`) narrow on
  * `param`, so neither can pass the wrong shape to a row's read.
  *
- * `path` is the URL segment under `/workspaces/{slug}/`, also the OpenAPI
- * template piece — and, because the contract names each read endpoint after
- * its path, the `workspace` group's endpoint identifier and the table's own
- * key. A `:param` piece in the template marks a parameterized read.
+ * `endpoint` references the contract's canonical path and schemas. The catalog
+ * adds capability behavior and permission policy, not a second wire contract.
  */
 export type CollectionReadOperation = {
-  readonly path: ReadOperationEndpoint
+  readonly mcpTool: true
+  readonly endpoint: HttpApiEndpoint.Top
   readonly permission: PermissionRequest
   readonly param?: undefined
   /**
@@ -107,9 +117,10 @@ export type CollectionReadOperation = {
 }
 
 export type ParameterizedReadOperation = {
-  readonly path: 'webhooks/:endpointId/deliveries'
+  readonly mcpTool: true
+  readonly endpoint: HttpApiEndpoint.Top
   readonly permission: PermissionRequest
-  readonly param: ReadOperationParam
+  readonly param: OperationParam
   /**
    * The page input rides along for a uniform call shape; the deliveries read
    * is capped by the capability (the 20 newest), not paged, and ignores it.
@@ -131,10 +142,11 @@ export type WorkspaceReadOperation =
 /**
  * The OpenAPI-style path of the mirrored REST route — `:endpointId` becomes
  * `{endpointId}` — so the MCP tool descriptions and the permission matrix
- * labels cannot drift from the contract's real template.
+ * labels cannot drift from the contract's real template. Reads and mutations
+ * alike: both row shapes reference their contract endpoint's full path.
  */
-export function mirroredRestPath(path: WorkspaceReadOperation['path']): string {
-  return `workspaces/{slug}/${path.replaceAll(/:(\w+)/g, '{$1}')}`
+export function mirroredRestPath(path: string): string {
+  return path.replace(/^\//, '').replaceAll(/:(\w+)/g, '{$1}')
 }
 
 /**
@@ -146,7 +158,8 @@ export function mirroredRestPath(path: WorkspaceReadOperation['path']): string {
  */
 export const READ_OPERATIONS = {
   overview: {
-    path: 'overview',
+    mcpTool: true,
+    endpoint: WorkspaceApi.endpoints.overview,
     permission: { notification: ['read'] },
     read: () => workspaceOverview,
     paged: false,
@@ -158,7 +171,8 @@ export const READ_OPERATIONS = {
   // by the plugin; see statements.ts. The plugin's `member` statement covers
   // mutations only — it has no `read` action.
   members: {
-    path: 'members',
+    mcpTool: true,
+    endpoint: WorkspaceApi.endpoints.members,
     permission: { ac: ['read'] },
     read: (page) =>
       Effect.flatMap(WorkspaceMembership, (membership) =>
@@ -169,7 +183,8 @@ export const READ_OPERATIONS = {
     toolDescription: 'List the workspace members and their roles.'
   },
   notifications: {
-    path: 'notifications',
+    mcpTool: true,
+    endpoint: WorkspaceApi.endpoints.notifications,
     permission: { notification: ['read'] },
     read: (page) => Effect.flatMap(NotificationFeed, (feed) => feed.listPage(page)),
     paged: true,
@@ -179,7 +194,8 @@ export const READ_OPERATIONS = {
   // A read scope may LIST tokens — wider than the `member` role, which cannot:
   // a token is minted by an owner or admin (see `readScopeStatements`).
   'api-tokens': {
-    path: 'api-tokens',
+    mcpTool: true,
+    endpoint: WorkspaceApi.endpoints['api-tokens'],
     permission: { apiToken: ['list'] },
     read: (page) => Effect.flatMap(ApiTokenRegistry, (tokens) => tokens.listPage(page)),
     paged: true,
@@ -187,7 +203,8 @@ export const READ_OPERATIONS = {
     toolDescription: 'List the workspace API token projections (never the secrets).'
   },
   webhooks: {
-    path: 'webhooks',
+    mcpTool: true,
+    endpoint: WorkspaceApi.endpoints.webhooks,
     permission: { webhook: ['list'] },
     read: (page) =>
       Effect.flatMap(WebhookEndpoints, (webhooks) => webhooks.listPage(page)),
@@ -196,9 +213,10 @@ export const READ_OPERATIONS = {
     toolDescription: 'List registered webhook endpoints and their success rates.'
   },
   'webhook-deliveries': {
-    path: 'webhooks/:endpointId/deliveries',
+    mcpTool: true,
+    endpoint: WorkspaceApi.endpoints['webhook-deliveries'],
     permission: { webhook: ['list'] },
-    param: { name: 'endpointId', sample: 'wh_release' },
+    param: { sample: 'wh_release' },
     read: (_page, args) =>
       Effect.flatMap(WebhookEndpoints, (webhooks) =>
         webhooks.listDeliveries({ endpointId: args.endpointId })
@@ -208,7 +226,8 @@ export const READ_OPERATIONS = {
       'List recent deliveries for one webhook endpoint, newest first, with response status and recorded evidence.'
   },
   'audit-events': {
-    path: 'audit-events',
+    mcpTool: true,
+    endpoint: WorkspaceApi.endpoints['audit-events'],
     permission: { auditLog: ['read'] },
     read: (page) => Effect.flatMap(AuditEventLog, (log) => log.list(page)),
     paged: true,
@@ -220,6 +239,280 @@ export const READ_OPERATIONS = {
 /** The table rows in contract order — what MCP tools and tests derive from. */
 export function readOperations(): ReadonlyArray<WorkspaceReadOperation> {
   return Object.values(READ_OPERATIONS)
+}
+
+/** Expected mutation failures; each concrete row retains its inferred subset. */
+type CapabilityMutationError =
+  | CapabilityUnavailable
+  | PlanLimitExceeded
+  | InvalidWebhookUrl
+  | WebhookEndpointNotFound
+  | WebhookDeliveryNotFound
+  | WebhookDispatchRejected
+  | WorkspaceExportNotDownloadable
+
+/** Stable services, separate from the request's workspace, actor and scope. */
+type CapabilityMutationServices = ApiTokenRegistry | WebhookEndpoints | WorkspaceExports
+
+/** Rows narrow this to their decoded path parameters and payload. */
+export type MutationRequestOptions = {
+  readonly params: { readonly slug: string }
+}
+
+/**
+ * `never` checks heterogeneous runs without widening their inputs. Callers
+ * use the concrete row, preserving its inferred success and error channels.
+ * Mutations require a separate MCP opt-in design, per ADR 0072.
+ */
+type WorkspaceMutationOperation = {
+  readonly endpoint: HttpApiEndpoint.Top
+  readonly permission: PermissionRequest
+  readonly param?: OperationParam
+  /** A concrete request body the permission matrix sends; absent when the endpoint declares no payload. */
+  readonly samplePayload?: typeof Schema.Json.Type
+  readonly run: (
+    options: never
+  ) => Effect.Effect<
+    unknown,
+    CapabilityMutationError,
+    | CapabilityMutationServices
+    | WorkspaceContext
+    | HttpServerRequest.HttpServerRequest
+    | Scope.Scope
+  >
+  readonly mcpTool: false
+}
+
+/** Response literals checked against the contract without assertions. */
+const TOKEN_REVOKED = { status: 'revoked' } satisfies { readonly status: 'revoked' }
+const WEBHOOK_DELETED = { status: 'deleted' } satisfies DeletedResponse
+
+/** Signed downloads use this request's origin, never the layer-build context. */
+const requestOrigin = Effect.map(
+  HttpServerRequest.HttpServerRequest,
+  (request) => new URL(webRequest(request).url).origin
+)
+
+/** Keys are existing wide-event names; rows follow contract group order. */
+export const MUTATION_OPERATIONS = {
+  'api-tokens.create': {
+    endpoint: ApiTokenApi.endpoints.create,
+    permission: { apiToken: ['create'] },
+    samplePayload: { name: 'CI token', scopes: ['read'] },
+    // The entitlement gate and the webhook fan-out live inside the
+    // capability, below the interface — identical for every surface.
+    run: (options: HttpApiEndpoint.Request<typeof ApiTokenApi.endpoints.create>) =>
+      Effect.gen(function* () {
+        const tokens = yield* ApiTokenRegistry
+        const created = yield* tokens.create({
+          name: options.payload.name,
+          scopes: options.payload.scopes
+        })
+        yield* Effect.annotateLogsScoped({
+          tokenId: created.id,
+          tokenScopes: created.scopes
+        })
+        return created
+      }),
+    mcpTool: false
+  },
+  // Revoking an unknown id answers `revoked` all the same: the capability
+  // resolves `false` and no typed failure exists for a no-match revoke.
+  'api-tokens.delete': {
+    endpoint: ApiTokenApi.endpoints.delete,
+    permission: { apiToken: ['revoke'] },
+    param: { sample: 'tok_seed' },
+    run: (options: HttpApiEndpoint.Request<typeof ApiTokenApi.endpoints.delete>) =>
+      Effect.gen(function* () {
+        const tokens = yield* ApiTokenRegistry
+        yield* tokens.revoke({ tokenId: options.params.tokenId })
+        return TOKEN_REVOKED
+      }),
+    mcpTool: false
+  },
+  // The endpoint projection rides the response; the one-time signing secret
+  // the capability also returns stays off the wire — the same split the web
+  // surface makes.
+  'webhooks.create': {
+    endpoint: WebhookApi.endpoints.create,
+    permission: { webhook: ['create'] },
+    samplePayload: {
+      url: 'https://hooks.example.com/x',
+      events: ['api_token.created']
+    },
+    run: (options: HttpApiEndpoint.Request<typeof WebhookApi.endpoints.create>) =>
+      Effect.gen(function* () {
+        const webhooks = yield* WebhookEndpoints
+        const created = yield* webhooks.create({
+          url: options.payload.url,
+          events: options.payload.events,
+          description: options.payload.description
+        })
+        yield* Effect.annotateLogsScoped({ webhookEndpointId: created.endpoint.id })
+        return created.endpoint
+      }),
+    mcpTool: false
+  },
+  'webhooks.update': {
+    endpoint: WebhookApi.endpoints.update,
+    permission: { webhook: ['update'] },
+    param: { sample: 'wh_release' },
+    samplePayload: { enabled: true },
+    run: (options: HttpApiEndpoint.Request<typeof WebhookApi.endpoints.update>) =>
+      Effect.gen(function* () {
+        const webhooks = yield* WebhookEndpoints
+        const patch: UpdateWebhookEndpointInput = {
+          endpointId: options.params.endpointId
+        }
+        if (options.payload.url !== undefined) {
+          patch.url = options.payload.url
+        }
+        if (options.payload.events !== undefined) {
+          patch.events = options.payload.events
+        }
+        if (options.payload.enabled !== undefined) {
+          patch.enabled = options.payload.enabled
+        }
+        const updated = yield* webhooks.update(patch)
+        yield* Effect.annotateLogsScoped({ webhookEndpointId: updated.id })
+        return updated
+      }),
+    mcpTool: false
+  },
+  // A no-match delete fails the capability's typed 404 — the same
+  // `WebhookEndpointNotFound` the contract declares.
+  'webhooks.delete': {
+    endpoint: WebhookApi.endpoints.delete,
+    permission: { webhook: ['delete'] },
+    param: { sample: 'wh_release' },
+    run: (options: HttpApiEndpoint.Request<typeof WebhookApi.endpoints.delete>) =>
+      Effect.gen(function* () {
+        const webhooks = yield* WebhookEndpoints
+        yield* webhooks.delete({ endpointId: options.params.endpointId })
+        return WEBHOOK_DELETED
+      }),
+    mcpTool: false
+  },
+  // The new secret rides this one response only — the same one-time reveal
+  // the web surface gives the operator.
+  'webhooks.rotate-secret': {
+    endpoint: WebhookApi.endpoints['rotate-secret'],
+    permission: { webhook: ['rotateSecret'] },
+    param: { sample: 'wh_release' },
+    run: (
+      options: HttpApiEndpoint.Request<(typeof WebhookApi.endpoints)['rotate-secret']>
+    ) =>
+      Effect.gen(function* () {
+        const webhooks = yield* WebhookEndpoints
+        const rotated = yield* webhooks.rotateSecret({
+          endpointId: options.params.endpointId
+        })
+        yield* Effect.annotateLogsScoped({
+          webhookEndpointId: options.params.endpointId
+        })
+        return { signingSecret: rotated.signingSecret }
+      }),
+    mcpTool: false
+  },
+  'webhooks.test-event': {
+    endpoint: WebhookApi.endpoints['test-event'],
+    permission: { webhook: ['test'] },
+    param: { sample: 'wh_release' },
+    run: (
+      options: HttpApiEndpoint.Request<(typeof WebhookApi.endpoints)['test-event']>
+    ) =>
+      Effect.gen(function* () {
+        const webhooks = yield* WebhookEndpoints
+        const sent = yield* webhooks.sendTestEvent({
+          endpointId: options.params.endpointId
+        })
+        yield* Effect.annotateLogsScoped({ deliveryId: sent.deliveryId })
+        return {
+          status: 'queued',
+          deliveryId: sent.deliveryId
+        } satisfies QueuedDeliveryResponse
+      }),
+    mcpTool: false
+  },
+  'webhooks.replay-delivery': {
+    endpoint: WebhookApi.endpoints['replay-delivery'],
+    permission: { webhook: ['replay'] },
+    param: { sample: 'whd_seed_failed' },
+    run: (
+      options: HttpApiEndpoint.Request<(typeof WebhookApi.endpoints)['replay-delivery']>
+    ) =>
+      Effect.gen(function* () {
+        const webhooks = yield* WebhookEndpoints
+        const replayed = yield* webhooks.replayDelivery({
+          deliveryId: options.params.deliveryId
+        })
+        yield* Effect.annotateLogsScoped({ deliveryId: replayed.deliveryId })
+        return {
+          status: 'queued',
+          deliveryId: replayed.deliveryId
+        } satisfies QueuedDeliveryResponse
+      }),
+    mcpTool: false
+  },
+  'workspace-exports.request': {
+    endpoint: WorkspaceExportApi.endpoints.request,
+    permission: { workspaceExport: ['request'] },
+    run: (
+      _options: HttpApiEndpoint.Request<typeof WorkspaceExportApi.endpoints.request>
+    ) =>
+      Effect.gen(function* () {
+        const exports = yield* WorkspaceExports
+        const created = yield* exports.request
+        yield* Effect.annotateLogsScoped({ exportId: created.id })
+        return created
+      }),
+    mcpTool: false
+  },
+  'workspace-exports.download-link': {
+    endpoint: WorkspaceExportApi.endpoints['download-link'],
+    permission: { workspaceExport: ['download'] },
+    param: { sample: 'exp_seed_ready' },
+    // A link this workspace cannot hand out — unknown, pending, failed,
+    // expired — is one typed 404 for every case, so a probing caller learns
+    // nothing about which.
+    run: (
+      options: HttpApiEndpoint.Request<
+        (typeof WorkspaceExportApi.endpoints)['download-link']
+      >
+    ) =>
+      Effect.gen(function* () {
+        const exports = yield* WorkspaceExports
+        const link = yield* exports.issueDownloadLink({
+          exportId: options.params.exportId
+        })
+        if (Option.isNone(link)) {
+          return yield* new WorkspaceExportNotDownloadable({
+            exportId: options.params.exportId
+          })
+        }
+        const origin = yield* requestOrigin
+        yield* Effect.annotateLogsScoped({ exportId: options.params.exportId })
+        return {
+          url: `${origin}${link.value.path}`,
+          expiresAt: link.value.expiresAt
+        }
+      }),
+    mcpTool: false
+  }
+} satisfies Record<string, WorkspaceMutationOperation>
+
+/** The mutation rows in contract order — what the permission matrix and tests derive from. */
+export function mutationOperations(): ReadonlyArray<
+  Omit<WorkspaceMutationOperation, 'run'>
+> {
+  return Object.values(MUTATION_OPERATIONS)
+}
+
+/** Explicit opt-in only. A tool name alone must never expose a mutation. */
+export function mcpToolOperations(): ReadonlyArray<WorkspaceReadOperation> {
+  return [...readOperations(), ...mutationOperations()].filter(
+    (operation) => operation.mcpTool
+  )
 }
 
 /** `notification:read`-style label, used by the permission matrix output. */

--- a/apps/api/src/permission-matrix.test.ts
+++ b/apps/api/src/permission-matrix.test.ts
@@ -1,9 +1,15 @@
 import { SEED_READONLY_API_TOKEN } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
+import { authorize, tokenPrincipal } from '@b2b-saas-starter/authz/client'
 import { BearerAuth, rateLimitBucketFor, StarterApi } from '@b2b-saas-starter/api'
 import { describe, expect, it } from '@effect/vitest'
 import { Effect, Schema } from 'effect'
 import { buildWebHandler } from './http.ts'
-import { mirroredRestPath, permissionLabel, readOperations } from './operations.ts'
+import {
+  mirroredRestPath,
+  mutationOperations,
+  permissionLabel,
+  readOperations
+} from './operations.ts'
 
 /**
  * The route-to-permission table of `handlers.ts`, asserted end to end.
@@ -82,100 +88,31 @@ const SLUG = 'starter-lab'
  * Parameterized rows build their request with the row's own sample value.
  */
 const READ_ROWS: ReadonlyArray<GatedOperation> = readOperations().map((op) => ({
-  operation: `GET /${mirroredRestPath(op.path)}`,
+  operation: `GET /${mirroredRestPath(op.endpoint.path)}`,
   permission: permissionLabel(op.permission),
   expected: 200,
   request: makeRequest(
     'GET',
-    `/workspaces/${SLUG}/${op.path.replaceAll(':endpointId', op.param?.sample ?? '')}`
+    op.endpoint.path
+      .replace(':slug', SLUG)
+      .replaceAll(':endpointId', op.param?.sample ?? '')
   )
 }))
 
 const MATRIX: ReadonlyArray<GatedOperation> = [
   ...READ_ROWS,
-
-  // Minting is the one mutation a `write` token is refused as well: a token
-  // allowed to create tokens could issue itself an `admin` one.
-  {
-    operation: 'POST /workspaces/{slug}/api-tokens',
-    permission: 'apiToken:create',
-    expected: 403,
-    request: makeRequest('POST', `/workspaces/${SLUG}/api-tokens`, {
-      name: 'CI token',
-      scopes: ['read']
-    })
-  },
-  {
-    operation: 'DELETE /workspaces/{slug}/api-tokens/{tokenId}',
-    permission: 'apiToken:revoke',
-    expected: 403,
-    request: makeRequest('DELETE', `/workspaces/${SLUG}/api-tokens/tok_seed`)
-  },
-  {
-    operation: 'POST /workspaces/{slug}/webhooks',
-    permission: 'webhook:create',
-    expected: 403,
-    request: makeRequest('POST', `/workspaces/${SLUG}/webhooks`, {
-      url: 'https://hooks.example.com/x',
-      events: ['api_token.created']
-    })
-  },
-  {
-    operation: 'PATCH /workspaces/{slug}/webhooks/{endpointId}',
-    permission: 'webhook:update',
-    expected: 403,
-    request: makeRequest('PATCH', `/workspaces/${SLUG}/webhooks/wh_release`, {
-      enabled: true
-    })
-  },
-  {
-    operation: 'DELETE /workspaces/{slug}/webhooks/{endpointId}',
-    permission: 'webhook:delete',
-    expected: 403,
-    request: makeRequest('DELETE', `/workspaces/${SLUG}/webhooks/wh_release`)
-  },
-  {
-    operation: 'POST /workspaces/{slug}/webhooks/{endpointId}/rotate-secret',
-    permission: 'webhook:rotateSecret',
+  ...mutationOperations().map((op): GatedOperation => ({
+    operation: `${op.endpoint.method} /${mirroredRestPath(op.endpoint.path)}`,
+    permission: permissionLabel(op.permission),
     expected: 403,
     request: makeRequest(
-      'POST',
-      `/workspaces/${SLUG}/webhooks/wh_release/rotate-secret`
+      op.endpoint.method,
+      op.endpoint.path
+        .replace(':slug', SLUG)
+        .replaceAll(/:\w+/g, op.param?.sample ?? ''),
+      op.samplePayload
     )
-  },
-  {
-    operation: 'POST /workspaces/{slug}/webhooks/{endpointId}/test-event',
-    permission: 'webhook:test',
-    expected: 403,
-    request: makeRequest('POST', `/workspaces/${SLUG}/webhooks/wh_release/test-event`)
-  },
-  {
-    operation: 'POST /workspaces/{slug}/webhooks/deliveries/{deliveryId}/replay',
-    permission: 'webhook:replay',
-    expected: 403,
-    request: makeRequest(
-      'POST',
-      `/workspaces/${SLUG}/webhooks/deliveries/whd_seed_failed/replay`
-    )
-  },
-
-  // Workspace export is owner-only: `workspaceExport:*` sits outside both the
-  // read and the write scope, so only an `admin`-scoped token reaches it.
-  {
-    operation: 'POST /workspaces/{slug}/exports',
-    permission: 'workspaceExport:request',
-    expected: 403,
-    request: makeRequest('POST', `/workspaces/${SLUG}/exports`)
-  },
-  {
-    operation: 'POST /workspaces/{slug}/exports/{exportId}/download-link',
-    permission: 'workspaceExport:download',
-    expected: 403,
-    request: makeRequest(
-      'POST',
-      `/workspaces/${SLUG}/exports/exp_seed_ready/download-link`
-    )
-  },
+  })),
 
   // The assistant and MCP surfaces each carry their own statement now.
   {
@@ -209,6 +146,59 @@ const HTTP_METHODS = new Set([
 ])
 
 describe('permission matrix', () => {
+  it('write scope permits webhook operations but cannot manage tokens or export data', () => {
+    expect(
+      mutationOperations()
+        .filter((op) => authorize(tokenPrincipal(['write']), op.permission).success)
+        .map((op) => `${op.endpoint.method} ${op.endpoint.path}`)
+        .toSorted()
+    ).toEqual([
+      'DELETE /workspaces/:slug/webhooks/:endpointId',
+      'PATCH /workspaces/:slug/webhooks/:endpointId',
+      'POST /workspaces/:slug/webhooks',
+      'POST /workspaces/:slug/webhooks/:endpointId/rotate-secret',
+      'POST /workspaces/:slug/webhooks/:endpointId/test-event',
+      'POST /workspaces/:slug/webhooks/deliveries/:deliveryId/replay'
+    ])
+  })
+
+  it('pins endpoint permissions to the reviewed authorization policy', () => {
+    // Independent policy oracle: changing a catalog permission must not change
+    // the expected answer. Full objects also catch extra required permissions.
+    expect(
+      Object.fromEntries(
+        [...readOperations(), ...mutationOperations()].map((op) => [
+          `${op.endpoint.method} /${mirroredRestPath(op.endpoint.path)}`,
+          op.permission
+        ])
+      )
+    ).toEqual({
+      'GET /workspaces/{slug}/overview': { notification: ['read'] },
+      'GET /workspaces/{slug}/members': { ac: ['read'] },
+      'GET /workspaces/{slug}/notifications': { notification: ['read'] },
+      'GET /workspaces/{slug}/api-tokens': { apiToken: ['list'] },
+      'GET /workspaces/{slug}/webhooks': { webhook: ['list'] },
+      'GET /workspaces/{slug}/webhooks/{endpointId}/deliveries': { webhook: ['list'] },
+      'GET /workspaces/{slug}/audit-events': { auditLog: ['read'] },
+      'POST /workspaces/{slug}/api-tokens': { apiToken: ['create'] },
+      'DELETE /workspaces/{slug}/api-tokens/{tokenId}': { apiToken: ['revoke'] },
+      'POST /workspaces/{slug}/webhooks': { webhook: ['create'] },
+      'PATCH /workspaces/{slug}/webhooks/{endpointId}': { webhook: ['update'] },
+      'DELETE /workspaces/{slug}/webhooks/{endpointId}': { webhook: ['delete'] },
+      'POST /workspaces/{slug}/webhooks/{endpointId}/rotate-secret': {
+        webhook: ['rotateSecret']
+      },
+      'POST /workspaces/{slug}/webhooks/{endpointId}/test-event': { webhook: ['test'] },
+      'POST /workspaces/{slug}/webhooks/deliveries/{deliveryId}/replay': {
+        webhook: ['replay']
+      },
+      'POST /workspaces/{slug}/exports': { workspaceExport: ['request'] },
+      'POST /workspaces/{slug}/exports/{exportId}/download-link': {
+        workspaceExport: ['download']
+      }
+    })
+  })
+
   it.effect('covers every gated operation the served contract advertises', () =>
     Effect.gen(function* () {
       const res = yield* send(new Request('https://api.test/openapi.json'))

--- a/docs/adr/0072-workspace-operation-catalog.md
+++ b/docs/adr/0072-workspace-operation-catalog.md
@@ -1,0 +1,77 @@
+# Workspace operation catalog
+
+`apps/api/src/operations.ts` now includes workspace mutations as well as reads.
+This reverses its earlier "writes stay out" decision. Keeping writes in manual
+REST bodies duplicated permissions and transport shaping in the permission
+matrix, and made transport reuse depend on copying those bodies. Capability
+business logic remains in `packages/capabilities`.
+
+The catalog has read and mutation row shapes. Each row references its canonical
+HTTP endpoint, which owns the method, path, input, success, and error schemas.
+The row adds its permission, capability call, and MCP decision. Mutation request
+types come from `HttpApiEndpoint.Request`, not a second payload or params shape.
+Its inferred Effect error channel retains the capability's expected failures;
+the download-link row translates an absent link into the contract's
+`WorkspaceExportNotDownloadable`. Guard failures remain in the shared request
+boundary. REST bindings preserve each row's input, success, and error types,
+so `HttpApiBuilder` checks them against the explicit endpoint schemas. We keep
+endpoint-to-row bindings explicit rather than erasing heterogeneous types with
+a cast-based dispatcher. Adding a mutation requires a contract endpoint, a
+catalog row, and its typed binding, but no handwritten handler body. The test
+policy oracle must also cover the new permission. Stable services are captured
+when building each mutation group; workspace
+context, audit actor, request origin, and scoped log annotations remain per call.
+
+MCP registration and discovery select the catalog's explicit `mcpTool` opt-ins.
+All existing reads opt in and retain their schemas and `readOnlyHint: true`.
+Every mutation currently opts out. Token creation/revocation and webhook secret
+rotation affect credentials; webhook creation/update/deletion affect outbound
+destinations; test/replay sends external traffic; export request/download-link
+creates data or grants download access. None gains agent access merely because
+it has a REST endpoint. Membership and invitation writes remain excluded from
+this bearer-token worker, as required by its Better Auth session boundary.
+
+A future MCP write tool requires a deliberate change to that row's opt-in
+type and the shared tool projection, with reviewed input/output schemas and tests.
+It must call the existing capability, enforce the row's permission on every
+invocation, preserve API Token versus OAuth Member audit provenance, and declare
+truthful `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`
+annotations. Annotations are client hints, never authorization or confirmation.
+Credential-bearing responses and externally visible side effects need explicit
+review before exposure. No generic write dispatcher or automatic tool naming
+is introduced. This catalog is not an automatic REST-and-MCP generator.
+
+Effect is pinned to `4.0.0-rc.112`. `HttpApiBuilder.handleAll` accepts a mapped
+handler record and checks each endpoint's input, success, errors, and remaining
+requirements. It does not map heterogeneous catalog callbacks into that record.
+Explicit bindings are a local choice to preserve those checks without assertions
+or a custom mapped-record builder, not a claim that Effect requires handwritten
+handler bodies. Contract references remove the avoidable method, path, and input
+type duplication. Event prefixes remain explicit to preserve existing log names.
+
+The pinned `Tool.make` and `McpServer.registerToolkit` can project schema-backed
+tools, but their default result encoding differs from our existing JSON-text
+results and typed-failure messages. We retain `McpServer.addTool` and the shared
+decoder, authorization, and exhaustive failure mapper. MCP currently supports
+three input shapes: no input, paging, and endpoint ID. A new shape needs a decoder
+and projection change; flipping `mcpTool` alone cannot expose a mutation. Any
+future write projection must invoke the existing row operation, not introduce a
+second dispatch table. HTTP-specific response shaping, notably signed download
+origins, needs explicit adaptation before reuse by a tool.
+
+Capability schemas remain owned by `packages/capabilities`; HTTP wire schemas
+remain in `packages/api` and are referenced through each row's endpoint. MCP JSON
+argument codecs remain in `mcp.ts`. Their paging codec intentionally differs from
+HTTP query decoding: an invalid optional HTTP limit is absent, while a non-number
+MCP limit is invalid params. We do not claim one interchangeable wire codec.
+
+The REST contract, SDK, error statuses, rate-limit buckets, MCP session protocol,
+and per-tool authorization are unchanged. `POST /mcp` still has no route-level
+permission check. The permission matrix derives mutation requests from rows and
+compares coverage with the served OpenAPI contract, including the fail-closed
+bucket rule. Those generated requests are coverage checks, not the permission
+oracle. Independent expectations pin the complete permission policy and the
+write-scope boundary. HTTP tests send independent denied mutation requests and
+check that the audit trail and token registry stay unchanged. Protocol and
+handler tests protect existing read behavior, mutation responses, error mapping,
+and audit provenance.


### PR DESCRIPTION
## Summary

Rebased onto `master` after #276 merged. Only the item 6 commit was replayed. Post-rebase `pnpm run check` passed. No merge is requested from automation.

- Extend the workspace operation catalog to mutations, keeping permissions and capability dispatch together.
- Reference canonical HttpApi endpoints for methods, paths, schemas, and request types rather than repeating contract metadata.
- Reuse catalog operations in REST handlers, MCP reads, discovery, and permission-matrix construction. Preserve audit provenance from #276.
- Ensure authorization runs before invoking operation callbacks; add independent permission-policy expectations and HTTP regressions proving denied mutations leave state unchanged.
- Record design and API evidence in ADR 0072 and update the API intent node.

## Deliberate limits

This is not fully automatic REST registration: endpoint-to-row bindings remain explicit to retain direct, per-endpoint type checking without a cast-based heterogeneous dispatcher. MCP remains read-only; every mutation explicitly opts out. A future write tool requires a reviewed projection change, not automatic exposure. HTTP query codecs and MCP JSON argument codecs retain their distinct semantics. No membership/invitation bearer-token mutations are added.

## Review and validation

- Fresh OpenAI session completed thermo-nuclear maintainability and Effect review, then fixed findings.
- Coordinator reran pnpm run check: exit 0.
- Reviewer ran uncached API tests: 105 tests across 9 files passed; uncached worker, HTTP contract, and SDK typechecks passed.
- git diff --check passed; worktree clean before push.
- No new lint suppressions or cast-based dispatcher. No changed source file crosses 1,000 lines.
- No browser E2E run locally for this API refactor; CI remains to run.

Backlog document, worker briefs, and validation logs are excluded.