### PR TITLE
fix(skills): bootstrap impeccable engine during setup

### DIFF
--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -20,6 +20,14 @@ Existing personal installations are left alone; the command reports conflicts.
 Start a new agent session after installation. This command is never run by
 `pnpm install`.
 
+The Impeccable installation also runs its pinned launcher with `engine-probe`
+before publishing the skill. The launcher may download its versioned engine
+cache under the selected home. The launcher keeps its upstream checksum
+verification for downloaded engines. A failed probe fails setup and leaves an
+existing managed installation unchanged. A later setup run repairs a missing
+engine cache when the managed skill has not been edited. Setup needs network
+access and write permission for that cache directory.
+
 Claude Code gives personal skills precedence over project skills with matching
 names. If you have a global `implement`, remove that conflicting installation or
 explicitly direct the agent to this repo's skill.

--- a/scripts/setup-agent-skills.test.ts
+++ b/scripts/setup-agent-skills.test.ts
@@ -73,6 +73,94 @@ function fixture(t: TestContext) {
   return { root, home, repo, skill, source, destination, alias, run, commit }
 }
 
+function impeccableFixture(t: TestContext) {
+  const f = fixture(t)
+  fs.mkdirSync(join(f.skill, 'scripts'), { recursive: true })
+  fs.writeFileSync(join(f.skill, 'scripts/VERSION'), '0.1.3\n')
+  fs.writeFileSync(
+    join(f.skill, 'scripts/impeccable'),
+    '#!/bin/sh\nif [ "$1" = engine-probe ]; then\n  mkdir -p "$IMPECCABLE_HOME/bin/0.1.3"\n  printf cached > "$IMPECCABLE_HOME/bin/0.1.3/engine"\n  printf "impeccable-engine 0.1.3\\n"\n  exit 0\nfi\nexit 0\n',
+    { mode: 0o755 }
+  )
+  const source = f.source
+  source.revision = f.commit()
+  source.path = 'skills/example'
+  function runImpeccable(update = false) {
+    return setup(f.home, update, { impeccable: source })
+  }
+  const destination = join(f.home, '.agents/skills/impeccable')
+  const alias = join(f.home, '.claude/skills/impeccable')
+  return { ...f, source, destination, alias, run: runImpeccable }
+}
+
+await test('bootstraps the pinned Impeccable engine into the selected home', (t) => {
+  const f = impeccableFixture(t)
+  const originalHome = process.env.HOME
+  assert.equal(f.run(), 0)
+  assert.equal(process.env.HOME, originalHome)
+  assert.equal(
+    fs.readFileSync(join(f.home, '.impeccable/bin/0.1.3/engine'), 'utf8'),
+    'cached'
+  )
+})
+
+await test('engine bootstrap failure preserves the previous install and state', (t) => {
+  const f = impeccableFixture(t)
+  assert.equal(f.run(), 0)
+  const before = digest(f.destination)
+  const stateBefore = fs.readFileSync(
+    join(f.home, '.agents/skill-install-state.json'),
+    'utf8'
+  )
+  fs.writeFileSync(
+    join(f.skill, 'scripts/impeccable'),
+    '#!/bin/sh\nprintf "no\\n"\nexit 23\n',
+    { mode: 0o755 }
+  )
+  f.source.revision = f.commit()
+  assert.equal(f.run(true), 1)
+  assert.equal(digest(f.destination), before)
+  assert.equal(
+    fs.readFileSync(join(f.home, '.agents/skill-install-state.json'), 'utf8'),
+    stateBefore
+  )
+  assert.equal(fs.realpathSync(f.alias), fs.realpathSync(f.destination))
+})
+
+await test('rejects a successful probe for the wrong engine version', (t) => {
+  const f = impeccableFixture(t)
+  fs.writeFileSync(
+    join(f.skill, 'scripts/impeccable'),
+    '#!/bin/sh\nprintf "impeccable-engine 0.1.2\\n"\n',
+    { mode: 0o755 }
+  )
+  f.source.revision = f.commit()
+  assert.equal(f.run(), 1)
+  assert.equal(fs.existsSync(f.destination), false)
+})
+
+await test('does not execute a modified managed launcher on rerun', (t) => {
+  const f = impeccableFixture(t)
+  assert.equal(f.run(), 0)
+  fs.rmSync(join(f.home, '.impeccable'), { recursive: true })
+  fs.writeFileSync(
+    join(f.destination, 'scripts/impeccable'),
+    '#!/bin/sh\nmkdir -p "$IMPECCABLE_HOME/should-not-exist"\nexit 0\n',
+    { mode: 0o755 }
+  )
+  assert.equal(f.run(), 1)
+  assert.equal(fs.existsSync(join(f.home, '.impeccable')), false)
+})
+
+await test('managed Impeccable reruns repair a missing engine cache', (t) => {
+  const f = impeccableFixture(t)
+  assert.equal(f.run(), 0)
+  fs.rmSync(join(f.home, '.impeccable'), { recursive: true })
+  fs.rmSync(f.repo, { recursive: true })
+  assert.equal(f.run(), 0)
+  assert.equal(fs.existsSync(join(f.home, '.impeccable/bin/0.1.3/engine')), true)
+})
+
 await test('copies pinned content, supporting files, licenses, modes and Claude alias', (t) => {
   const f = fixture(t)
   fs.writeFileSync(join(f.skill, 'SKILL.md'), 'Newer instructions')

--- a/scripts/setup-agent-skills.ts
+++ b/scripts/setup-agent-skills.ts
@@ -35,6 +35,10 @@ type Source = {
 }
 type State = Record<string, { digest: string }>
 
+const IMPECCABLE_VERSION_FILE = join('scripts', 'VERSION')
+const IMPECCABLE_LAUNCHER = join('scripts', 'impeccable')
+const IMPECCABLE_WINDOWS_LAUNCHER = join('scripts', 'impeccable.cmd')
+
 function exists(path: string) {
   return lstatSync(path, { throwIfNoEntry: false }) !== undefined
 }
@@ -170,6 +174,55 @@ function prepare(
   }
 }
 
+function bootstrapImpeccable(stage: string, home: string) {
+  const launcher =
+    process.platform === 'win32'
+      ? join(stage, IMPECCABLE_WINDOWS_LAUNCHER)
+      : join(stage, IMPECCABLE_LAUNCHER)
+  const versionPath = join(stage, IMPECCABLE_VERSION_FILE)
+  if (!existsSync(launcher) || !existsSync(versionPath)) {
+    throw new Error('Impeccable skill is missing its launcher or VERSION file')
+  }
+  const version = readFileSync(versionPath, 'utf8').trim()
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`Invalid Impeccable engine version: ${version || '(empty)'}`)
+  }
+  const cache = join(home, '.impeccable', 'bin', version)
+  let output: string
+  try {
+    const windows = process.platform === 'win32'
+    output = execFileSync(
+      windows ? 'cmd.exe' : launcher,
+      windows ? ['/d', '/s', '/c', 'impeccable.cmd engine-probe'] : ['engine-probe'],
+      {
+        cwd: windows ? dirname(launcher) : undefined,
+        env: {
+          ...process.env,
+          IMPECCABLE_HOME: join(home, '.impeccable'),
+          IMPECCABLE_SKILL_DIR: stage,
+          IMPECCABLE_SELF: launcher,
+          IMPECCABLE_BIN: '',
+          IMPECCABLE_LAUNCHER_PROBE: ''
+        },
+        timeout: 180_000,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+      }
+    ).trim()
+  } catch (error) {
+    throw new Error(
+      `Impeccable engine bootstrap failed for ${cache}; check network access and cache directory permissions, then rerun setup`,
+      { cause: error }
+    )
+  }
+  const expected = `impeccable-engine ${version}`
+  if (output !== expected) {
+    throw new Error(
+      `Impeccable engine bootstrap returned ${JSON.stringify(output)}; expected ${JSON.stringify(expected)}`
+    )
+  }
+}
+
 // oxlint-disable anti-slop/no-runtime-typeof -- Parse persisted JSON at this dependency-free bootstrap boundary before permitting global replacements.
 function readState(path: string) {
   const value: unknown = existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : {}
@@ -216,6 +269,12 @@ function install(
       throw new Error(`Unmanaged installation preserved: ${destination}`)
     }
     if (!update) {
+      if (name === 'impeccable') {
+        if (digest(destination) !== previous.digest) {
+          throw new Error(`Personal modifications preserved: ${destination}`)
+        }
+        bootstrapImpeccable(destination, home)
+      }
       if (!exists(alias)) {
         mkdirSync(dirname(alias), { recursive: true })
         symlinkSync(destination, alias)
@@ -235,6 +294,9 @@ function install(
   const stateTemporary = join(work, 'state.json')
   try {
     prepare(source, stage, cache, temporary)
+    if (name === 'impeccable') {
+      bootstrapImpeccable(stage, home)
+    }
     const entry = { digest: digest(stage) }
     if (present) {
       renameSync(destination, backup)


### PR DESCRIPTION
## Outcome

A fresh `skills:setup` install copied Impeccable's launcher without its native engine. The first design command then attempted a cache write and download, which could fail silently inside an agent sandbox.

Setup now runs the pinned launcher's `engine-probe` and verifies the exact version before publishing the skill. An unchanged managed install also runs the probe, repairing a missing engine cache without refetching the skill. Bootstrap failures return a nonzero setup result with network/cache guidance and preserve the previous installation, state, and aliases.

## Decisions

The bootstrap remains specific to Impeccable and uses the upstream launcher's checksum verification. `--home` selects the engine cache through `IMPECCABLE_HOME`; the caller's `HOME` remains unchanged. Modified and unmanaged installations stay protected.

This is independent of customer-support PR #308 and branches from `master`.

## Validation

Validated revision: `672e858e7983213f2260149c656a88cc065d3957`, with the independently reviewed setup diff unchanged.

- `pnpm run validate` passed, including type checking, lint, formatting, dead-code analysis, unit/integration/operations tests, build, Wrangler drift check, D1 migration/seed, and E2E. All 27 Playwright tests passed without retries.

- Focused script tests passed, including engine installation, wrong-version rejection, failure rollback, missing-cache repair, and modified-launcher protection.
- Actual pinned upstream smoke passed in a fresh temporary home on macOS ARM64. Engine `0.1.3` then started with the download source unavailable.
- Independent Standards and Spec reviews found no actionable issues.

## Risks and remaining work

The first setup needs network access and write permission for the selected cache. Existing personal modifications require manual resolution. The Windows `.cmd` invocation has not been exercised locally.
