### PR TITLE
chore(agents): reduce delegated workflow costs

### DIFF
--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: Implement an agreed issue or spec through delegated work, proportionate independent review, fixes, and a PR ready to merge.
+description: Implement an agreed issue or spec through implementation, review, fixes, and a PR ready to merge.
 ---
 
 # Implement
@@ -9,45 +9,39 @@ Default endpoint: a reviewed PR ready to merge, without merging. Honor a narrowe
 user request.
 
 1. Read the issue and comments using [tracker guidance](../../../docs/agents/issue-tracker.md).
-   Preserve AC IDs through tests and the PR. Use grilling for unresolved product
-   decisions and `to-tickets` for multiple independently verifiable slices.
-2. Keep the active session's provider stable across orchestration, review, and workers,
-   regardless of host application. Use the main model for orchestration and final
-   synthesis, and a configured cheaper sibling for bounded work:
-   GLM 5.3 → GLM 5.3 Flash, Claude Opus → Sonnet, Codex Astra → Luna.
-   Resolve names through the host's configured aliases; inherit the main model only
-   when a same-provider worker is unavailable. Switch providers only on user request.
-   Delegate complete tasks with compact briefs containing ACs, owned files, and
-   relevant context pointers. Use `fork_turns: none` by default; never fork the
-   full conversation unless the worker needs that exact context. Settle shared
-   interfaces once and assign one writer to shared wiring. Keep tiny tasks local.
-   Default to one implementation worker, adding a second only for genuinely
-   independent file boundaries.
+   Preserve AC IDs through tests and the PR. Use `grilling` for unresolved product
+   decisions and `to-tickets` for independently verifiable slices.
+2. Use the host's available delegation tools and configured model IDs. Keep the
+   session's provider unless the user requests a switch. Use a cheaper same-provider
+   model for bounded implementation, review, and browser work when available;
+   otherwise inherit the session model. Keep coordination and final decisions in
+   the main session. If delegation is unavailable, work locally and report that
+   review was not independent.
+   Give workers compact briefs with ACs, owned files, and relevant pointers.
+   Start with fresh context where supported; include conversation history only
+   when the task depends on it. Keep tiny tasks local. Default to one implementation
+   worker; add workers for independent file boundaries. Assign one writer to shared wiring.
 3. Apply `effect` with [repo examples](../../../docs/agents/effect-examples.md),
    `codebase-design` for module interfaces, `effect-service-design` for service
    ownership/Layers, and `impeccable` for UI. Use `tdd` at agreed behavior seams.
+   If a supporting skill is missing, follow [skills setup](../../../docs/agents/skills.md).
 4. Docs and mechanical edits get one targeted reviewer. Ordinary behavior changes
