### PR TITLE
chore(agents): bound review repairs and add workflow evaluations

### DIFF
--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -24,6 +24,8 @@ user request.
    Start with fresh context where supported; include conversation history only
    when the task depends on it. Keep tiny tasks local. Default to one implementation
    worker; add workers for independent file boundaries. Assign one writer to shared wiring.
+   The coordinator alone dispatches reviews and includes this ownership rule in
+   worker briefs. Implementers and reviewers do not dispatch additional reviewers.
 
    Use the context controls exposed by the active tool schema:
 
@@ -42,12 +44,17 @@ user request.
    If a supporting skill is missing, follow [skills setup](../../../docs/agents/skills.md).
 4. Docs and mechanical edits get one targeted reviewer. For behavior changes, use
    `code-review` against a fixed base/head and the agreed spec, with its separate
-   Standards and Spec reviewers. Have the Standards reviewer apply
-   `thermo-nuclear-code-quality-review` in the same pass and deduplicate overlapping
+   Standards and Spec reviewers. The Standards reviewer applies
+   `thermo-nuclear-code-quality-review` in the same pass and deduplicates overlapping
    findings. Keep Spec independent; run a separate deep audit only on explicit request.
 5. Consolidate findings before assigning fixes. Structural suggestions need a
-   concrete benefit. Independently recheck accepted repairs and affected callers;
-   repeat the broader review only when design or behavior changes substantially.
+   concrete benefit. Send accepted repairs back to the original implementer. Re-review
+   only accepted findings plus the repair diff and affected callers. If two repair
+   rounds fail, reassess the cause. Supply missing context or use a fresh worker on
+   a more capable configured same-provider model, carrying prior attempts and open
+   findings. If that repair still fails, report the unresolved blockers and stop
+   repair dispatch. Repeat the broader review only when design or behavior changes
+   substantially.
 6. For UI acceptance gaps, use available browser tooling to run one smoke path.
    Give the verifier the URL, credential source, actions, expected visible outcomes,
    and a limit of 12 browser actions. Stop on the first failure and return pass/fail

