### PR TITLE
ci: parallelize PR checks and workspace tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  ci:
+  quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: pnpm run typecheck
       - run: pnpm run lint
+      - run: pnpm run format:check
       # Dead-code regression gate (the `dead-code` step of `pnpm run check`).
       # Fallow is pinned in the workspace catalog so local and CI runs use the
       # same analyzer binary.
@@ -37,13 +38,61 @@ jobs:
         run: |
           pnpm run infra:wrangler
           git diff --exit-code -- apps/*/wrangler.jsonc
+
+  # Web tests can start immediately instead of waiting for dependency tests.
+  # The complementary filters include every workspace, including new packages.
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: web
+            filter: web
+          - name: packages
+            filter: '!web'
+    name: Tests (${{ matrix.name }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm -C packages/i18n generate
       # Includes the coverage ratchet on the application layer: the
       # capabilities `test` script runs with --coverage (thresholds live in
       # packages/capabilities/vitest.config.ts) — fails on decay.
-      - run: pnpm run test
-      - run: pnpm run test:scripts
-      - run: pnpm run test:operations
+      - name: Run workspace tests
+        env:
+          TEST_FILTER: ${{ matrix.filter }}
+        run: vp run --filter "$TEST_FILTER" --fail-if-no-match test
+      - name: Run script tests
+        if: ${{ matrix.name == 'packages' }}
+        run: pnpm run test:scripts
+      - name: Run operations tests
+        if: ${{ matrix.name == 'packages' }}
+        run: pnpm run test:operations
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
       - run: pnpm run build
+
+  # Keep the existing required check name, and fail on skipped/cancelled jobs.
+  ci:
+    if: ${{ always() }}
+    needs: [quality, tests, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required CI jobs succeeded
+        env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          if [[ "$QUALITY_RESULT" != "success" || "$TESTS_RESULT" != "success" || "$BUILD_RESULT" != "success" ]]; then
+            echo "CI jobs did not all succeed: quality=$QUALITY_RESULT tests=$TESTS_RESULT build=$BUILD_RESULT"
+            exit 1
+          fi
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
       - name: Run workspace tests
         env:
           TEST_FILTER: ${{ matrix.filter }}
-        run: vp run --filter "$TEST_FILTER" --fail-if-no-match test
+        # The root test script recursively runs workspace tests. Exclude that
+        # orchestration script so each package executes in exactly one group.
+        run: vp run --filter "$TEST_FILTER" --filter '!b2b-saas-starter' --fail-if-no-match test
       - name: Run script tests
         if: ${{ matrix.name == 'packages' }}
         run: pnpm run test:scripts


### PR DESCRIPTION
## Outcome

PR CI now runs quality checks, build, web tests, and the remaining workspace tests in parallel. On the first successful run of the final change, elapsed time from the first CI job starting through the `ci` gate completing fell from **7m29s to 4m18s, about 43% faster**. This is a single-run comparison, not a guaranteed runtime.

[Baseline run](https://github.com/brandhaug/b2b-saas-starter/actions/runs/34157466118) · [Final run](https://github.com/brandhaug/b2b-saas-starter/actions/runs/34160379026)

## Decisions

Keep `ci` as a strict aggregate gate. Failed, cancelled, or skipped prerequisites fail it. Keep E2E, deployment dependencies, permissions, test scripts, and capabilities coverage thresholds intact. Complementary web/non-web filters include all workspace packages; explicitly exclude the root orchestration script to prevent recursive duplicate execution. Matrix fail-fast is disabled so both groups can finish. Add the formatting check already required by local `check`.

The change uses more concurrent runners to reduce elapsed time. It does not introduce cached check results or path-based check skipping.

## Validation

Tested head: `de682d27495c638f5c78f4d23865bc8745331016`, including the latest master documentation changes. [Final head CI run](https://github.com/brandhaug/b2b-saas-starter/actions/runs/34160761412) passed all checks.

- All GitHub checks passed: quality, build, both test groups, E2E, `ci`, audit, PR title, and preview deployment.
- Quality includes typecheck, lint, formatting, dead-code detection, and generated Wrangler config drift detection. The package group includes script and operations tests.
- Final logs confirm one capabilities coverage invocation with all 55 test files passing, and all 99 web test files passing.
- Independent targeted review verified the final filter exclusions and strict aggregation.
- `actionlint`, `git diff --check`, local formatting, and script tests passed. The aggregate gate passed an exhaustive check of all 64 success/failure/cancelled/skipped combinations; only all-success returns zero.
- Full local `pnpm run validate` did not complete. Subsequent local checks passed typecheck/lint/format/dead-code but hit Workers sandbox restrictions and test timeouts. The isolated GitHub run passed the complete check set on the final head.

## Risks and remaining work

More concurrent jobs consume additional runner minutes and depend on runner availability. No known merge blockers; the final head is up to date with master and mergeable.