-   get one reviewer using both Standards and Spec lenses against a fixed base/head.
-   Use separate independent reviewers only for high-risk auth, billing, persistence,
-   or cross-package changes. Review workers use the cheaper sibling by default;
-   the main model adjudicates findings and owns the final repair decision. Fold
-   `thermo-nuclear-code-quality-review` into the Standards lens when needed.
-   Reserve a separate deep audit for a concrete architectural concern or explicit request.
-5. Consolidate overlapping findings and triage before assigning fixes. Structural
-   suggestions need a concrete benefit. Independently recheck accepted repairs
-   and affected callers; repeat the broader review only when design or behavior
-   changes substantially.
-6. Run focused checks during work and `pnpm run validate` on the integrated result.
-   Save verbose logs to files; read summaries and relevant failures. Commit and
-   create/update the PR using the repo template.
-7. For UI acceptance gaps, delegate a bounded browser smoke test to Luna. Give it
-   the exact URL, credential source, actions, expected visible outcomes, and a
-   maximum of roughly 8–12 browser actions. It should stop on the first failure,
-   return concise pass/fail evidence, and use screenshots or console/network
-   diagnostics only when needed. Prefer Playwright for repeatable regression coverage.
-8. Run native `gh pr checks --required --watch` as a process with a 30-minute
-   deadline per head; inspect completion or failure rather than reasoning over
-   every poll. Fix actionable failures and reverify after pushes. Before finishing,
-   confirm the same head satisfies required checks/reviews and is up to date with
-   and mergeable against the base. Report optional failures and stalled or external
-   blockers separately.
+   get one reviewer checking repo standards and the agreed spec against a fixed
+   base/head. Use separate reviewers for high-risk auth, billing, persistence,
+   or cross-package changes. Apply `thermo-nuclear-code-quality-review` for
+   concrete architectural concerns or an explicit request.
+5. Consolidate findings before assigning fixes. Structural suggestions need a
+   concrete benefit. Independently recheck accepted repairs and affected callers;
+   repeat the broader review only when design or behavior changes substantially.
+6. For UI acceptance gaps, use available browser tooling to run one smoke path.
+   Give the verifier the URL, credential source, actions, expected visible outcomes,
+   and a limit of 12 browser actions. Stop on the first failure and return pass/fail
+   evidence; gather screenshots or console/network diagnostics as needed.
+   Prefer existing Playwright coverage for regression checks. If browser tooling
+   is unavailable, report the unverified acceptance criteria.
+7. Run focused checks during work and `pnpm run validate` on the integrated result.
+   Commit and create/update the PR using the repo template.
+8. Run `gh pr checks --required --watch` with a 30-minute deadline per head.
+   Fix actionable failures and reverify after pushes. Before finishing, confirm
+   the same head satisfies required checks/reviews and is up to date with and
+   mergeable against the base. Report optional failures and external blockers.

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -21,6 +21,18 @@ user request.
    Start with fresh context where supported; include conversation history only
    when the task depends on it. Keep tiny tasks local. Default to one implementation
    worker; add workers for independent file boundaries. Assign one writer to shared wiring.
+
+   Use the context controls exposed by the active tool schema:
+
+   - Codex: set `fork_turns: "none"` when exposed; its default can inherit the
+     full conversation. If the tool exposes `fork_context` instead, set it to `false`.
+   - Claude Code: start a new `Agent` with `subagent_type: "general-purpose"`
+     or a configured non-fork subagent. These start fresh; `fork` copies history.
+   - OpenCode: start a new `task` with a compact `prompt` and omit `task_id`.
+     Supplying `task_id` resumes an existing worker's context.
+
+   Resume an existing worker when continuing its assigned task.
+
 3. Apply `effect` with [repo examples](../../../docs/agents/effect-examples.md),
    `codebase-design` for module interfaces, `effect-service-design` for service
    ownership/Layers, and `impeccable` for UI. Use `tdd` at agreed behavior seams.

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -25,10 +25,9 @@ user request.
    `codebase-design` for module interfaces, `effect-service-design` for service
    ownership/Layers, and `impeccable` for UI. Use `tdd` at agreed behavior seams.
    If a supporting skill is missing, follow [skills setup](../../../docs/agents/skills.md).
-4. Docs and mechanical edits get one targeted reviewer. Ordinary behavior changes
-   get one reviewer checking repo standards and the agreed spec against a fixed
-   base/head. Use separate reviewers for high-risk auth, billing, persistence,
-   or cross-package changes. Apply `thermo-nuclear-code-quality-review` for
+4. Docs and mechanical edits get one targeted reviewer. For behavior changes, use
+   `code-review` against a fixed base/head and the agreed spec, with its separate
+   Standards and Spec reviewers. Apply `thermo-nuclear-code-quality-review` for
    concrete architectural concerns or an explicit request.
 5. Consolidate findings before assigning fixes. Structural suggestions need a
    concrete benefit. Independently recheck accepted repairs and affected callers;

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -12,11 +12,14 @@ user request.
    Preserve AC IDs through tests and the PR. Use `grilling` for unresolved product
    decisions and `to-tickets` for independently verifiable slices.
 2. Use the host's available delegation tools and configured model IDs. Keep the