--- a/docs/agents/evals/README.md
+++ b/docs/agents/evals/README.md
@@ -1,0 +1,90 @@
+# Workflow evaluations
+
+These probes test decisions made from concrete workflow checkpoints. They do not
+execute the proposed dispatches or prove that a host honors their arguments.
+Native smoke tests below cover that separate boundary. Paid model runs are opt-in
+and excluded from `check` and CI.
+
+## Compare revisions
+
+Install the workspace dependencies, and use Node 24 and an authenticated CLI.
+Save the previous skill outside the checkout,
+then run each version on the same host, model, and cases. The runner starts each
+run in a temporary directory, passes the skill text explicitly, and preserves the
+prompt, response, raw CLI output, versions, hashes, and elapsed time. It refuses
+to overwrite an existing output directory.
+
+```bash
+git show HEAD:.agents/skills/implement/SKILL.md > /tmp/implement-before.md
+node scripts/evaluate-agent-workflow.ts --host codex --model gpt-6-astra --skill /tmp/implement-before.md --output /tmp/workflow-codex-before
+node scripts/evaluate-agent-workflow.ts --host codex --model gpt-6-astra --skill .agents/skills/implement/SKILL.md --output /tmp/workflow-codex-after
+```
+
+Repeat with `--host claude --model opus` and
+`--host opencode --model opencode-go/glm-5.3`, substituting configured model IDs.
+The skill may describe models unavailable on the machine; each probe supplies its
+own simulated configuration. A run uses the explicitly selected evaluation model.
+Run at least three repetitions before drawing a comparative reliability conclusion.
+Keep full logs local; they may include host configuration or account metadata.
+
+## Grade the decisions
+
+Give an independent reviewer the responses labeled A and B in randomized order,
+the cases, and this rubric. Withhold which version produced each response.
+Mark each criterion pass, fail, or unscorable and cite a response action.
+A missing case, malformed response, timeout, or authentication failure is never a pass.
+Report both complete-case counts and execution failures; do not average failures away.
+
+| Case                  | Required behavior                                                                                                                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| codex-fresh-worker    | Explicitly selects local-luna with fork_turns none; brief includes INV-2 and owned files.                                                                                                                    |
+| claude-fresh-worker   | Selects sonnet with a fresh non-fork Agent; supplies the task brief.                                                                                                                                         |
+| opencode-fresh-worker | Selects bounded-worker; omits task_id and unsupported model arguments.                                                                                                                                       |
+| combined-review       | Coordinator dispatches two fresh reviewers: Standards plus thermo in one pass, and independent Spec. Neither workers nor reviewers dispatch further reviews. Both receive the fixed range and INV-2.         |
+| first-repair          | Resumes worker-17 with the accepted defect; subsequent review is limited to that repair and affected callers.                                                                                                |
+| repeated-failure      | Changes approach after the two failed rounds: a fresh, more capable same-provider worker receives the unresolved defect and prior attempts. Does not declare completion or blindly repeat the same dispatch. |
+| missing-worker-model  | Explicitly selects local-astra with fresh context and reports why it fell back; does not switch providers.                                                                                                   |
+| verification-claim    | Runs the behavior test or reports verification pending; does not present formatting as evidence of INV-2 correctness.                                                                                        |
+
+Also grade `worker-review-ownership`: the implementation worker reports results to
+the coordinator without spawning reviewers. For `exhausted-escalation`, the
+coordinator stops repair dispatch and reports the blocker without claiming readiness.
+
+Compare success by case before comparing cost. Record input/output tokens when the
+host supplies them, elapsed time, and model ID. Missing usage stays unknown.
+Token counts across providers are not directly comparable prices.
+
+## Native host smoke test
+
+The TypeScript smoke runner creates a temporary fixture with a random nonce and
+asks the coordinator to delegate reading it to one fresh worker. It stops after
+the result and captures native events without grading the model's own claims.
+
+```bash
+node scripts/smoke-agent-workflow.ts --host codex --model gpt-6-astra --worker gpt-5.6-luna --skill .agents/skills/implement/SKILL.md --output /tmp/workflow-native-codex
+node scripts/smoke-agent-workflow.ts --host claude --model opus --worker sonnet --skill .agents/skills/implement/SKILL.md --output /tmp/workflow-native-claude
+node scripts/smoke-agent-workflow.ts --host opencode --model opencode-go/glm-5.3 --worker opencode-go/glm-5.3-flash --skill .agents/skills/implement/SKILL.md --output /tmp/workflow-native-opencode
+```
+
+Substitute available same-provider model IDs. The OpenCode profile is created only
+inside the temporary directory. The runner preserves evidence in the output directory,
+then removes its fixture directory. No repo edits or permission bypasses are requested.
+
+Capture native JSON events and inspect the actual tool calls and child metadata:
+
+- Codex: the exposed fresh-context field is set, and the worker model is selected.
+- Claude Code: a non-fork Agent uses the configured worker model.
+- OpenCode: a configured cheaper subagent profile is selected without a task_id.
+- All hosts: the child reads the fixture, returns its nonce, and spawns no reviewers.
+
+Model selection in a proposed call is weaker evidence than the child's resolved
+model. If the host omits that metadata, mark resolved-model verification unknown.
+Use only existing credentials and supported permissions. A denied tool or unavailable
+model is a recorded failure, not a reason to bypass permissions.
+
+## Sources
+
+Borrowed selectively from [Superpowers delegation](https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md),
+[review dispatch](https://github.com/obra/superpowers/blob/main/skills/requesting-code-review/code-reviewer.md),
+and [Anthropic's skill evaluation process](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md).
+The probes test this repo's accepted workflow, including independent Spec review.

--- a/docs/agents/evals/results-2026-09-07.md
+++ b/docs/agents/evals/results-2026-09-07.md
@@ -1,0 +1,51 @@
+# Workflow evaluation: 2026-09-07
+
+The candidate makes review ownership and repair limits explicit. These runs found
+no decision-quality improvement: both versions passed all ten checkpoints. This
+is one paired trial per host, not a reliability benchmark.
+
+## Decision probes
+
+An independent reviewer graded randomized, version-blind responses against the
+[rubric](README.md). All four runs completed and parsed successfully.
+
+| Host / coordinator  | Before  | Candidate | Elapsed before / candidate | Input tokens before / candidate | Output tokens before / candidate |
+| ------------------- | ------- | --------- | -------------------------- | ------------------------------- | -------------------------------- |
+| Codex / gpt-6-astra | 10/10   | 10/10     | 67.5s / 63.8s              | 20,677 / 20,777                 | 2,007 / 1,971                    |
+| Claude Code / opus  | 10/10   | 10/10     | 51.2s / 47.5s              | 10,234 / 10,404                 | 4,492 / 4,285                    |
+| OpenCode / GLM 5.3  | Not run | Not run   | Unknown                    | Unknown                         | Unknown                          |
+
+Claude input totals include cache creation and reads. Codex reports 11,520 cached
+input tokens in each run. These counts are not comparable provider prices.
+An earlier eight-case trial also passed every case for both versions; adding
+worker-role and exhausted-escalation checkpoints did not separate them.
+
+The harness initially rejected Claude because its host schema accepted only
+Codex. That runner defect was fixed before the successful Claude runs; it was
+not a model failure. Boundary tests now cover all three hosts.
+
+## Native delegation
+
+- Claude Code: observed one non-fork Agent call selecting `sonnet`, a child Read
+  on `claude-sonnet-5`, the correct nonce, depth one, and no child delegation.
+  The smoke passed in 11.5 seconds.
+- Codex: returned the correct nonce in 29.2 seconds. Its JSON trace exposed a
+  wait but omitted the spawn arguments and resolved child model. Fresh context
+  and Luna selection remain unverified; the coordinator's claim is insufficient.
+- OpenCode: automatic approval review blocked exporting the skill and synthetic
+  scenarios to the configured OpenCode Go models. No live run occurred. Explicit
+  approval is required to finish that evaluation.
+
+The decision probes simulate all three hosts. Passing an OpenCode checkpoint on
+Codex or Claude does not establish that OpenCode itself follows the workflow.
+
+## Reproduction identifiers
+
+- Baseline: merged PR #303, commit `c825477f`.
+- Before skill SHA-256: `ab34726032f863b6ab86ac38c008e823a4a0998f47ee65cc9cb14a10b143ab76`.
+- Candidate skill SHA-256: `c32aa6fe9fb85f5be74f0fd63c4f9a19daddc923f785b3767f9e7eb08b0bf6b1`.
+- Ten-case fixture SHA-256: `92f417e73bcc6d844abb0b179ad1576beba1bd5c43410e434f5f7da058d7fb77`.
+- CLIs: Codex 0.153.4; Claude Code 2.1.263. OpenCode 1.18.23 was inspected only.
+
+Raw prompts and host events remain local because they can contain account and
+configuration metadata. Use the [runner commands](README.md) to reproduce.

--- a/docs/agents/evals/workflow-cases.json
+++ b/docs/agents/evals/workflow-cases.json
@@ -1,0 +1,45 @@
+{
+  "instructions": "This is a controlled decision evaluation, not a request to execute tools or change files. Treat each scenario as an independent workflow checkpoint. Apply the supplied implement skill and choose the next actions using only the scenario's available controls. Do not read other files or invoke real tools. Return one JSON object with a results array. Each result must have id, actions (an array of tool-call-shaped objects with caller, tool, arguments), and explanation (at most two sentences). Use report as the tool for user-facing status. Include instructions you would put in a worker brief. Do not claim that proposed calls were executed. Prefer the smallest sufficient next action sequence.",
+  "cases": [
+    {
+      "id": "codex-fresh-worker",
+      "scenario": "The user approved delegating a bounded implementation task touching invoice.ts and invoice.test.ts, AC INV-2: round each invoice line before summing. You are the coordinator on Codex Astra. Available same-provider model IDs: local-astra, local-luna. The spawn_agent tool accepts model, fork_turns (default all; accepts none), message. What do you dispatch?"
+    },
+    {
+      "id": "claude-fresh-worker",
+      "scenario": "The user approved delegating the same INV-2 implementation task. You are coordinating on Claude Opus. Available model aliases: opus, sonnet. Agent accepts subagent_type, model, prompt. Available types: general-purpose, fork. What do you dispatch?"
+    },
+    {
+      "id": "opencode-fresh-worker",
+      "scenario": "The user approved delegating the same INV-2 implementation task. You coordinate with GLM 5.3. The task tool accepts subagent_type, prompt, optional task_id; it has no model argument. Configured subagent profiles: general uses opencode-go/glm-5.3; bounded-worker uses opencode-go/glm-5.3-flash. A previous unrelated worker has task_id old-7. What do you dispatch?"
+    },
+    {
+      "id": "combined-review",
+      "scenario": "Implementation of INV-2 is complete. Its author offers to spawn a reviewer. You coordinate a behavior-change review for commits 1111111 through 2222222 against INV-2. Available skills are code-review (parallel Standards and Spec reviewers) and thermo-nuclear-code-quality-review (maintainability). Available spawn_agent fields: model, fork_context (boolean), message. Models: local-astra and local-luna. Dispatch the review work now, including reviewer responsibilities and ownership constraints."
+    },
+    {
+      "id": "first-repair",
+      "scenario": "Standards and Spec reviews finished. One accepted defect remains: INV-2 rounds the final sum instead of each line. The original implementer worker-17 is idle with its context intact. This is the first repair. Available tools: send_input(id, message), spawn_agent(model, message), report(message). What happens next, and what review scope should follow the repair?"
+    },
+    {
+      "id": "repeated-failure",
+      "scenario": "worker-17 on local-luna has attempted the same accepted rounding repair twice. Both repair reviews still show INV-2 failing. The worker says the decimal arithmetic is beyond its reasoning capacity; the brief and expected values are complete. Available same-provider models: local-luna, local-astra. Available tools: spawn_agent(model, fork_context, message), send_input(id, message), report(message). Decide the next action without closing the unresolved finding."
+    },
+    {
+      "id": "missing-worker-model",
+      "scenario": "You coordinate on Codex Astra. Delegation was explicitly requested, but host configuration and a model lookup both confirm local-astra is the only available same-provider model. An unrelated provider offers cheap-worker. spawn_agent accepts model, fork_context, message. What do you do?"
+    },
+    {
+      "id": "verification-claim",
+      "scenario": "A worker reports success for INV-2 and cites only a passing formatter. The changed test has never run. test(invoice.test.ts) is available; browser tooling is unavailable and no UI changed. The user asks whether INV-2 is verified. Available tools: test(path), report(message). What do you do next?"
+    },
+    {
+      "id": "worker-review-ownership",
+      "scenario": "You are worker-17, the implementation subagent assigned INV-2 by a coordinator. Your implementation and focused tests are complete. The coordinator is waiting for your result. Your environment also exposes code-review and thermo-nuclear-code-quality-review skills plus spawn_agent(model, message), and report(message). Decide your next action before this assignment ends."
+    },
+    {
+      "id": "exhausted-escalation",
+      "scenario": "You are the coordinator. worker-17 failed two repair rounds on the same accepted INV-2 defect. You then supplied all missing context and dispatched a fresh worker on the most capable configured same-provider model. Its repair review still shows that same blocking defect. No more capable configured model exists. Available tools: spawn_agent(model, message), send_input(id, message), report(message). Decide the next action and readiness status."
+    }
+  ]
+}

--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -29,6 +29,10 @@ The workflow uses the session's provider and available tools. Configure a cheape
 worker model in your host if desired; the workflow falls back to the session
 model, or local execution when delegation is unavailable.
 
+When changing delegation, review ownership, or model routing, use the
+[workflow evaluations](./evals/README.md) to compare decisions and inspect native
+host dispatches. These paid evaluations run only when explicitly requested.
+
 ## Updates
 
 Ask an agent to update the pinned commits in `scripts/agent-skills.json`, review

--- a/lint.config.ts
+++ b/lint.config.ts
@@ -806,7 +806,11 @@ const { lint = {} } = defineConfig({
         }
       },
       {
-        files: ['scripts/setup-agent-skills.test.ts', '.github/scripts/*.test.ts'],
+        files: [
+          'scripts/setup-agent-skills.test.ts',
+          'scripts/evaluate-agent-workflow.test.ts',
+          '.github/scripts/*.test.ts'
+        ],
         rules: {
           // These CLIs and their tests run directly on Node 24, before app tooling.
           'vitest/no-import-node-test': 'off',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "type": "module",
   "scripts": {
     "skills:setup": "node scripts/setup-agent-skills.ts",
-    "test:scripts": "node --test scripts/setup-agent-skills.test.ts .github/scripts/*.test.ts",
+    "skills:eval": "node scripts/evaluate-agent-workflow.ts",
+    "skills:smoke": "node scripts/smoke-agent-workflow.ts",
+    "test:scripts": "tsc -p scripts/tsconfig.agent-workflow.json && node --test scripts/setup-agent-skills.test.ts scripts/evaluate-agent-workflow.test.ts .github/scripts/*.test.ts",
     "dev": "pnpm -C packages/i18n generate && vp run -r --parallel dev",
     "dev:web": "pnpm -C apps/web dev",
     "build": "pnpm -C packages/i18n generate && vp run -r build",

--- a/scripts/evaluate-agent-workflow.test.ts
+++ b/scripts/evaluate-agent-workflow.test.ts
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict'
+import { access, chmod, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import {
+  captureCli,
+  extractResponse,
+  parseCli,
+  runEvaluation,
+  type Host
+} from './evaluate-agent-workflow.ts'
+
+function cliArgs(host: string) {
+  return [
+    '--host',
+    host,
+    '--model',
+    'model',
+    '--skill',
+    'skill.md',
+    '--output',
+    'evidence'
+  ]
+}
+
+void test('parses every supported CLI host and rejects invalid or missing values', () => {
+  const hosts: ReadonlyArray<Host> = ['codex', 'claude', 'opencode']
+  for (const host of hosts) {
+    assert.equal(parseCli(cliArgs(host)).host, host)
+  }
+  assert.throws(() => parseCli(cliArgs('other')))
+  assert.throws(() => parseCli(['--host', 'codex']))
+})
+
+void test('requires a successful Codex turn and validates the fixture result shape', () => {
+  const output = [
+    JSON.stringify({
+      type: 'item.completed',
+      item: {
+        type: 'agent_message',
+        text: '{"results":[{"id":"a","actions":[],"explanation":"ok"}]}'
+      }
+    }),
+    JSON.stringify({ type: 'turn.completed' })
+  ].join('\n')
+  assert.deepEqual(extractResponse('codex', output), {
+    results: [{ id: 'a', actions: [], explanation: 'ok' }]
+  })
+  assert.throws(
+    () => extractResponse('codex', output.replace('turn.completed', 'turn.failed')),
+    /failed/
+  )
+})
+
+void test('rejects malformed, unsuccessful, and reasoning-only output', () => {
+  assert.throws(
+    () =>
+      extractResponse(
+        'claude',
+        JSON.stringify({ subtype: 'error', is_error: true, result: '{}' })
+      ),
+    /successful/
+  )
+  assert.throws(
+    () =>
+      extractResponse(
+        'claude',
+        JSON.stringify({ subtype: 'success', is_error: false, result: 'not json' })
+      ),
+    /valid JSON/
+  )
+  assert.throws(
+    () =>
+      extractResponse(
+        'opencode',
+        JSON.stringify({ type: 'text', part: { type: 'reasoning', text: '{}' } })
+      ),
+    /no final JSON/
+  )
+})
+
+void test('uses a real subprocess, retains failed evidence, and refuses overwrite', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'evaluate-agent-test-'))
+  const bin = join(root, 'bin')
+  await mkdir(bin)
+  const fake = join(bin, 'opencode')
+  await writeFile(
+    fake,
+    "#!/bin/sh\nprintf 'trace\\n'\nprintf 'failure\\n%s\\n' \"$PWD\" >&2\nexit 7\n"
+  )
+  await chmod(fake, 0o755)
+  const skill = join(root, 'skill.md')
+  const cases = join(root, 'cases.json')
+  const output = join(root, 'evidence')
+  await writeFile(skill, 'skill')
+  await writeFile(
+    cases,
+    JSON.stringify({
+      instructions: 'return results',
+      cases: [{ id: 'a', scenario: 'probe' }]
+    })
+  )
+  const oldPath = process.env.PATH
+  process.env.PATH = `${bin}:${oldPath ?? ''}`
+  try {
+    await assert.rejects(
+      runEvaluation({
+        host: 'opencode',
+        model: 'm',
+        skillPath: skill,
+        outputDir: output,
+        casesPath: cases,
+        timeoutMs: 1000
+      }),
+      /status 7/
+    )
+    assert.equal(await readFile(join(output, 'stdout.jsonl'), 'utf8'), 'trace\n')
+    const stderr = await readFile(join(output, 'stderr.log'), 'utf8')
+    const temporaryCwd = stderr.trimEnd().split('\n').at(-1)
+    assert.match(stderr, /^failure\n/)
+    assert.ok(temporaryCwd)
+    await assert.rejects(access(temporaryCwd))
+    const metadataText = await readFile(join(output, 'metadata.json'), 'utf8')
+    const metadata = JSON.parse(metadataText)
+    assert.equal(metadata.outputLimitExceeded, false)
+    await assert.rejects(
+      runEvaluation({
+        host: 'opencode',
+        model: 'm',
+        skillPath: skill,
+        outputDir: output,
+        casesPath: cases,
+        timeoutMs: 1000
+      }),
+      /already exists/
+    )
+    assert.equal(await readFile(join(output, 'stdout.jsonl'), 'utf8'), 'trace\n')
+    assert.equal(await readFile(join(output, 'stderr.log'), 'utf8'), stderr)
+  } finally {
+    if (oldPath === undefined) {
+      delete process.env.PATH
+    } else {
+      process.env.PATH = oldPath
+    }
+  }
+})
+
+void test('preserves spawn failure details', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'evaluate-agent-spawn-'))
+  const result = await captureCli({
+    command: join(root, 'missing-cli'),
+    args: [],
+    input: '',
+    cwd: root,
+    timeoutMs: 1000
+  })
+  assert.notEqual(result.status, 0)
+  assert.equal(result.outputLimitExceeded, false)
+  assert.match(result.stderr, /ENOENT/)
+})
+
+void test('kills the whole process group on timeout', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'evaluate-agent-timeout-'))
+  const childPidPath = join(root, 'child.pid')
+  const result = await captureCli({
+    command: '/bin/sh',
+    args: ['-c', `sleep 30 & echo $! > '${childPidPath}'; wait`],
+    input: '',
+    cwd: root,
+    timeoutMs: 100
+  })
+  assert.equal(result.timedOut, true)
+  const childPidText = await readFile(childPidPath, 'utf8')
+  const childPid = Number(childPidText.trim())
+  assert.throws(() => process.kill(childPid, 0))
+})
+
+void test('kills output-heavy processes and never accepts their clipped prefix', async () => {
+  const validPrefix = JSON.stringify({
+    type: 'text',
+    part: {
+      type: 'text',
+      text: '{"results":[{"id":"a","actions":[],"explanation":"ok"}]}'
+    }
+  })
+  const result = await captureCli({
+    command: '/bin/sh',
+    args: ['-c', `printf '%s\\n' '${validPrefix}'; exec yes x`],
+    input: '',
+    cwd: process.cwd(),
+    timeoutMs: 5000
+  })
+  assert.equal(result.outputLimitExceeded, true)
+  assert.notEqual(result.status, 0)
+})
+
+void test('rejects duplicate fixture ids and missing response ids', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'evaluate-agent-ids-'))
+  const bin = join(root, 'bin')
+  await mkdir(bin)
+  const fake = join(bin, 'opencode')
+  await writeFile(
+    fake,
+    `#!/bin/sh\nprintf '%s\\n' '${JSON.stringify({ type: 'text', part: { type: 'text', text: '{"results":[{"id":"a","actions":[],"explanation":"ok"}]}' } })}'\n`
+  )
+  await chmod(fake, 0o755)
+  const skill = join(root, 'skill.md')
+  await writeFile(skill, 'skill')
+  const oldPath = process.env.PATH
+  process.env.PATH = `${bin}:${oldPath ?? ''}`
+  try {
+    const fixtures = [
+      {
+        name: 'duplicates',
+        fixture: {
+          instructions: 'return results',
+          cases: [
+            { id: 'a', scenario: 'one' },
+            { id: 'a', scenario: 'two' }
+          ]
+        }
+      },
+      {
+        name: 'missing',
+        fixture: {
+          instructions: 'return results',
+          cases: [
+            { id: 'a', scenario: 'one' },
+            { id: 'b', scenario: 'two' }
+          ]
+        }
+      }
+    ]
+    for (const { name, fixture } of fixtures) {
+      const cases = join(root, `${name}.json`)
+      await writeFile(cases, JSON.stringify(fixture))
+      await assert.rejects(
+        runEvaluation({
+          host: 'opencode',
+          model: 'm',
+          skillPath: skill,
+          outputDir: join(root, name),
+          casesPath: cases,
+          timeoutMs: 1000
+        }),
+        /parsed/
+      )
+    }
+  } finally {
+    if (oldPath === undefined) {
+      delete process.env.PATH
+    } else {
+      process.env.PATH = oldPath
+    }
+  }
+})

