### PR TITLE
feat(audit): add linkable event inspection

### DIFF
--- a/apps/background/src/export-consumer.test.ts
+++ b/apps/background/src/export-consumer.test.ts
@@ -125,6 +125,7 @@ function stubReads(failing = false) {
       autoDisableEndpoint: () => unused
     }),
     Layer.succeed(AuditEventLog)({
+      get: () => unused,
       list: () => list({ items: [], nextCursor: null }),
       listGlobal: unused,
       record: () => unused,

--- a/apps/web/e2e/audit-inspection.spec.ts
+++ b/apps/web/e2e/audit-inspection.spec.ts
@@ -1,0 +1,128 @@
+import { Deferred, Effect } from 'effect'
+import { expect, test, type Page } from '@playwright/test'
+import { hasLocalD1State } from '../src/lib/local-d1-state'
+
+function auditRequest(url: URL) {
+  return (
+    url.pathname.startsWith('/_serverFn/') &&
+    Buffer.from(url.pathname.slice('/_serverFn/'.length), 'base64url')
+      .toString()
+      .includes('workspace-audit.ts')
+  )
+}
+
+const auditPath = '/workspaces/starter-lab/audit'
+
+async function signIn(page: Page, email = 'demo@starter.local') {
+  await page.goto(`/sign-in?redirect=${encodeURIComponent(auditPath)}`)
+  await page.locator('form[data-hydrated="true"]').waitFor()
+  await page.getByLabel('Email', { exact: true }).fill(email)
+  await page.getByLabel('Password', { exact: true }).fill('demo-starter-password')
+  await page.getByRole('button', { name: 'Continue', exact: true }).click()
+  await page.waitForURL((url) => url.pathname === auditPath)
+}
+
+test.beforeEach(() => {
+  test.skip(!hasLocalD1State(), 'requires migrated and seeded local D1')
+})
+
+test('event links preserve filters, keyboard focus, and back/forward history', async ({
+  page
+}) => {
+  await signIn(page)
+  await page.getByRole('combobox', { name: 'Filter by actor' }).click()
+  await page.getByRole('option', { name: 'Ops Lead', exact: true }).click()
+  await expect(page).toHaveURL(`${auditPath}?actor=usr_ops`)
+  const link = page.getByRole('link', { name: /^Inspect API token created/ }).first()
+  await expect(link).toHaveAttribute('href', /actor=usr_ops.*event=aud_token/)
+  await expect(page.getByRole('button', { name: /^Sort by/ })).toHaveCount(0)
+  await link.focus()
+  await link.press('Enter')
+  const dialog = page.getByRole('dialog', { name: 'Audit event' })
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByText('aud_token', { exact: true })).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(dialog).toHaveCount(0)
+  await expect(page).toHaveURL(`${auditPath}?actor=usr_ops`)
+  await expect(link).toBeFocused()
+  await page.goForward()
+  await expect(dialog).toBeVisible()
+  await page.goBack()
+  await expect(dialog).toHaveCount(0)
+  await expect(link).toBeFocused()
+  await link.click()
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Close', exact: true }).click()
+  await expect(page).toHaveURL(`${auditPath}?actor=usr_ops`)
+})
+
+test('a direct link resolves outside the visible list and closes in place on mobile', async ({
+  page
+}, testInfo) => {
+  await signIn(page)
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto(`${auditPath}?eventType=no.such.event&cursor=invalid&event=aud_token`)
+  const dialog = page.getByRole('dialog', { name: 'Audit event' })
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByText('tok_ops', { exact: true })).toBeVisible()
+  await expect(dialog.getByText('usr_ops', { exact: true })).toBeVisible()
+  await expect(dialog.getByText('No permitted metadata recorded.')).toBeVisible()
+  const dimensions = await dialog.evaluate((element) => ({
+    scroll: element.scrollWidth,
+    client: element.clientWidth,
+    width: element.getBoundingClientRect().width
+  }))
+  expect(dimensions.scroll).toBeLessThanOrEqual(dimensions.client)
+  expect(dimensions.width).toBeLessThanOrEqual(390)
+  await page.screenshot({ path: testInfo.outputPath('audit-mobile.png') })
+  await dialog.getByRole('button', { name: 'Close', exact: true }).click()
+  await expect(dialog).toHaveCount(0)
+  await expect(page).toHaveURL(`${auditPath}?eventType=no.such.event&cursor=invalid`)
+  await expect(page.getByRole('combobox', { name: 'Filter by actor' })).toBeFocused()
+})
+
+test('missing and foreign-workspace events have the same unavailable result', async ({
+  page
+}) => {
+  await signIn(page)
+  // oxlint-disable no-await-in-loop -- each navigation replaces the same browser page
+  for (const event of ['missing', 'aud_admin']) {
+    await page.goto(`${auditPath}?event=${event}`)
+    const dialog = page.getByRole('dialog', { name: 'Audit event' })
+    await expect(dialog.getByText('Event not found', { exact: true })).toBeVisible()
+    await expect(dialog.getByText('Event ID', { exact: true })).toHaveCount(0)
+  }
+  // oxlint-enable no-await-in-loop
+})
+
+test('a member cannot inspect an event by direct link', async ({ page }) => {
+  await signIn(page, 'engineer@example.com')
+  await page.goto(`${auditPath}?event=aud_token`)
+  await expect(page.getByRole('dialog', { name: 'Audit event' })).toHaveCount(0)
+  await expect(page.getByText('aud_token', { exact: true })).toHaveCount(0)
+  await expect(page.getByRole('heading', { name: 'Audit access denied' })).toBeVisible()
+})
+
+test('a failed detail request shows a retryable error instead of a missing event', async ({
+  page
+}) => {
+  await signIn(page)
+  await expect(
+    page.getByRole('link', { name: /^Inspect API token created/ })
+  ).toBeVisible()
+  const release = Deferred.makeUnsafe<boolean>()
+  await page.route(auditRequest, async (route) => {
+    await Effect.runPromise(Deferred.await(release))
+    await route.abort('failed')
+  })
+  await page.getByRole('link', { name: /^Inspect API token created/ }).click()
+  await expect(page.getByText('Loading…', { exact: true })).toBeAttached()
+  await Effect.runPromise(Deferred.succeed(release, true))
+  await expect(
+    page.getByRole('heading', { name: 'Audit trail unavailable' })
+  ).toBeVisible()
+  await expect(page.getByText('Event not found', { exact: true })).toHaveCount(0)
+  await page.unroute(auditRequest)
+  await page.getByRole('button', { name: 'Try again', exact: true }).click()
+  await expect(page.getByRole('dialog', { name: 'Audit event' })).toBeVisible()
+})