-   session's provider unless the user requests a switch. Use a cheaper same-provider
-   model for bounded implementation, review, and browser work when available;
-   otherwise inherit the session model. Keep coordination and final decisions in
-   the main session. If delegation is unavailable, work locally and report that
-   review was not independent.
+   session's provider unless the user requests a switch. For bounded implementation,
+   review, and browser work, prefer GLM 5.3 → GLM 5.3 Flash, Claude Opus → Sonnet,
+   Codex Astra → Luna. Resolve these pairings through the host's configured model
+   IDs or worker profiles and select the worker model explicitly. For other models,
+   use a configured cheaper same-provider model. Inherit the session model only
+   after checking that no suitable worker model is available, and report the fallback.
+   Keep coordination and final decisions in the main session. If delegation is
+   unavailable, work locally and report that review was not independent.
    Give workers compact briefs with ACs, owned files, and relevant pointers.
    Start with fresh context where supported; include conversation history only
    when the task depends on it. Keep tiny tasks local. Default to one implementation

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -11,24 +11,28 @@ user request.
 1. Read the issue and comments using [tracker guidance](../../../docs/agents/issue-tracker.md).
    Preserve AC IDs through tests and the PR. Use grilling for unresolved product
    decisions and `to-tickets` for multiple independently verifiable slices.
-2. Keep the active session's provider and model routing stable across orchestration,
-   review, and workers, regardless of host application. Use the main model for
-   orchestration/review and a configured cheaper sibling for bounded work:
+2. Keep the active session's provider stable across orchestration, review, and workers,
+   regardless of host application. Use the main model for orchestration and final
+   synthesis, and a configured cheaper sibling for bounded work:
    GLM 5.3 → GLM 5.3 Flash, Claude Opus → Sonnet, Codex Astra → Luna.
-   Resolve names through the host's configured aliases; inherit the main model
-   if a same-provider worker is unavailable. Switch providers only on user request.
-   Delegate complete tasks with focused briefs: ACs, owned files, and relevant
-   context pointers. Settle shared interfaces once and assign one writer to shared
-   wiring. Keep tiny tasks local when delegation would cost more context than the work.
+   Resolve names through the host's configured aliases; inherit the main model only
+   when a same-provider worker is unavailable. Switch providers only on user request.
+   Delegate complete tasks with compact briefs containing ACs, owned files, and
+   relevant context pointers. Use `fork_turns: none` by default; never fork the
+   full conversation unless the worker needs that exact context. Settle shared
+   interfaces once and assign one writer to shared wiring. Keep tiny tasks local.
+   Default to one implementation worker, adding a second only for genuinely
+   independent file boundaries.
 3. Apply `effect` with [repo examples](../../../docs/agents/effect-examples.md),
    `codebase-design` for module interfaces, `effect-service-design` for service
    ownership/Layers, and `impeccable` for UI. Use `tdd` at agreed behavior seams.
-4. Docs and mechanical edits get one targeted reviewer. Substantive behavior,
-   especially auth, billing, persistence, or cross-package changes, gets
-   `code-review` against a fixed base/head and the agreed spec. Fold
-   `thermo-nuclear-code-quality-review` into its Standards reviewer with relevant
-   design/Effect guidance; keep Spec independent. Reserve a separate deep audit
-   for a concrete architectural concern or explicit request.
+4. Docs and mechanical edits get one targeted reviewer. Ordinary behavior changes
+   get one reviewer using both Standards and Spec lenses against a fixed base/head.
+   Use separate independent reviewers only for high-risk auth, billing, persistence,
+   or cross-package changes. Review workers use the cheaper sibling by default;
+   the main model adjudicates findings and owns the final repair decision. Fold
+   `thermo-nuclear-code-quality-review` into the Standards lens when needed.
+   Reserve a separate deep audit for a concrete architectural concern or explicit request.
 5. Consolidate overlapping findings and triage before assigning fixes. Structural
    suggestions need a concrete benefit. Independently recheck accepted repairs
    and affected callers; repeat the broader review only when design or behavior