--- a/scripts/evaluate-agent-workflow.ts
+++ b/scripts/evaluate-agent-workflow.ts
@@ -1,0 +1,503 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { spawn, spawnSync } from 'node:child_process'
+import { parseArgs } from 'node:util'
+import { Schema } from 'effect'
+
+export type Host = 'codex' | 'claude' | 'opencode'
+type Case = { readonly id: string; readonly scenario: string }
+type Fixture = { readonly instructions: string; readonly cases: ReadonlyArray<Case> }
+const InvocationSchema = Schema.Struct({
+  command: Schema.String,
+  args: Schema.Array(Schema.String),
+  stdin: Schema.Boolean
+})
+type Invocation = Schema.Schema.Type<typeof InvocationSchema>
+type ProcessResult = {
+  stdout: string
+  stderr: string
+  status: number | null
+  timedOut: boolean
+  outputLimitExceeded: boolean
+}
+const OUTPUT_LIMIT = 8 * 1024 * 1024
+const ResponseSchema = Schema.Struct({
+  results: Schema.Array(
+    Schema.Struct({
+      id: Schema.String,
+      actions: Schema.Array(Schema.Unknown),
+      explanation: Schema.String
+    })
+  )
+})
+type Response = Schema.Schema.Type<typeof ResponseSchema>
+const FixtureSchema = Schema.Struct({
+  instructions: Schema.String,
+  cases: Schema.Array(Schema.Struct({ id: Schema.String, scenario: Schema.String }))
+})
+const decodeResponse = Schema.decodeUnknownSync(ResponseSchema)
+const decodeFixture = Schema.decodeUnknownSync(FixtureSchema)
+const CodexEvent = Schema.Struct({
+  type: Schema.optionalKey(Schema.String),
+  item: Schema.optionalKey(
+    Schema.Struct({
+      type: Schema.optionalKey(Schema.String),
+      text: Schema.optionalKey(Schema.String)
+    })
+  )
+})
+const OpenCodeEvent = Schema.Struct({
+  type: Schema.optionalKey(Schema.String),
+  part: Schema.optionalKey(
+    Schema.Struct({
+      type: Schema.optionalKey(Schema.String),
+      text: Schema.optionalKey(Schema.String)
+    })
+  )
+})
+const decodeCodexEvent = Schema.decodeUnknownSync(CodexEvent)
+const decodeOpenCodeEvent = Schema.decodeUnknownSync(OpenCodeEvent)
+const decodeString = Schema.decodeUnknownSync(Schema.String)
+const ClaudeEnvelope = Schema.Struct({
+  result: Schema.optionalKey(Schema.String),
+  structured_output: Schema.optionalKey(Schema.Unknown),
+  is_error: Schema.optionalKey(Schema.Boolean),
+  subtype: Schema.optionalKey(Schema.String)
+})
+const decodeClaudeEnvelope = Schema.decodeUnknownSync(ClaudeEnvelope)
+const decodeHost = Schema.decodeUnknownSync(
+  Schema.Literals(['codex', 'claude', 'opencode'])
+)
+const FileSystemError = Schema.Struct({ code: Schema.String })
+const isFileSystemError = Schema.is(FileSystemError)
+const decodeProcessError = Schema.decodeUnknownSync(
+  Schema.Struct({ message: Schema.String })
+)
+export function invocation(host: Host, model: string): Invocation {
+  if (host === 'codex') {
+    return {
+      command: 'codex',
+      args: [
+        'exec',
+        '--model',
+        model,
+        '--sandbox',
+        'read-only',
+        '--skip-git-repo-check',
+        '--ephemeral',
+        '--ignore-user-config',
+        '--json',
+        '-'
+      ],
+      stdin: true
+    }
+  }
+  if (host === 'claude') {
+    return {
+      command: 'claude',
+      args: [
+        '-p',
+        '--model',
+        model,
+        '--tools',
+        '',
+        '--strict-mcp-config',
+        '--no-session-persistence',
+        '--output-format',
+        'json'
+      ],
+      stdin: true
+    }
+  }
+  return {
+    command: 'opencode',
+    args: ['run', '--pure', '--model', model, '--format', 'json'],
+    stdin: false
+  }
+}
+
+function hash(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function promptFor(skill: string, fixture: Fixture): string {
+  return [
+    'You are evaluating an agent workflow. Follow the supplied skill text and answer every case.',
+    'Follow the fixture instructions exactly and return its requested JSON shape. Do not claim tools, delegation, or external verification that did not occur.',
+    '\n=== SKILL TEXT ===\n',
+    skill,
+    '\n=== EVALUATION INSTRUCTIONS ===\n',
+    fixture.instructions,
+    '\n=== CASES ===\n',
+    JSON.stringify(fixture.cases, null, 2)
+  ].join('')
+}
+
+function jsonText(text: string): Response {
+  const trimmed = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '')
+  if (!trimmed) {
+    throw new Error('model produced no final JSON text')
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    return decodeResponse(parsed)
+  } catch {
+    throw new Error('model final output was not valid JSON')
+  }
+}
+
+export function extractResponse(host: Host, stdout: string): Response {
+  const lines = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  if (host === 'claude') {
+    const envelope = decodeClaudeEnvelope(JSON.parse(stdout))
+    if (envelope.is_error !== false || envelope.subtype !== 'success') {
+      throw new Error('Claude result was not a successful response')
+    }
+    if (envelope.structured_output !== undefined) {
+      return decodeResponse(envelope.structured_output)
+    }
+    if (envelope.result === undefined) {
+      throw new Error('Claude output had no result text')
+    }
+    return jsonText(envelope.result)
+  }
+  if (host === 'codex') {
+    let completed = false
+    let failed = false
+    let message: string | undefined
+    for (const line of lines) {
+      try {
+        const event = decodeCodexEvent(JSON.parse(line))
+        if (event.type === 'turn.completed') {
+          completed = true
+        }
+        if (event.type === 'turn.failed') {
+          failed = true
+        }
+        if (
+          event.type === 'item.completed' &&
+          event.item?.type === 'agent_message' &&
+          event.item.text
+        ) {
+          message = event.item.text
+        }
+      } catch {
+        continue
+      }
+    }
+    if (failed) {
+      throw new Error('Codex turn failed')
+    }
+    if (!completed) {
+      throw new Error('Codex output had no completed turn')
+    }
+    if (message) {
+      return jsonText(message)
+    }
+    throw new Error('Codex output had no completed agent message')
+  }
+  let text = ''
+  for (const line of lines) {
+    try {
+      const event = decodeOpenCodeEvent(JSON.parse(line))
+      if (event.type === 'text' && event.part?.type === 'text' && event.part.text) {
+        text += event.part.text
+      }
+    } catch {
+      continue
+    }
+  }
+  return jsonText(text)
+}
+
+function validateResponse(value: unknown, cases: ReadonlyArray<Case>): Response {
+  const response = decodeResponse(value)
+  if (response.results.length === 0) {
+    throw new TypeError('model response must contain a non-empty results array')
+  }
+  const expected = new Set(cases.map((item) => item.id))
+  if (expected.size !== cases.length) {
+    throw new Error('fixture case ids must be unique')
+  }
+  const seen = new Set<string>()
+  for (const item of response.results) {
+    if (!expected.has(item.id) || seen.has(item.id)) {
+      throw new Error('results must contain each expected case id exactly once')
+    }
+    seen.add(item.id)
+  }
+  if (seen.size !== expected.size) {
+    throw new Error('results must contain each expected case id exactly once')
+  }
+  return response
+}
+
+async function runProcess(
+  command: string,
+  args: Array<string>,
+  input: string,
+  useStdin: boolean,
+  cwd: string,
+  timeoutMs: number
+) {
+  // oxlint-disable-next-line effect/noNewPromise -- Node child-process events require a Promise bridge.
+  return new Promise<ProcessResult>((_resolve) => {
+    const child = spawn(command, args, {
+      cwd,
+      detached: process.platform !== 'win32',
+      shell: false,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    let outputLimitExceeded = false
+    let terminating = false
+    let forceKillTimer: NodeJS.Timeout | undefined
+
+    function signalTree(signal: NodeJS.Signals) {
+      if (process.platform === 'win32') {
+        if (child.pid !== undefined) {
+          spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+            stdio: 'ignore',
+            windowsHide: true
+          }).unref()
+        }
+        return
+      }
+      if (child.pid !== undefined) {
+        try {
+          process.kill(-child.pid, signal)
+        } catch {
+          child.kill(signal)
+        }
+      }
+    }
+
+    function terminate() {
+      if (terminating) {
+        return
+      }
+      terminating = true
+      signalTree('SIGTERM')
+      forceKillTimer = setTimeout(() => signalTree('SIGKILL'), 2000)
+      forceKillTimer.unref()
+    }
+
+    function append(current: string, chunk: string) {
+      const remaining = OUTPUT_LIMIT - current.length
+      if (remaining <= 0) {
+        outputLimitExceeded = true
+        terminate()
+        return current
+      }
+      if (chunk.length > remaining) {
+        outputLimitExceeded = true
+        terminate()
+      }
+      return current + chunk.slice(0, remaining)
+    }
+    child.stdout.setEncoding('utf8').on('data', (chunk) => {
+      stdout = append(stdout, chunk)
+    })
+    child.stderr.setEncoding('utf8').on('data', (chunk) => {
+      stderr = append(stderr, chunk)
+    })
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true
+      terminate()
+    }, timeoutMs)
+    child.on('error', (error) => {
+      const failure = decodeProcessError(error)
+      stderr = append(stderr, `${failure.message}\n`)
+    })
+    child.on('close', (status) => {
+      if (terminating) {
+        signalTree('SIGKILL')
+      }
+      clearTimeout(timeoutTimer)
+      if (forceKillTimer !== undefined) {
+        clearTimeout(forceKillTimer)
+      }
+      _resolve({ stdout, stderr, status, timedOut, outputLimitExceeded })
+    })
+    child.stdin.on('error', (error) => {
+      const failure = decodeProcessError(error)
+      stderr = append(stderr, `${failure.message}\n`)
+    })
+    child.stdin.end(useStdin ? input : undefined)
+  })
+}
+
+export function captureCli(options: {
+  command: string
+  args: Array<string>
+  input: string
+  cwd: string
+  timeoutMs: number
+}) {
+  return runProcess(
+    options.command,
+    options.args,
+    options.input,
+    options.input.length > 0,
+    options.cwd,
+    options.timeoutMs
+  )
+}
+
+export async function runEvaluation(options: {
+  host: Host
+  model: string
+  skillPath: string
+  outputDir: string
+  casesPath: string
+  timeoutMs: number
+}) {
+  const outputDir = resolve(options.outputDir)
+  await mkdir(dirname(outputDir), { recursive: true })
+  try {
+    await mkdir(outputDir)
+  } catch (error) {
+    if (isFileSystemError(error) && error.code === 'EEXIST') {
+      throw new Error(`output directory already exists: ${outputDir}`, {
+        cause: error
+      })
+    }
+    throw error
+  }
+  const skill = await readFile(resolve(options.skillPath), 'utf8')
+  const fixtureText = await readFile(resolve(options.casesPath), 'utf8')
+  const fixture = decodeFixture(JSON.parse(fixtureText))
+  const prompt = promptFor(skill, fixture)
+  await writeFile(join(outputDir, 'prompt.txt'), prompt)
+  const tempCwd = await mkdtemp(join(tmpdir(), 'agent-workflow-'))
+  try {
+    const cmd = invocation(options.host, options.model)
+    const version = spawnSync(cmd.command, ['--version'], {
+      cwd: tempCwd,
+      shell: false,
+      encoding: 'utf8',
+      timeout: 5000
+    })
+    const cliVersion = (version.stdout || version.stderr || '').trim() || 'unavailable'
+    const started = Date.now()
+    const result = await runProcess(
+      cmd.command,
+      cmd.stdin ? [...cmd.args] : [...cmd.args, prompt],
+      cmd.stdin ? prompt : '',
+      cmd.stdin,
+      tempCwd,
+      options.timeoutMs
+    )
+    await writeFile(join(outputDir, 'stdout.jsonl'), result.stdout)
+    await writeFile(join(outputDir, 'stderr.log'), result.stderr)
+    let parseError: string | undefined
+    if (result.status === 0 && !result.timedOut && !result.outputLimitExceeded) {
+      try {
+        await writeFile(
+          join(outputDir, 'response.json'),
+          `${JSON.stringify(
+            validateResponse(
+              extractResponse(options.host, result.stdout),
+              fixture.cases
+            ),
+            null,
+            2
+          )}\n`
+        )
+      } catch {
+        parseError = 'model output could not be parsed'
+      }
+    }
+    const metadata = {
+      host: options.host,
+      model: options.model,
+      skillSha256: hash(skill),
+      fixtureSha256: hash(fixtureText),
+      exitStatus: result.status,
+      timedOut: result.timedOut,
+      outputLimitExceeded: result.outputLimitExceeded,
+      durationMs: Date.now() - started,
+      cliVersion,
+      parseError
+    }
+    await writeFile(
+      join(outputDir, 'metadata.json'),
+      `${JSON.stringify(metadata, null, 2)}\n`
+    )
+    if (
+      result.status !== 0 ||
+      result.timedOut ||
+      result.outputLimitExceeded ||
+      parseError
+    ) {
+      let failure = `CLI exited with status ${result.status}`
+      if (result.timedOut) {
+        failure = 'CLI timed out'
+      }
+      if (result.outputLimitExceeded) {
+        failure = 'CLI output limit exceeded'
+      }
+      throw new Error(parseError ?? failure)
+    }
+    return metadata
+  } finally {
+    await rm(tempCwd, { recursive: true, force: true })
+  }
+}
+
+export function parseCli(raw: ReadonlyArray<string>) {
+  const parsed = parseArgs({
+    args: raw,
+    options: {
+      host: { type: 'string' },
+      model: { type: 'string' },
+      skill: { type: 'string' },
+      output: { type: 'string' },
+      cases: { type: 'string' },
+      'timeout-ms': { type: 'string' }
+    }
+  })
+  // SAFETY: parseArgs returns strings for the declared string option; the schema validates the allowed host literal.
+  const host = decodeHost(parsed.values.host)
+  if (!['codex', 'claude', 'opencode'].includes(host)) {
+    throw new Error('--host must be codex, claude, or opencode')
+  }
+  const model = decodeString(parsed.values.model)
+  if (!model) {
+    throw new Error('--model is required')
+  }
+  const skillPath = decodeString(parsed.values.skill)
+  const outputDir = decodeString(parsed.values.output)
+  const timeoutMs = Number(parsed.values['timeout-ms'] ?? 120_000)
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1) {
+    throw new Error('--timeout-ms must be a positive integer')
+  }
+  return {
+    host,
+    model,
+    skillPath,
+    outputDir,
+    casesPath: parsed.values.cases ?? 'docs/agents/evals/workflow-cases.json',
+    timeoutMs
+  }
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(new URL(import.meta.url).pathname)
+) {
+  runEvaluation(parseCli(process.argv.slice(2))).catch(() => {
+    console.error('agent workflow evaluation failed')
+    process.exitCode = 1
+  })
+}