--- a/apps/web/e2e/audit-inspection.spec.ts
+++ b/apps/web/e2e/audit-inspection.spec.ts
@@ -52,8 +52,11 @@ test('event links preserve filters, keyboard focus, and back/forward history', a
   await expect(link).toBeFocused()
   await link.click()
   await expect(dialog).toBeVisible()
+  await page.reload()
+  await expect(dialog).toBeVisible()
   await dialog.getByRole('button', { name: 'Close', exact: true }).click()
   await expect(page).toHaveURL(`${auditPath}?actor=usr_ops`)
+  await expect(link).toBeFocused()
 })
 
 test('a direct link resolves outside the visible list and closes in place on mobile', async ({
@@ -125,4 +128,9 @@ test('a failed detail request shows a retryable error instead of a missing event
   await page.unroute(auditRequest)
   await page.getByRole('button', { name: 'Try again', exact: true }).click()
   await expect(page.getByRole('dialog', { name: 'Audit event' })).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page).toHaveURL(auditPath)
+  await expect(
+    page.getByRole('link', { name: /^Inspect API token created/ })
+  ).toBeFocused()
 })

--- a/apps/web/src/components/audit-event-sheet.test.tsx
+++ b/apps/web/src/components/audit-event-sheet.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vite-plus/test'
+import { AuditEventSheet } from './audit-event-sheet'
+import { renderWithRouter } from '@/test/router-harness'
+
+describe('AuditEventSheet', () => {
+  it('renders permitted metadata as text with full actor and target context', async () => {
+    const close = vi.fn()
+    await renderWithRouter(
+      <AuditEventSheet
+        eventId="aud_delivery"
+        onClose={close}
+        event={{
+          id: 'aud_delivery',
+          eventType: 'webhook.delivery_failed',
+          actor: '<script>private</script>',
+          actorType: 'system',
+          actorUserId: null,
+          targetType: 'webhook_endpoint',
+          targetId: 'wh_operations',
+          createdAt: '2026-06-02T10:00:00.000Z',
+          metadata: { attempts: 3, responseStatus: 503 }
+        }}
+      />
+    )
+    expect(screen.getByText('<script>private</script>')).toBeTruthy()
+    expect(screen.getByText('wh_operations')).toBeTruthy()
+    expect(screen.getByText('2026-06-02T10:00:00.000Z')).toBeTruthy()
+    expect(screen.getByText(/"attempts": 3/)).toBeTruthy()
+    expect(screen.getByText(/"responseStatus": 503/)).toBeTruthy()
+    expect(document.querySelector('script')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Close', exact: true }))
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/components/audit-event-sheet.test.tsx
+++ b/apps/web/src/components/audit-event-sheet.test.tsx
@@ -29,7 +29,7 @@ describe('AuditEventSheet', () => {
     expect(screen.getByText(/"attempts": 3/)).toBeTruthy()
     expect(screen.getByText(/"responseStatus": 503/)).toBeTruthy()
     expect(document.querySelector('script')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: 'Close', exact: true }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(close).toHaveBeenCalledOnce()
   })
 })

--- a/apps/web/src/components/audit-event-sheet.tsx
+++ b/apps/web/src/components/audit-event-sheet.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from 'react'
+import { Link } from '@tanstack/react-router'
+import {
+  type AuditEvent,
+  type AuditEventDetail
+} from '@b2b-saas-starter/capabilities/governance/audit-event-log'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription
+} from '@/components/ui/sheet'
+import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from '@/components/ui/empty'
+import { auditActorTypeLabel, auditEventLabel } from '@/lib/audit-labels'
+import { formatDateTime } from '@/lib/format-date'
+
+export function AuditEventLink({ event }: { readonly event: AuditEvent }) {
+  return (
+    <Link
+      id={`audit-event-${event.id}`}
+      to="."
+      search={(previous) => ({ ...previous, event: event.id })}
+      state={{ auditEventOpened: true }}
+      resetScroll={false}
+      className="inline-flex min-h-11 items-center rounded-md text-primary underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring md:min-h-9"
+      aria-label={`Inspect ${auditEventLabel(event.eventType)}, ${formatDateTime(event.createdAt)}`}
+    >
+      {auditEventLabel(event.eventType)}
+    </Link>
+  )
+}
+
+export function AuditEventSheet({
+  eventId,
+  event,
+  onClose
+}: {
+  readonly eventId: string | null
+  readonly event: AuditEventDetail | null
+  readonly onClose: () => void
+}) {
+  const returnFocus = useRef<HTMLElement | null>(null)
+  useEffect(() => {
+    if (eventId !== null) {
+      returnFocus.current =
+        document.getElementById(`audit-event-${eventId}`) ??
+        document.getElementById('audit-actor-filter')
+    }
+  }, [eventId])
+  return (
+    <Sheet
+      open={eventId !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose()
+        }
+      }}
+    >
+      <SheetContent
+        className="overflow-y-auto data-[side=right]:w-full data-[side=right]:sm:max-w-lg"
+        finalFocus={returnFocus}
+      >
+        <SheetHeader className="pr-16">
+          <SheetTitle>Audit event</SheetTitle>
+          <SheetDescription>Event details for this workspace.</SheetDescription>
+        </SheetHeader>
+        {event ? (
+          <EventDetails event={event} />
+        ) : (
+          <Empty>
+            <EmptyHeader>
+              <EmptyTitle>Event not found</EmptyTitle>
+              <EmptyDescription>
+                This event does not exist in this workspace or is no longer available.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function EventDetails({ event }: { readonly event: AuditEventDetail }) {
+  const fields = [
+    ['Event', auditEventLabel(event.eventType)],
+    ['Event type', event.eventType],
+    ['Event ID', event.id],
+    ['Time (UTC)', event.createdAt],
+    ['Actor', event.actor],
+    ['Actor type', auditActorTypeLabel(event.actorType)],
+    ['Actor user ID', event.actorUserId ?? 'Not recorded'],
+    ['Target type', event.targetType],
+    ['Target ID', event.targetId ?? 'Not recorded']
+  ]
+  return (
+    <div className="grid min-w-0 gap-6 p-4 pt-0 text-sm">
+      <dl className="grid gap-4">
+        {fields.map(([label, value]) => (
+          <div key={label} className="grid gap-1">
+            <dt className="text-muted-foreground">{label}</dt>
+            <dd className="font-mono [overflow-wrap:anywhere]">{value}</dd>
+          </div>
+        ))}
+      </dl>
+      <section className="grid gap-2" aria-label="Permitted metadata">
+        <h3 className="font-medium">Metadata</h3>
+        {Object.keys(event.metadata).length > 0 ? (
+          <pre className="whitespace-pre-wrap bg-muted p-3 font-mono [overflow-wrap:anywhere]">
+            {JSON.stringify(event.metadata, null, 2)}
+          </pre>
+        ) : (
+          <p className="text-muted-foreground">No permitted metadata recorded.</p>
+        )}
+        <p className="text-muted-foreground">
+          Only approved operational fields are shown. Personal data, URLs, scopes, and
+          credentials are withheld.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/components/audit-route-error.tsx
+++ b/apps/web/src/components/audit-route-error.tsx
@@ -1,0 +1,31 @@
+import { Link, useRouter } from '@tanstack/react-router'
+import { Button } from '@/components/ui/button'
+import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from '@/components/ui/empty'
+import { FORBIDDEN_ERROR_NAME } from '@/lib/capability-error'
+
+export function AuditRouteError({ error }: { readonly error: Error }) {
+  const router = useRouter()
+  const forbidden = error.name === FORBIDDEN_ERROR_NAME
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyTitle>
+          <h1>{forbidden ? 'Audit access denied' : 'Audit trail unavailable'}</h1>
+        </EmptyTitle>
+        <EmptyDescription>
+          {forbidden
+            ? 'You do not have permission to read audit events in this workspace. Ask a workspace owner or admin.'
+            : 'Audit events could not be loaded. Try again.'}
+        </EmptyDescription>
+      </EmptyHeader>
+      {!forbidden && (
+        <Button variant="outline" onClick={() => void router.invalidate()}>
+          Try again
+        </Button>
+      )}
+      <Link to="/workspaces" className="text-primary underline underline-offset-4">
+        Back to workspaces
+      </Link>
+    </Empty>
+  )
+}

--- a/apps/web/src/components/workspace-audit-page.test.tsx
+++ b/apps/web/src/components/workspace-audit-page.test.tsx
@@ -14,6 +14,7 @@ import { renderWithRouter } from '@/test/router-harness'
 const applySearch = vi.fn<ApplyWorkspaceAuditSearch>()
 
 const payload: WorkspaceAuditPayload = {
+  selectedEvent: null,
   viewer: { role: 'owner' },
   events: [
     {
@@ -39,6 +40,8 @@ async function renderPage(overrides: Partial<WorkspaceAuditPayload> = {}) {
       workspaceSlug="starter-lab"
       data={{ ...payload, ...overrides }}
       applySearch={applySearch}
+      selectedEventId={null}
+      closeEvent={vi.fn()}
     />,
     { path: '/workspaces/starter-lab/audit' }
   )
@@ -60,10 +63,10 @@ describe('WorkspaceAuditPage', () => {
     expect(applySearch).toHaveBeenCalledWith({ actor: 'usr_demo', cursor: 'cur_2' })
   })
 
-  it('drops the cursor but keeps the actor when a filter changes', async () => {
+  it('clears all filters and the cursor', async () => {
     await renderPage({ filters: { actorUserId: 'usr_demo' }, nextCursor: 'cur_2' })
     fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
-    expect(applySearch).toHaveBeenCalledWith({ actor: 'usr_demo' })
+    expect(applySearch).toHaveBeenCalledWith({})
   })
 
   it('drops empty values so cleared controls disappear from the URL', () => {

--- a/apps/web/src/components/workspace-audit-page.tsx
+++ b/apps/web/src/components/workspace-audit-page.tsx
@@ -1,3 +1,4 @@
+import { AuditEventLink, AuditEventSheet } from './audit-event-sheet'
 import { FilterXIcon, HistoryIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -23,11 +24,7 @@ import { WorkspaceCrumb } from '@/components/page/workspace-crumb'
 import { Badge } from '@/components/ui/badge'
 import { DataTable, type DataTableColumnDef } from '@/components/data-table'
 import { WorkspaceShell } from '@/components/workspace-shell'
-import {
-  AUDIT_EVENT_FILTER_OPTIONS,
-  auditActorTypeLabel,
-  auditEventLabel
-} from '@/lib/audit-labels'
+import { AUDIT_EVENT_FILTER_OPTIONS, auditActorTypeLabel } from '@/lib/audit-labels'
 import { auditActorTypeVariant } from '@/lib/badge-variants'
 import {
   auditSearchFromFilters,
@@ -54,13 +51,12 @@ import { type AuditEvent } from '@b2b-saas-starter/capabilities/governance/audit
 const SELECT_CLASSES = 'max-w-52'
 
 // Column definitions are static — module scope keeps the cell renderers out of
-// the render body (they would remount every render). Sorting reorders the
-// loaded page locally; the server's own order stays newest-first.
+// the render body. The server owns collection order: newest first.
 const auditColumns: Array<DataTableColumnDef<AuditEvent>> = [
   {
     accessorKey: 'createdAt',
     header: 'When',
-    enableSorting: true,
+    enableSorting: false,
     // The shared table timestamp, identical to the admin dashboard's.
     cell: ({ row }) => (
       <span className="font-mono text-muted-foreground whitespace-nowrap tabular-nums">
@@ -71,13 +67,13 @@ const auditColumns: Array<DataTableColumnDef<AuditEvent>> = [
   {
     accessorKey: 'eventType',
     header: 'Event',
-    enableSorting: true,
-    cell: ({ row }) => auditEventLabel(row.original.eventType)
+    enableSorting: false,
+    cell: ({ row }) => <AuditEventLink event={row.original} />
   },
   {
     accessorKey: 'targetType',
     header: 'Target',
-    enableSorting: true,
+    enableSorting: false,
     // Target ids are the long values — this wraps instead of forcing the
     // table out to 700px on a phone, where the other columns clip.
     cell: ({ row }) => (
@@ -90,7 +86,7 @@ const auditColumns: Array<DataTableColumnDef<AuditEvent>> = [
   {
     accessorKey: 'actor',
     header: 'Actor',
-    enableSorting: true,
+    enableSorting: false,
     // The joined display name alone cannot tell "the platform did this"
     // from "an API token did" — both render as `system` when no user row
     // joins — so the actor type rides beside it as a badge.
@@ -109,8 +105,12 @@ export function WorkspaceAuditPage({
   workspaceSlug,
   data,
   applySearch,
-  systemRole
+  systemRole,
+  selectedEventId,
+  closeEvent
 }: {
+  readonly selectedEventId: string | null
+  readonly closeEvent: () => void
   readonly workspaceSlug: string
   readonly data: WorkspaceAuditPayload
   readonly applySearch: ApplyWorkspaceAuditSearch
@@ -156,7 +156,7 @@ export function WorkspaceAuditPage({
         description="Newest first, up to 100 events per server page."
         actions={
           hasFilters ? (
-            <Button variant="ghost" onClick={() => withFilter({})}>
+            <Button variant="ghost" onClick={() => applySearch({})}>
               <FilterXIcon aria-hidden className="size-4" />
               Clear
             </Button>
@@ -179,7 +179,11 @@ export function WorkspaceAuditPage({
               }))
             ]}
           >
-            <SelectTrigger aria-label="Filter by actor" className={SELECT_CLASSES}>
+            <SelectTrigger
+              id="audit-actor-filter"
+              aria-label="Filter by actor"
+              className={SELECT_CLASSES}
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -287,6 +291,11 @@ export function WorkspaceAuditPage({
           </>
         )}
       </Panel>
+      <AuditEventSheet
+        eventId={selectedEventId}
+        event={data.selectedEvent}
+        onClose={closeEvent}
+      />
     </WorkspaceShell>
   )
 }

--- a/apps/web/src/lib/audit-search.ts
+++ b/apps/web/src/lib/audit-search.ts
@@ -9,6 +9,7 @@ export type WorkspaceAuditSearchUpdate = {
   readonly eventType?: string
   readonly since?: string
   readonly until?: string
+  readonly event?: string
   readonly cursor?: string
 }
 
@@ -33,7 +34,8 @@ export function compact(
     'eventType',
     'since',
     'until',
-    'cursor'
+    'cursor',
+    'event'
   ]
   for (const key of keys) {
     const value = search[key]

--- a/apps/web/src/lib/server/workspace-audit.effects.ts
+++ b/apps/web/src/lib/server/workspace-audit.effects.ts
@@ -43,11 +43,16 @@ export async function loadWorkspaceAuditEventsHandler(
         // No second gate here: the hard `auditLog` read above already decided
         // who reaches this payload (owner/admin only), and the role table has no
         // separate member-list statement to compose.
-        const [page, members] = yield* Effect.all(
-          [log.list(listInput), membership.listMembers],
+        const [page, members, selectedEvent] = yield* Effect.all(
+          [
+            log.list(listInput),
+            membership.listMembers,
+            input.event ? log.get(input.event) : Effect.succeed(null)
+          ],
           { concurrency: 'unbounded' }
         )
         return {
+          selectedEvent,
           events: page.items,
           nextCursor: page.nextCursor,
           filters: input.filters,

--- a/apps/web/src/lib/server/workspace-audit.test.ts
+++ b/apps/web/src/lib/server/workspace-audit.test.ts
@@ -47,6 +47,43 @@ describe('loadWorkspaceAuditEventsHandler', () => {
     ).rejects.toMatchObject({ name: 'ForbiddenError' })
   })
 
+  it('resolves direct event links outside the current list and cursor', async () => {
+    const payload = await loadWorkspaceAuditEventsHandler({
+      workspaceSlug: 'starter-lab',
+      filters: { eventType: 'no.such.event' },
+      cursor: 'invalid',
+      event: 'aud_token'
+    })
+    expect(payload.events).toEqual([])
+    expect(payload.selectedEvent).toMatchObject({
+      id: 'aud_token',
+      targetType: 'api_token'
+    })
+  })
+
+  it.each(['missing', 'aud_admin'])(
+    'does not disclose unavailable event %s',
+    async (event) => {
+      const payload = await loadWorkspaceAuditEventsHandler({
+        workspaceSlug: 'starter-lab',
+        filters: {},
+        event
+      })
+      expect(payload.selectedEvent).toBeNull()
+    }
+  )
+
+  it('denies an event lookup to a member', async () => {
+    actor.userId = 'usr_dev'
+    await expect(
+      loadWorkspaceAuditEventsHandler({
+        workspaceSlug: 'starter-lab',
+        filters: {},
+        event: 'aud_token'
+      })
+    ).rejects.toMatchObject({ name: 'ForbiddenError' })
+  })
+
   it('gives an owner the workspace-scoped events, newest first', async () => {
     const payload = await load()
     expect(payload.viewer).toEqual({ role: 'owner' })

--- a/apps/web/src/lib/server/workspace-audit.ts
+++ b/apps/web/src/lib/server/workspace-audit.ts
@@ -1,4 +1,7 @@
-import { type AuditEvent } from '@b2b-saas-starter/capabilities/governance/audit-event-log'
+import {
+  type AuditEvent,
+  type AuditEventDetail
+} from '@b2b-saas-starter/capabilities/governance/audit-event-log'
 import { type WorkspaceViewer } from '@/lib/permissions'
 import { createServerFn } from '@tanstack/react-start'
 import { Schema, type Types } from 'effect'
@@ -44,6 +47,7 @@ export type WorkspaceAuditFilters = Types.Mutable<typeof WorkspaceAuditFilters.T
  * and the hard gate above already decided who reaches this payload.
  */
 export type WorkspaceAuditPayload = {
+  readonly selectedEvent: AuditEventDetail | null
   readonly viewer: WorkspaceViewer | null
   readonly events: ReadonlyArray<AuditEvent>
   /** Opaque keyset cursor for the next older page, or null on the last one. */
@@ -61,7 +65,8 @@ export type WorkspaceAuditPayload = {
 const WorkspaceAuditInput = Schema.Struct({
   workspaceSlug: Schema.NonEmptyString,
   filters: WorkspaceAuditFilters,
-  cursor: Schema.optionalKey(Schema.String)
+  cursor: Schema.optionalKey(Schema.String),
+  event: Schema.optionalKey(Schema.NonEmptyString)
 })
 
 export type WorkspaceAuditInput = typeof WorkspaceAuditInput.Type

--- a/apps/web/src/router-register.d.ts
+++ b/apps/web/src/router-register.d.ts
@@ -9,6 +9,9 @@
 import  { type getRouter } from './router'
 
 declare module '@tanstack/react-router' {
+  interface HistoryState {
+    auditEventOpened?: boolean
+  }
   interface Register {
     router: ReturnType<typeof getRouter>
   }

--- a/apps/web/src/routes/workspaces.$workspaceSlug.audit.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.audit.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { pageTitle } from '@/components/page/page-title'
+import { AuditRouteError } from '@/components/audit-route-error'
 import { RoutePending } from '@/components/route-pending'
 import { WorkspaceAuditPage } from '@/components/workspace-audit-page'
 import { type ApplyWorkspaceAuditSearch } from '@/lib/audit-search'
@@ -16,7 +17,7 @@ import {
  * unknown event type or an undecodable cursor addresses an empty result, not
  * an error (mirrors the capability's read contract).
  *
- * The five keys are picked with `pickOptionalStrings`, not effect/Schema:
+ * The search keys are picked with `pickOptionalStrings`, not effect/Schema:
  * `validateSearch` runs client-side in the route shell the whole route tree
  * carries, and a Schema construct here would pin the 145 kB Effect Schema
  * chunk onto every page — the same trade the auth-flow routes make
@@ -27,7 +28,8 @@ const AUDIT_SEARCH_KEYS: ReadonlyArray<string> = [
   'eventType',
   'since',
   'until',
-  'cursor'
+  'cursor',
+  'event'
 ]
 
 type AuditSearch = {
@@ -35,6 +37,7 @@ type AuditSearch = {
   readonly eventType?: string | undefined
   readonly since?: string | undefined
   readonly until?: string | undefined
+  readonly event?: string | undefined
   readonly cursor?: string | undefined
 }
 
@@ -68,10 +71,12 @@ export const Route = createFileRoute('/workspaces/$workspaceSlug/audit')({
       data: {
         workspaceSlug: params.workspaceSlug,
         filters: filtersFromSearch(deps.search),
-        ...(deps.search.cursor !== undefined && { cursor: deps.search.cursor })
+        ...(deps.search.cursor !== undefined && { cursor: deps.search.cursor }),
+        ...(deps.search.event && { event: deps.search.event })
       }
     }),
   pendingComponent: RoutePending,
+  errorComponent: AuditRouteError,
   component: WorkspaceAuditRoute,
   head: ({ params }) => ({
     meta: [{ title: pageTitle('Audit trail', params.workspaceSlug) }]
@@ -83,17 +88,28 @@ export const Route = createFileRoute('/workspaces/$workspaceSlug/audit')({
 function WorkspaceAuditRoute() {
   const { workspaceSlug } = Route.useParams()
   const data = Route.useLoaderData()
+  const search = Route.useSearch()
   const router = useRouter()
   // Full replacement, not a merge with the previous search: the page always
   // hands back complete state (a filter change drops the cursor by omitting
   // it), which is exactly what keyset pagination needs.
-  function applySearch(search: Parameters<ApplyWorkspaceAuditSearch>[0]): void {
-    void router.navigate({ to: '.', search })
+  function applySearch(nextSearch: Parameters<ApplyWorkspaceAuditSearch>[0]): void {
+    void router.navigate({ to: '.', search: nextSearch })
   }
   return (
     <WorkspaceAuditPage
       workspaceSlug={workspaceSlug}
       data={data}
+      selectedEventId={search.event || null}
+      closeEvent={() => {
+        if (router.state.location.state.auditEventOpened) {
+          router.history.back()
+        } else {
+          const listSearch = { ...search }
+          delete listSearch.event
+          void router.navigate({ to: '.', search: listSearch, replace: true })
+        }
+      }}
       applySearch={applySearch}
       systemRole={Route.useRouteContext().session.user.role}
     />

--- a/docs/adr/0025-persisted-audit-events.md
+++ b/docs/adr/0025-persisted-audit-events.md
@@ -1,3 +1,30 @@
 # Persisted audit events
 
 The starter includes a simple persisted audit event table from the start. Audit events should record security, admin, workspace membership, billing, API token, and webhook actions so the reference app supports B2B governance expectations and creates a foundation for safer future capabilities such as impersonation.
+
+## Individual event inspection
+
+The audit page addresses an event with the `event` search parameter. The
+capability's `get(id)` reads by both event ID and the resolved workspace ID,
+independently of list filters and cursors. The web server function requires a
+session and `auditLog: ['read']` before either read. A missing or foreign-workspace
+event returns the same not-found panel; lack of audit permission remains an
+explicit permission denial.
+Store failures use the existing route error boundary and never masquerade as
+missing events.
+
+Details add the recorded actor user ID and an explicit metadata projection.
+Only validated role, SSO protocol, delivery attempt count, HTTP response status,
+and export size fields may cross this boundary. Unknown fields, nested payloads,
+emails, names, IPs, URLs, scopes, and credentials remain private. Invalid approved
+fields yield no metadata. Seed retains recorded metadata and applies the same
+projection as Live; list and global reads continue to omit metadata entirely.
+This is a web inspection feature, so it adds no REST endpoint or MCP catalog row.
+
+The table follows the deterministic collection order from ADR 0057. Local column
+sorting was removed because reordering one loaded page misrepresented the whole
+collection. Native event links open the existing sheet, preserve list search
+state, and push browser history. Close returns to the prior list entry for an
+in-app open; a direct link closes by replacing only the event search parameter.
+The sheet restores focus to the event link, or the actor filter when the event
+is outside the visible list. No additional table or state framework is used.

--- a/docs/adr/0025-persisted-audit-events.md
+++ b/docs/adr/0025-persisted-audit-events.md
@@ -18,7 +18,10 @@ Only validated role, SSO protocol, delivery attempt count, HTTP response status,
 and export size fields may cross this boundary. Unknown fields, nested payloads,
 emails, names, IPs, URLs, scopes, and credentials remain private. Invalid approved
 fields yield no metadata. Seed retains recorded metadata and applies the same
-projection as Live; list and global reads continue to omit metadata entirely.
+projection as Live. Seed snapshots metadata on ingestion so a caller cannot
+rewrite a recorded event by mutating its input. The detail contract derives its
+metadata shape from the same allowlist schema; list and global reads continue
+to omit metadata entirely.
 This is a web inspection feature, so it adds no REST endpoint or MCP catalog row.
 
 The table follows the deterministic collection order from ADR 0057. Local column

--- a/packages/capabilities/src/billing/billing.test.ts
+++ b/packages/capabilities/src/billing/billing.test.ts
@@ -33,6 +33,7 @@ function billingFixture(options?: {
   const recordedAuditEvents: Array<RecordAuditEventInput> = []
   const auditLayer = Layer.effect(AuditEventLog)(
     Effect.succeed({
+      get: () => Effect.die('not used here'),
       list: () => Effect.die('not used here'),
       listGlobal: Effect.succeed([]),
       record: (input: RecordAuditEventInput) =>

--- a/packages/capabilities/src/governance/audit-event-log.contract.ts
+++ b/packages/capabilities/src/governance/audit-event-log.contract.ts
@@ -88,6 +88,21 @@ export function auditEventLogContractCases(
 ): ReadonlyArray<AuditEventLogContractCase> {
   return [
     {
+      name: 'gets an event independently of list filters and cursors',
+      assert: Effect.gen(function* () {
+        const audit = yield* AuditEventLog
+        expect(
+          (yield* list({ eventType: 'no.such.event', cursor: 'invalid' })).items
+        ).toEqual([])
+        const event = yield* audit.get('aud_c_old')
+        expect(event?.id).toBe('aud_c_old')
+        expect(event?.actorUserId).toBe('usr_alice')
+        expect(event?.actor).toBe('Alice')
+        expect(event?.targetId).toBe('tok_a')
+        expect(yield* audit.get('missing')).toBe(null)
+      })
+    },
+    {
       name: 'missing provenance fails before recording or preparing a write',
       assert: Effect.gen(function* () {
         const audit = yield* AuditEventLog
@@ -271,7 +286,16 @@ export function auditEventLogContractCases(
           actorType: 'system',
           eventType: 'workspace.created',
           targetType: 'workspace',
-          targetId: 'automated_workspace'
+          targetId: 'automated_workspace',
+          metadata: {
+            role: 'admin',
+            attempts: 2,
+            responseStatus: 503,
+            email: 'private@example.com',
+            scopes: ['admin'],
+            url: 'https://secret.example',
+            nested: { token: 'secret' }
+          }
         })
         yield* audit.record({
           workspaceId: ctx.workspace.id,
@@ -282,6 +306,25 @@ export function auditEventLogContractCases(
           targetId: 'interactive_workspace'
         })
         const page = yield* list({ eventType: 'workspace.created' })
+        const recorded = page.items.find(
+          (event) => event.targetId === 'automated_workspace'
+        )
+        const detail = yield* audit.get(recorded?.id ?? '')
+        expect(detail?.metadata).toEqual({
+          role: 'admin',
+          attempts: 2,
+          responseStatus: 503
+        })
+        const ctxOther = {
+          ...ctx,
+          workspace: { ...ctx.workspace, id: 'other-workspace' }
+        }
+        expect(
+          yield* audit
+            .get(recorded?.id ?? '')
+            .pipe(Effect.provideService(WorkspaceContext, ctxOther))
+        ).toBe(null)
+        expect('metadata' in (recorded ?? {})).toBe(false)
         expect(
           page.items.find((event) => event.targetId === 'automated_workspace')
             ?.actorType

--- a/packages/capabilities/src/governance/audit-event-log.contract.ts
+++ b/packages/capabilities/src/governance/audit-event-log.contract.ts
@@ -325,6 +325,11 @@ export function auditEventLogContractCases(
             .pipe(Effect.provideService(WorkspaceContext, ctxOther))
         ).toBe(null)
         expect('metadata' in (recorded ?? {})).toBe(false)
+        const globalEvent = (yield* audit.listGlobal).find(
+          (event) => event.id === recorded?.id
+        )
+        expect(globalEvent?.id).toBe(recorded?.id)
+        expect('metadata' in (globalEvent ?? {})).toBe(false)
         expect(
           page.items.find((event) => event.targetId === 'automated_workspace')
             ?.actorType
@@ -333,6 +338,30 @@ export function auditEventLogContractCases(
           page.items.find((event) => event.targetId === 'interactive_workspace')
             ?.actorType
         ).toBe('user')
+      })
+    },
+    {
+      name: 'snapshots recorded metadata so callers cannot rewrite an audit event',
+      assert: Effect.gen(function* () {
+        const audit = yield* AuditEventLog
+        const ctx = yield* WorkspaceContext
+        const metadata = { attempts: 2 }
+        yield* audit.record({
+          workspaceId: ctx.workspace.id,
+          actorType: 'system',
+          eventType: 'webhook.delivery_failed',
+          targetType: 'webhook_endpoint',
+          targetId: 'metadata-snapshot',
+          metadata
+        })
+        metadata.attempts = 99
+        const page = yield* audit.list({ eventType: 'webhook.delivery_failed' })
+        const recorded = page.items.find(
+          (event) => event.targetId === 'metadata-snapshot'
+        )
+        expect((yield* audit.get(recorded?.id ?? ''))?.metadata).toEqual({
+          attempts: 2
+        })
       })
     }
   ]

--- a/packages/capabilities/src/governance/audit-event-log.live.ts
+++ b/packages/capabilities/src/governance/audit-event-log.live.ts
@@ -16,6 +16,7 @@ import { clampPageLimit, cutKeysetPage, type Page } from '../internal/keyset-cur
 import { keysetResume } from '../internal/keyset-query.ts'
 import { newCapabilityId } from '../internal/ids.ts'
 import { orUnavailable } from '../internal/unavailable.ts'
+import { permittedAuditMetadata } from './audit-event-metadata.ts'
 import { WorkspaceContext } from '../workspace-context.ts'
 
 function pageLimit(input: ListAuditEventsInput | undefined): number {
@@ -133,6 +134,31 @@ export const LiveAuditEventLog: Layer.Layer<AuditEventLog, never, Database> =
       })
 
       return {
+        get: Effect.fn('AuditEventLog.get')(function* (id: string) {
+          const ctx = yield* WorkspaceContext
+          const rows = yield* orUnavailable('audit-event-log')(
+            db
+              .select({ event: auditEvents, actor: user })
+              .from(auditEvents)
+              .leftJoin(user, eq(user.id, auditEvents.actorUserId))
+              .where(
+                and(
+                  eq(auditEvents.workspaceId, ctx.workspace.id),
+                  eq(auditEvents.id, id)
+                )
+              )
+              .limit(1)
+          )
+          const row = rows[0]
+          if (!row) {
+            return null
+          }
+          return {
+            ...toWireRow(row),
+            actorUserId: row.event.actorUserId,
+            metadata: permittedAuditMetadata(row.event.metadata)
+          }
+        }),
         list: (input) =>
           Effect.gen(function* () {
             const ctx = yield* WorkspaceContext

--- a/packages/capabilities/src/governance/audit-event-log.live.ts
+++ b/packages/capabilities/src/governance/audit-event-log.live.ts
@@ -16,7 +16,7 @@ import { clampPageLimit, cutKeysetPage, type Page } from '../internal/keyset-cur
 import { keysetResume } from '../internal/keyset-query.ts'
 import { newCapabilityId } from '../internal/ids.ts'
 import { orUnavailable } from '../internal/unavailable.ts'
-import { permittedAuditMetadata } from './audit-event-metadata.ts'
+import { decodeAuditEventMetadata } from './audit-event-metadata.ts'
 import { WorkspaceContext } from '../workspace-context.ts'
 
 function pageLimit(input: ListAuditEventsInput | undefined): number {
@@ -156,7 +156,7 @@ export const LiveAuditEventLog: Layer.Layer<AuditEventLog, never, Database> =
           return {
             ...toWireRow(row),
             actorUserId: row.event.actorUserId,
-            metadata: permittedAuditMetadata(row.event.metadata)
+            metadata: decodeAuditEventMetadata(row.event.metadata)
           }
         }),
         list: (input) =>

--- a/packages/capabilities/src/governance/audit-event-log.ts
+++ b/packages/capabilities/src/governance/audit-event-log.ts
@@ -3,7 +3,7 @@ import { auditActorTypes, type AuditActorTypeValue } from '@b2b-saas-starter/db/
 import { type BatchStatement } from '@b2b-saas-starter/db/service'
 import { Context, DateTime, Effect, Layer, Schema } from 'effect'
 
-import { permittedAuditMetadata } from './audit-event-metadata.ts'
+import { AuditEventMetadata, decodeAuditEventMetadata } from './audit-event-metadata.ts'
 
 import { type CapabilityUnavailable } from '../errors.ts'
 import {
@@ -31,7 +31,7 @@ export type AuditEvent = typeof AuditEvent.Type
 export const AuditEventDetail = Schema.Struct({
   ...AuditEvent.fields,
   actorUserId: Schema.NullOr(Schema.String),
-  metadata: Schema.JsonObject
+  metadata: AuditEventMetadata
 })
 export type AuditEventDetail = typeof AuditEventDetail.Type
 
@@ -263,7 +263,7 @@ export function SeedAuditEventLog(
   // A private copy: `record` appends without mutating the caller's fixture
   // array. Sharing state across adapters happens by providing one instance of
   // this layer (see layers.ts), not by sharing the fixture array.
-  const rows: Array<SeedAuditEventRow> = [...seed]
+  const rows: Array<SeedAuditEventRow> = structuredClone([...seed])
   return Layer.succeed(AuditEventLog)({
     get: Effect.fn('AuditEventLog.get')(function* (id: string) {
       const ctx = yield* WorkspaceContext
@@ -276,7 +276,7 @@ export function SeedAuditEventLog(
       return {
         ...toSeedWire(row),
         actorUserId: row.actorUserId ?? null,
-        metadata: permittedAuditMetadata(row.metadata ?? {})
+        metadata: decodeAuditEventMetadata(row.metadata ?? {})
       }
     }),
     // Same scoping as Live: the per-workspace read filters on the resolved
@@ -306,7 +306,7 @@ export function SeedAuditEventLog(
           actorType: input.actorType,
           actorUserId: input.actorUserId ?? null,
           workspaceId: input.workspaceId ?? null,
-          metadata: input.metadata ?? {},
+          metadata: structuredClone(input.metadata ?? {}),
           createdAt: DateTime.formatIso(yield* DateTime.now)
         }
         rows.push(row)

--- a/packages/capabilities/src/governance/audit-event-log.ts
+++ b/packages/capabilities/src/governance/audit-event-log.ts
@@ -3,6 +3,8 @@ import { auditActorTypes, type AuditActorTypeValue } from '@b2b-saas-starter/db/
 import { type BatchStatement } from '@b2b-saas-starter/db/service'
 import { Context, DateTime, Effect, Layer, Schema } from 'effect'
 
+import { permittedAuditMetadata } from './audit-event-metadata.ts'
+
 import { type CapabilityUnavailable } from '../errors.ts'
 import {
   seedKeysetPage,
@@ -25,6 +27,13 @@ export const AuditEvent = Schema.Struct({
   createdAt: Schema.String
 })
 export type AuditEvent = typeof AuditEvent.Type
+
+export const AuditEventDetail = Schema.Struct({
+  ...AuditEvent.fields,
+  actorUserId: Schema.NullOr(Schema.String),
+  metadata: Schema.JsonObject
+})
+export type AuditEventDetail = typeof AuditEventDetail.Type
 
 /**
  * The keyset position every audit page cuts on — newest first on
@@ -77,6 +86,7 @@ export const AUDIT_EVENT_PAGE_SIZE = 100
  * can answer the same server-side filters as Live without reaching into D1.
  */
 export type SeedAuditEventRow = AuditEvent & {
+  readonly metadata?: JsonObject
   readonly actorType: AuditActorTypeValue
   readonly workspaceId?: string | null
   readonly actorUserId?: string | null
@@ -121,6 +131,9 @@ export function assertAuditActorType(
 }
 
 export type AuditEventLogInterface = {
+  readonly get: (
+    id: string
+  ) => Effect.Effect<AuditEventDetail | null, CapabilityUnavailable, WorkspaceContext>
   readonly list: (
     input?: ListAuditEventsInput
   ) => Effect.Effect<Page<AuditEvent>, CapabilityUnavailable, WorkspaceContext>
@@ -252,6 +265,20 @@ export function SeedAuditEventLog(
   // this layer (see layers.ts), not by sharing the fixture array.
   const rows: Array<SeedAuditEventRow> = [...seed]
   return Layer.succeed(AuditEventLog)({
+    get: Effect.fn('AuditEventLog.get')(function* (id: string) {
+      const ctx = yield* WorkspaceContext
+      const row = rows.find(
+        (event) => event.id === id && event.workspaceId === ctx.workspace.id
+      )
+      if (!row) {
+        return null
+      }
+      return {
+        ...toSeedWire(row),
+        actorUserId: row.actorUserId ?? null,
+        metadata: permittedAuditMetadata(row.metadata ?? {})
+      }
+    }),
     // Same scoping as Live: the per-workspace read filters on the resolved
     // workspace from `WorkspaceContext` (invariant 1) — never an unscoped pass
     // over the fixture. Like the other Seed adapters, the context arrives
@@ -279,6 +306,7 @@ export function SeedAuditEventLog(
           actorType: input.actorType,
           actorUserId: input.actorUserId ?? null,
           workspaceId: input.workspaceId ?? null,
+          metadata: input.metadata ?? {},
           createdAt: DateTime.formatIso(yield* DateTime.now)
         }
         rows.push(row)

--- a/packages/capabilities/src/governance/audit-event-metadata.test.ts
+++ b/packages/capabilities/src/governance/audit-event-metadata.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from '@effect/vitest'
+import { permittedAuditMetadata } from './audit-event-metadata.ts'
+
+describe('permitted audit metadata', () => {
+  it('keeps only validated operational fields and discards unknown or sensitive values', () => {
+    expect(
+      permittedAuditMetadata({
+        role: 'admin',
+        protocol: 'saml',
+        attempts: 0,
+        responseStatus: null,
+        sizeBytes: 42,
+        token: 'secret',
+        email: 'private@example.com',
+        name: 'private name',
+        ip: '127.0.0.1',
+        scopes: ['read'],
+        nested: { role: 'owner', password: 'secret' }
+      })
+    ).toEqual({
+      role: 'admin',
+      protocol: 'saml',
+      attempts: 0,
+      responseStatus: null,
+      sizeBytes: 42
+    })
+  })
+
+  it('fails closed on malformed approved fields', () => {
+    expect(permittedAuditMetadata({ attempts: { secret: 'hidden' } })).toEqual({})
+    expect(permittedAuditMetadata({ role: 'private arbitrary value' })).toEqual({})
+    expect(permittedAuditMetadata({ responseStatus: 999 })).toEqual({})
+    expect(permittedAuditMetadata({ sizeBytes: -1 })).toEqual({})
+  })
+})

--- a/packages/capabilities/src/governance/audit-event-metadata.test.ts
+++ b/packages/capabilities/src/governance/audit-event-metadata.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from '@effect/vitest'
-import { permittedAuditMetadata } from './audit-event-metadata.ts'
+import { decodeAuditEventMetadata } from './audit-event-metadata.ts'
 
 describe('permitted audit metadata', () => {
   it('keeps only validated operational fields and discards unknown or sensitive values', () => {
     expect(
-      permittedAuditMetadata({
+      decodeAuditEventMetadata({
         role: 'admin',
         protocol: 'saml',
         attempts: 0,
@@ -27,9 +27,17 @@ describe('permitted audit metadata', () => {
   })
 
   it('fails closed on malformed approved fields', () => {
-    expect(permittedAuditMetadata({ attempts: { secret: 'hidden' } })).toEqual({})
-    expect(permittedAuditMetadata({ role: 'private arbitrary value' })).toEqual({})
-    expect(permittedAuditMetadata({ responseStatus: 999 })).toEqual({})
-    expect(permittedAuditMetadata({ sizeBytes: -1 })).toEqual({})
+    expect(decodeAuditEventMetadata({ attempts: { secret: 'hidden' } })).toEqual({})
+    expect(decodeAuditEventMetadata({ role: 'private arbitrary value' })).toEqual({})
+    expect(decodeAuditEventMetadata({ responseStatus: 999 })).toEqual({})
+    expect(decodeAuditEventMetadata({ sizeBytes: -1 })).toEqual({})
+    expect(decodeAuditEventMetadata({ attempts: 2, role: 'invalid' })).toEqual({})
   })
+
+  it.each([null, undefined, 'private text', ['private'], 42])(
+    'discards malformed stored metadata %j',
+    (metadata) => {
+      expect(decodeAuditEventMetadata(metadata)).toEqual({})
+    }
+  )
 })

--- a/packages/capabilities/src/governance/audit-event-metadata.ts
+++ b/packages/capabilities/src/governance/audit-event-metadata.ts
@@ -1,0 +1,29 @@
+import { type JsonObject } from '@b2b-saas-starter/db/schema'
+import { Option, Schema } from 'effect'
+
+// A positive allowlist: new producer fields remain private until reviewed here.
+// Never expose names, emails, IPs, URLs, scopes, credentials, or nested payloads.
+const PermittedMetadata = Schema.Struct({
+  role: Schema.optionalKey(Schema.Literals(['owner', 'admin', 'member'])),
+  protocol: Schema.optionalKey(Schema.Literals(['saml', 'oidc'])),
+  attempts: Schema.optionalKey(
+    Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))
+  ),
+  responseStatus: Schema.optionalKey(
+    Schema.NullOr(
+      Schema.Number.check(
+        Schema.isInt(),
+        Schema.isBetween({ minimum: 100, maximum: 599 })
+      )
+    )
+  ),
+  sizeBytes: Schema.optionalKey(
+    Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))
+  )
+})
+
+const decodePermittedMetadata = Schema.decodeUnknownOption(PermittedMetadata)
+
+export function permittedAuditMetadata(metadata: JsonObject): JsonObject {
+  return Option.getOrElse(decodePermittedMetadata(metadata), () => ({}))
+}

--- a/packages/capabilities/src/governance/audit-event-metadata.ts
+++ b/packages/capabilities/src/governance/audit-event-metadata.ts
@@ -1,9 +1,8 @@
-import { type JsonObject } from '@b2b-saas-starter/db/schema'
 import { Option, Schema } from 'effect'
 
 // A positive allowlist: new producer fields remain private until reviewed here.
 // Never expose names, emails, IPs, URLs, scopes, credentials, or nested payloads.
-const PermittedMetadata = Schema.Struct({
+export const AuditEventMetadata = Schema.Struct({
   role: Schema.optionalKey(Schema.Literals(['owner', 'admin', 'member'])),
   protocol: Schema.optionalKey(Schema.Literals(['saml', 'oidc'])),
   attempts: Schema.optionalKey(
@@ -22,8 +21,11 @@ const PermittedMetadata = Schema.Struct({
   )
 })
 
-const decodePermittedMetadata = Schema.decodeUnknownOption(PermittedMetadata)
+const decodePermittedMetadata = Schema.decodeUnknownOption(AuditEventMetadata)
 
-export function permittedAuditMetadata(metadata: JsonObject): JsonObject {
+export function decodeAuditEventMetadata(
+  // oxlint-disable-next-line anti-slop/no-unknown-parameters -- this decoder is the boundary for untrusted persisted JSON, including malformed non-object values
+  metadata: unknown
+): typeof AuditEventMetadata.Type {
   return Option.getOrElse(decodePermittedMetadata(metadata), () => ({}))
 }


### PR DESCRIPTION
## What

Make individual audit events linkable from the workspace audit table. An `event`
search parameter opens the existing detail sheet with full event, actor, target,
and UTC timestamp context, even when the event falls outside the current filters
or cursor. Collection ordering stays newest first, with page-only sorting removed.

The server rechecks the session and workspace audit-read permission before loading
details. Seed and Live look up the event within the resolved workspace and return
the same result for missing and foreign events. Details expose only validated
metadata fields from one allowlist schema. Lists omit metadata, and Seed snapshots
recorded metadata so subsequent caller mutations cannot rewrite an event.

Native links preserve filters. The sheet supports keyboard activation, Escape,
close, Back/Forward, refresh, focus restoration, and narrow screens. Slow requests
show the existing pending state; permission denials and retryable failures remain
distinct from missing events. Clear removes all filters and the cursor.

## Checklist

- [x] `pnpm run check` and `pnpm run build` pass locally
- [x] Tests added or updated for behavioural changes
- [x] `CONTEXT.md` reviewed; no new domain language introduced
- [x] ADR 0025 updated with lookup, metadata, ordering, and navigation decisions

## Notes for reviewers

Validation includes 131 focused capability tests, shared Seed/Live contracts, and
all five Playwright audit tests against real local auth and D1 on port 3074. Browser
coverage includes refresh and focus restoration after retry. The 390 × 844 mobile
screenshot was inspected. A fresh recursive build with task caching disabled also
passed, including the client bundle boundary guard.

This adds no REST endpoint or MCP operation, and no table or state framework.
Billing and background changes only complete existing audit service test stubs.

The shared TanStack SSR error transport still returns HTTP 500 for a forbidden
loader. The audit UI explicitly reports access denied and exposes no audit payload;
this PR does not change the shared transport mapping.