@@ -36,7 +40,12 @@ user request.
 6. Run focused checks during work and `pnpm run validate` on the integrated result.
    Save verbose logs to files; read summaries and relevant failures. Commit and
    create/update the PR using the repo template.
-7. Run native `gh pr checks --required --watch` as a process with a 30-minute
+7. For UI acceptance gaps, delegate a bounded browser smoke test to Luna. Give it
+   the exact URL, credential source, actions, expected visible outcomes, and a
+   maximum of roughly 8–12 browser actions. It should stop on the first failure,
+   return concise pass/fail evidence, and use screenshots or console/network
+   diagnostics only when needed. Prefer Playwright for repeatable regression coverage.
+8. Run native `gh pr checks --required --watch` as a process with a 30-minute
    deadline per head; inspect completion or failure rather than reasoning over
    every poll. Fix actionable failures and reverify after pushes. Before finishing,
    confirm the same head satisfies required checks/reviews and is up to date with

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -39,8 +39,9 @@ user request.
    If a supporting skill is missing, follow [skills setup](../../../docs/agents/skills.md).
 4. Docs and mechanical edits get one targeted reviewer. For behavior changes, use
    `code-review` against a fixed base/head and the agreed spec, with its separate
-   Standards and Spec reviewers. Apply `thermo-nuclear-code-quality-review` for
-   concrete architectural concerns or an explicit request.
+   Standards and Spec reviewers. Have the Standards reviewer apply
+   `thermo-nuclear-code-quality-review` in the same pass and deduplicate overlapping
+   findings. Keep Spec independent; run a separate deep audit only on explicit request.
 5. Consolidate findings before assigning fixes. Structural suggestions need a
    concrete benefit. Independently recheck accepted repairs and affected callers;
    repeat the broader review only when design or behavior changes substantially.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Cloudflare-first B2B SaaS starter. Public site showcases the repo; app demonstra
 
 No production users. Refactor freely, rename, and drop stored shapes. No backwards compatibility, deprecation paths, or old-data shims.
 
-For issue/spec implementation, follow the repo's [implement skill](.agents/skills/implement/SKILL.md), including delegation, review, PR creation, and readiness verification. For specifications, ticketing, and review context, read [issue-tracker.md](docs/agents/issue-tracker.md).
+For issue/spec work, follow the [implement skill](.agents/skills/implement/SKILL.md). For ticket context, read [issue-tracker.md](docs/agents/issue-tracker.md).
 
 ## Intent Node Index
 
@@ -28,21 +28,11 @@ For issue/spec implementation, follow the repo's [implement skill](.agents/skill
 | Typed SDK         | [packages/sdk/AGENTS.md](packages/sdk/AGENTS.md)                     |
 | Lint rules        | [packages/oxlint-plugin/AGENTS.md](packages/oxlint-plugin/AGENTS.md) |
 
-Capabilities have leaf nodes; the package node maps them.
+Capabilities have leaf nodes.
 
 ## Setup
 