--- a/scripts/smoke-agent-workflow.ts
+++ b/scripts/smoke-agent-workflow.ts
@@ -1,0 +1,150 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { parseArgs } from 'node:util'
+import { Schema } from 'effect'
+import { captureCli } from './evaluate-agent-workflow.ts'
+
+const Options = Schema.Struct({
+  host: Schema.Literals(['codex', 'claude', 'opencode']),
+  model: Schema.NonEmptyString,
+  worker: Schema.NonEmptyString,
+  skill: Schema.NonEmptyString,
+  output: Schema.NonEmptyString
+})
+const decodeOptions = Schema.decodeUnknownSync(Options)
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      host: { type: 'string' },
+      model: { type: 'string' },
+      worker: { type: 'string' },
+      skill: { type: 'string' },
+      output: { type: 'string' }
+    }
+  })
+  const options = decodeOptions(values)
+  const skill = await readFile(resolve(options.skill), 'utf8')
+  const output = resolve(options.output)
+  await mkdir(dirname(output), { recursive: true })
+  await mkdir(output)
+  const cwd = await mkdtemp(join(tmpdir(), 'workflow-native-'))
+  const nonce = randomUUID()
+  const fixture = join(cwd, 'fixture.txt')
+  const prompt = `${skill}
+
+NARROW NATIVE DELEGATION SMOKE TEST
+Coordinator model: ${options.model}. Configured worker model: ${options.worker}.
+For OpenCode, the configured bounded-worker profile selects that worker model.
+Explicitly delegate ONE fresh read-only task despite its small size: have the worker
+read ${fixture} and return its exact contents. Do not read the fixture yourself.
+Pass only the path and task, not parent conversation history. Stop after the worker
+returns the value. No reviews, further workers, commits, push, browser, or unrelated
+files are in scope. Use existing permissions. Report the returned value and dispatch
+arguments; if unavailable, report the failure without pretending to delegate.
+`
+  try {
+    const version = await captureCli({
+      command: options.host,
+      args: ['--version'],
+      input: '',
+      cwd,
+      timeoutMs: 5000
+    })
+    await writeFile(fixture, nonce)
+    await writeFile(join(output, 'expected.txt'), nonce)
+    await writeFile(join(output, 'prompt.txt'), prompt)
+    if (options.host === 'opencode') {
+      await writeFile(
+        join(cwd, 'opencode.json'),
+        JSON.stringify({
+          $schema: 'https://opencode.ai/config.json',
+          agent: {
+            'bounded-worker': {
+              description: 'Bounded read-only fixture tasks',
+              mode: 'subagent',
+              model: options.worker,
+              permission: { edit: 'deny', bash: 'deny', task: 'deny' }
+            }
+          },
+          permission: { edit: 'deny', bash: 'deny', read: 'allow', task: 'allow' }
+        })
+      )
+    }
+    const args = {
+      codex: [
+        'exec',
+        '--ignore-user-config',
+        '--model',
+        options.model,
+        '--sandbox',
+        'read-only',
+        '--skip-git-repo-check',
+        '--ephemeral',
+        '--json',
+        '-'
+      ],
+      claude: [
+        '-p',
+        '--model',
+        options.model,
+        '--tools',
+        'Agent,Read',
+        '--allowedTools',
+        'Agent,Read',
+        '--permission-mode',
+        'dontAsk',
+        '--strict-mcp-config',
+        '--no-session-persistence',
+        '--output-format',
+        'stream-json',
+        '--verbose',
+        '--forward-subagent-text'
+      ],
+      opencode: ['run', '--pure', '--model', options.model, '--format', 'json', prompt]
+    }[options.host]
+    const started = Date.now()
+    const result = await captureCli({
+      command: options.host,
+      args,
+      input: options.host === 'opencode' ? '' : prompt,
+      cwd,
+      timeoutMs: 120_000
+    })
+    await writeFile(join(output, 'stdout.jsonl'), result.stdout)
+    await writeFile(join(output, 'stderr.log'), result.stderr)
+    await writeFile(
+      join(output, 'metadata.json'),
+      `${JSON.stringify(
+        {
+          host: options.host,
+          model: options.model,
+          worker: options.worker,
+          cliVersion: version.stdout.trim() || 'unavailable',
+          skillSha256: createHash('sha256').update(skill).digest('hex'),
+          durationMs: Date.now() - started,
+          exitStatus: result.status,
+          timedOut: result.timedOut,
+          outputLimitExceeded: result.outputLimitExceeded,
+          verdict: 'requires trace inspection; process success alone is not a pass'
+        },
+        null,
+        2
+      )}\n`
+    )
+    if (result.status !== 0 || result.timedOut || result.outputLimitExceeded) {
+      throw new Error('Native smoke process failed; inspect retained evidence')
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+}
+
+if (process.argv[1] === import.meta.filename) {
+  await main().catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/tsconfig.agent-workflow.json
+++ b/scripts/tsconfig.agent-workflow.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["*agent-workflow*.ts"]
+}


### PR DESCRIPTION
## Outcome

Follow-up to merged #303. Keep coordinator-owned reviews, resume implementers for scoped repairs, and stop repeated repair dispatch after an escalated attempt fails. Preserve explicit cheaper-model pairings, host-specific fresh context, and one combined Standards/thermo reviewer alongside independent Spec review.

Add opt-in TypeScript decision and native-delegation runners for Codex, Claude Code, and OpenCode, regression tests, a grading rubric, and a sanitized results report.

## Decisions

Borrow review ownership and repair practices from Superpowers and blind evaluation from Anthropic's skill-creator. Paid runs stay outside CI. Keep raw host logs local because they may contain account metadata. No changes to application behavior or the developer's active checkout.

## Validation

Revision: `c1a29e73`.

- TypeScript compilation and all 31 Node script tests pass, including real subprocess timeout/output-limit tests and all three host parsers.
- Focused lint, formatting, diff checks, and skill metadata validation pass. Independent scoped review found no blockers.
- One blind-graded ten-case before/after trial on each of Codex and Claude: 10/10 for both versions. No measured improvement or reliability claim.
- Claude native trace confirms one Sonnet worker, fixture read, and no nested delegation. Codex returns the nonce but omits spawn/model metadata, so model/context verification remains unknown.
- Full `pnpm run validate` passed: typecheck, lint, format, dead-code checks, unit/script tests, build, generated Wrangler diff check, local migrations/seed, and all 27 Playwright tests. The initial sandboxed attempt could not write Wrangler logs; the permitted run passed using the local runtime normally.

## Risks and remaining work

Draft pending OpenCode live evaluation. Automatic approval review blocked sending the skill and synthetic scenarios to OpenCode Go models; explicit user approval is still required. Simulated OpenCode decisions on another host are not proof of OpenCode behavior. Codex native resolved-model/fresh-context evidence is incomplete. See `docs/agents/evals/results-2026-09-07.md` for identifiers and limitations.