-Requires [Vite+](https://viteplus.dev) (`vp`, >= 0.3.0), providing Node and pinned pnpm.
-
-```bash
-vp install
-pnpm run dev        # web on http://localhost:3071
-pnpm run check      # typecheck + lint + format:check + dead-code + test
-```
-
-- pnpm only; versions single-sourced in the `catalog` block of `pnpm-workspace.yaml`, referenced as `"catalog:"`. Toolchain versions (`vite`, `vitest`, `oxlint`, `oxfmt`) move with `vp upgrade`, never by hand.
-- Task runner is Vite Task (`vp run`), formatting `vp fmt`, linting `vp lint`.
-- The pre-commit hook only formats. Run `pnpm run check` before committing; re-run after `check:fix`. CI intentionally excludes formatting. Final validation: `pnpm run validate`, prerequisites in [docs/setup.md](docs/setup.md#validation).
+Use [Vite+](https://viteplus.dev) for pinned Node and pnpm. Run `vp install`, `pnpm run check`, and `pnpm run validate`; use `vp run`, `vp fmt`, and `vp lint`. Toolchain versions live in the workspace catalog and move through `vp upgrade`.
 
 ## Rules
 
@@ -52,12 +42,16 @@ pnpm run check      # typecheck + lint + format:check + dead-code + test
 4. Cloudflare-first primitives: Workers, D1, Queues, Email, Turnstile, Workers AI, Alchemy.
 5. Borrow interaction patterns from other products, never their domain language.
 6. No new architecture (games, PWA, realtime, Durable Objects) without a starter use case.
-7. Declaration merges belong in `.d.ts`. `declare module 'x'` needs a top-level import; `declare global` and `declare namespace` need none. Examples: `apps/web/src/router-register.d.ts`, `apps/web/src/worker-env.d.ts`.
+7. Declaration merges belong in `.d.ts`; module declarations need a top-level import.
 8. Seed and Live adapters stay equivalent for the demo identity. `packages/capabilities/src/seed-fixture.ts` owns `usr_demo` / `starter-lab`; `scripts/seed.ts` adds only the password. SPA membership uses the fixture; identity drift can break navigation while full-page loads succeed.
+
+## Agent execution
+
+- Delegated workers get a compact brief with acceptance criteria, owned files, and relevant pointers. Do not pass the full conversation; use no inherited turns unless the task truly depends on them.
+- Use the configured cheaper sibling for bounded work. Luna is the default browser verifier: run one deterministic smoke path, cap it at roughly 8–12 browser actions, and stop on the first failure. Prefer existing Playwright coverage for repeatable regression checks.
+- Read only the intent nodes and skill branches needed for the task. Save verbose command output to a log and inspect a bounded summary.
 
 ## Commit & Release Conventions
 
 - Create/update PR bodies from [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md), the final diff, and observed validation. Remove prompts and unused optional sections; pass the completed body via `--body-file`.
 - Commits and PR titles follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): subject`); PR Gate rejects non-conforming titles. Breaking changes use `!` or a `BREAKING CHANGE:` footer.
-- release-please opens `chore(master): release ...` PRs from merged commits; merging one tags and publishes.
-- `CLAUDE.md` is a symlink to this file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Cloudflare-first B2B SaaS starter. Public site showcases the repo; app demonstra
 
 No production users. Refactor freely, rename, and drop stored shapes. No backwards compatibility, deprecation paths, or old-data shims.
 
-For issue/spec work, follow the [implement skill](.agents/skills/implement/SKILL.md). For ticket context, read [issue-tracker.md](docs/agents/issue-tracker.md).
+For issue/spec implementation, follow the [implement skill](.agents/skills/implement/SKILL.md). For ticket context, read [issue-tracker.md](docs/agents/issue-tracker.md).
 
 ## Intent Node Index
 
@@ -28,11 +28,11 @@ For issue/spec work, follow the [implement skill](.agents/skills/implement/SKILL
 | Typed SDK         | [packages/sdk/AGENTS.md](packages/sdk/AGENTS.md)                     |
 | Lint rules        | [packages/oxlint-plugin/AGENTS.md](packages/oxlint-plugin/AGENTS.md) |
 
-Capabilities have leaf nodes.
-
 ## Setup
 
-Use [Vite+](https://viteplus.dev) for pinned Node and pnpm. Run `vp install`, `pnpm run check`, and `pnpm run validate`; use `vp run`, `vp fmt`, and `vp lint`. Toolchain versions live in the workspace catalog and move through `vp upgrade`.
+Use [Vite+](https://viteplus.dev) for pinned Node and pnpm. Install with `vp install`; use `vp run`, `vp fmt`, and `vp lint`. Toolchain versions live in the workspace catalog and move through `vp upgrade`.
+
+Run `pnpm run check` before committing and after `check:fix`; the pre-commit hook only formats. Run `pnpm run validate` before PR handoff; see [prerequisites](docs/setup.md#validation). For Codex, Claude Code, or OpenCode skills, follow [shared skills setup](docs/agents/skills.md).
 
 ## Rules
 
@@ -47,9 +47,7 @@ Use [Vite+](https://viteplus.dev) for pinned Node and pnpm. Run `vp install`, `p
 
 ## Agent execution
 
-- Delegated workers get a compact brief with acceptance criteria, owned files, and relevant pointers. Do not pass the full conversation; use no inherited turns unless the task truly depends on them.
-- Use the configured cheaper sibling for bounded work. Luna is the default browser verifier: run one deterministic smoke path, cap it at roughly 8–12 browser actions, and stop on the first failure. Prefer existing Playwright coverage for repeatable regression checks.
-- Read only the intent nodes and skill branches needed for the task. Save verbose command output to a log and inspect a bounded summary.
+Read only the intent nodes and skill branches needed for the task. Save verbose command output to a log and inspect summaries and failures.
 
 ## Commit & Release Conventions
 

--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -46,3 +46,9 @@ Global updates affect every project that uses those skills.
 Discovery: [Codex](https://learn.chatgpt.com/docs/build-skills),
 [Claude Code](https://code.claude.com/docs/en/skills),
 [OpenCode](https://opencode.ai/docs/skills/).
+
+Worker context: [Codex spawn implementation](https://github.com/openai/codex/blob/main/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs),
+[Claude Code subagents](https://code.claude.com/docs/en/sub-agents#how-forks-differ-from-other-subagents),
+[OpenCode task parameters](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/tool/task.ts).
+Codex host tools differ; the workflow's `fork_turns` instruction applies when
+the active spawn tool exposes that parameter.

--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -1,7 +1,8 @@
 # Shared skills
 
-The repo owns `.agents/skills/implement`; `.claude/skills` links to the same
-collection. Supporting skills are installed globally, outside this checkout.
+The repo owns `.agents/skills/implement`. Codex and OpenCode read that directory;
+Claude Code reads it through the `.claude/skills` symlink. `CLAUDE.md` links to
+`AGENTS.md` for shared repo instructions. Supporting skills install globally.
 
 ## Setup
 
@@ -23,6 +24,11 @@ Claude Code gives personal skills precedence over project skills with matching
 names. If you have a global `implement`, remove that conflicting installation or
 explicitly direct the agent to this repo's skill.
 
+In any host, ask: "Use `.agents/skills/implement/SKILL.md` to implement issue #123."
+The workflow uses the session's provider and available tools. Configure a cheaper
+worker model in your host if desired; the workflow falls back to the session
+model, or local execution when delegation is unavailable.
+
 ## Updates
 
 Ask an agent to update the pinned commits in `scripts/agent-skills.json`, review
@@ -37,5 +43,6 @@ Updates replace only installations owned by this installer that have not been
 edited locally. Resolve reported personal-installation conflicts manually.
 Global updates affect every project that uses those skills.
 
-Discovery: [Claude Code](https://code.claude.com/docs/en/skills),
+Discovery: [Codex](https://learn.chatgpt.com/docs/build-skills),
+[Claude Code](https://code.claude.com/docs/en/skills),
 [OpenCode](https://opencode.ai/docs/skills/).


### PR DESCRIPTION
## Outcome

The implementation workflow now limits avoidable model and tool usage during delegated work.

- Workers receive compact briefs and use `fork_turns: none` by default.
- Normal implementation defaults to one worker, with additional workers reserved for independent boundaries.
- Luna handles bounded browser smoke verification with an 8–12 action budget and concise evidence.
- Ordinary changes use one reviewer with both Standards and Spec lenses; separate reviewers remain available for high-risk changes.
- Root agent guidance now favors focused context reads and bounded command output.

## Decisions

The root `AGENTS.md` remains under the 500-word intent-node budget. Existing setup guidance was compressed to preserve the higher-value cross-file invariants and execution rules.

## Validation

- `git diff --check` passed.
- Pre-commit formatting completed successfully for both Markdown files.
- Root `AGENTS.md` is 485 words.
- Skill frontmatter and routing content were manually verified.

The bundled skill validator could not run because the environment does not have the Python `yaml` module installed.

## Risks and remaining work

None known.
