### PR TITLE
refactor(capabilities): own resource admission and delivery completion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,10 @@ token slots and one webhook slot. The selection is a logical allow-list over
 current eligible resources. Token verification, REST/MCP authorization, and
 queued webhook dispatch re-check it at execution time, so existing credentials
 and queued work cannot bypass a downgrade. Creation admission reads the same
-deadline-aware Billing decision.
+deadline-aware Billing decision through Resource entitlements, which owns admission
+counts as well as execution eligibility. Token admission counts current unrevoked,
+unexpired replacement leaves. Webhook admission counts all stored endpoints,
+while dispatch eligibility considers enabled endpoints.
 
 Lifecycle state and its audit/outbox commit do not wait for notice delivery.
 Payment-failure, grace-expiry, and recovery notices have independent retryable

--- a/apps/background/AGENTS.md
+++ b/apps/background/AGENTS.md
@@ -6,7 +6,7 @@ Cloudflare Worker for queued, scheduled and inbound-provider work: webhook fan-o
 
 ## Entry Points & Contracts
 
-- `src/index.ts`: `fetch` (only `POST /webhooks/stripe`), `queue` branching on `batch.queue` against the names in `infra/bindings.ts`, `scheduled` for the digest cron. Each wires wide-event providers first.
+- Every entry wires wide-event providers before running work.
 - `src/queue-consumer.ts` is the shared boundary; never hand-roll around it. `consumerInvocation` is the one consumer entry: trace continuation, `withTriggerScope` with the attempt count, capability layers, one named fold to `'retry' | 'ack'`.
 
 ## Usage Patterns
@@ -14,7 +14,7 @@ Cloudflare Worker for queued, scheduled and inbound-provider work: webhook fan-o
 Per queue the outcome table is the contract; the non-obvious parts:
 
 - Webhooks retry a retryable failure (5xx, 408, 429, network, timeout) at `backoffSeconds(attempts)`; a 4xx or SSRF rejection is `failed_permanent`; undispatchable or malformed acks.
-- The capability atomically updates the failure streak and disables at 20. The worker warns owners at accepted rungs 5/10/15/20 using the existing notification kind; notifications are best-effort. Terminal bookkeeping after HTTP attempts does not climb the streak again.
+- [Webhook Attempt completion](../../packages/capabilities/src/developer-platform/webhook-attempt-completion.ts) owns planning, recording and accepted-only warnings. The worker owns signing and HTTP dispatch; it follows completion's queue disposition, including for duplicate or late observations.
 - The DLQ consumer acks after writing the terminal `dead_lettered` row, but retries if that write fails, so a D1 blip cannot lose the evidence.
 - Exports resolve `WorkspaceContext` from the slug with no actor, ownership having been checked at request time; a slug naming another `workspaceId` fails the row. No DLQ, the row is the record. `WORKSPACE_EXPORT_RETENTION_DAYS` is declared twice, in `infra/bindings.ts` (R2 lifecycle rule) and the capability; `export-consumer.test.ts` fails if they diverge.
 - Seat sync uses the billing queue and its dead-letter queue. The primary queue
@@ -22,13 +22,13 @@ Per queue the outcome table is the contract; the non-obvious parts:
   so recovery does not require a later mutation. Its Stripe env is
   `starterEnv(env)` plus `billingOptionsFromEnv(env)`, because `starterEnv`
   projects bindings only.
-- Notification email messages carry ids only, so re-read notification and preferences. Digest sends are never fatal, and the run retries so a failed cron is recorded.
+- Notification email messages carry ids only, so re-read notification and preferences before claiming. Email delivery owns retry timing; use its completion decision even when an active lease skips sending. Digest sends are never fatal, and failed reads retry the run.
 
 ## Anti-patterns
 
 - Do not mint a trace id or set `traceparent`/`b3`: `currentTraceId` is the only source, and `HttpClient` injects the headers on the delivery POST.
 - Do not emit terminal delivery audit events here: the capability batches that row with the attempt so both commit together.
-- Do not duplicate the delivery state machine: `backoffSeconds`, `classifyResponseStatus`, `planDeliveryAttempt` and `validateWebhookUrl` are pure capability exports.
+- Do not infer queue disposition from delivery evidence or repeat failure notifications after completion.
 - Do not give `webhook-signing.ts` dependencies; a test imports it directly against a fixed HMAC vector.
 - Do not edit the generated `wrangler.jsonc`, and build no OTLP exporter at isolate level (ADR 0050): `runInvocation` provides it per invocation, so exporters flush before the handler settles.
 
@@ -41,7 +41,7 @@ Per queue the outcome table is the contract; the non-obvious parts:
 
 - One decode per delivery: `readDelivery(schema, envelope)` folds the platform fields and the message-schema decode into one `QueueDelivery`, so malformed is a named `kind` rather than an absent value, and terminal (no trusted `endpointId` to attach a row to).
 - The fold sits outside `withTriggerScope`, so the wide event exits carrying the failure cause before it becomes a queue outcome. `onFailure: 'retry'` except the DLQ entry.
-- The publisher stamps `deliveryId` before enqueueing. Both queue consumers use it; each observation is unique by delivery, attempt ordinal, and phase. The capability returns actual summary status and whether it advanced; duplicate or late observations produce no repeated notifications (ADR 0073).
+- The publisher stamps `deliveryId` before enqueueing. Both queue consumers use it; each observation is unique by delivery, attempt ordinal, and phase. Completion prevents repeated warnings (ADR 0073).
 - `signatureHeaderValue` owns the signature format: Standard Webhooks HMAC-SHA256 over `"<deliveryId>.<unix>.<rawBody>"`, one space-separated `v1,<base64>` per active secret, current first, two only inside a rotation's grace window (ADR 0062).
 - The SSRF guard runs at endpoint creation _and again at dispatch_; DNS rebinding is out of scope.
 

--- a/apps/background/src/notification-email-consumer.test.ts
+++ b/apps/background/src/notification-email-consumer.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@b2b-saas-starter/capabilities/notifications/notification-preferences'
 import { SeedAuditEventLog } from '@b2b-saas-starter/capabilities/governance/audit-event-log'
 import { SeedEmailDelivery } from '@b2b-saas-starter/capabilities/email-delivery/email-delivery.seed'
+import { EmailDelivery } from '@b2b-saas-starter/capabilities/email-delivery/email-delivery'
 import {
   EmailDispatcher,
   type EmailDeliveryResult,
@@ -187,6 +188,42 @@ describe('processNotificationEmailMessage', () => {
       })
     })
   )
+
+  it.effect('retries when an active delivery lease skips the send', () => {
+    const sent: Array<EmailMessage> = []
+    return Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse(context.notification.createdAt))
+      const delivery = yield* EmailDelivery
+      const claim = yield* delivery.claim({
+        id: 'notification:not_1:usr_owner',
+        purpose: 'notification',
+        recipient: context.recipient.email,
+        userId: context.recipient.userId,
+        workspaceId: null,
+        queuedAt: context.notification.createdAt
+      })
+      expect(claim).not.toBeNull()
+      const outcome = yield* processNotificationEmailMessage(
+        readDelivery(NotificationEmailQueueMessage, {
+          id: 'q1',
+          body: message,
+          attempts: 1
+        }),
+        'https://app.test'
+      )
+      expect(outcome).toEqual({ retryAfterSeconds: 300 })
+      expect(sent).toHaveLength(0)
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          stubFeed(context),
+          SeedNotificationPreferences([]).pipe(Layer.provide(audit)),
+          stubDispatcher(sent),
+          SeedEmailDelivery()
+        )
+      )
+    )
+  })
 
   it.effect(
     'does not resend a provider-accepted notification on queue redelivery',

--- a/apps/background/src/notification-email-consumer.ts
+++ b/apps/background/src/notification-email-consumer.ts
@@ -17,7 +17,7 @@ import {
 import { notificationEmailFor } from '@b2b-saas-starter/email/notification-emails'
 import { dispatchTrackedEmail } from '@b2b-saas-starter/email/tracked'
 import { EmailDelivery } from '@b2b-saas-starter/capabilities/email-delivery/email-delivery'
-import { Clock, Effect, Layer, type Scope } from 'effect'
+import { Effect, Layer, type Scope } from 'effect'
 
 import { appUrlFrom, openUrlFor, preferencesUrl } from './notification-links.ts'
 import {
@@ -135,26 +135,16 @@ export function processNotificationEmailMessage(
           renderError: 'template_failed'
         }).pipe(Effect.as(ack))
       ),
-      // The tracked attempt persisted its sanitized failure. Its next due time
-      // below controls queue delivery, including transient and ambiguous sends.
+      // The capability persists the sanitized failure; completion below owns
+      // whether the queue should retry, including an active-lease skip.
       Effect.catchTag('EmailSendError', () => Effect.succeed(ack))
     )
-    const record = yield* history.get(messageId)
-    // A concurrent attempt or an ambiguous send keeps its queue message alive
-    // until the capability's lease/backoff permits the next bounded attempt.
-    if (
-      record &&
-      ['queued', 'temporary_failure', 'ambiguous'].includes(record.status)
-    ) {
-      yield* Effect.annotateLogsScoped({ outcome: 'retry_pending' })
-      const now = yield* Clock.currentTimeMillis
-      const due = Math.min(
-        Date.parse(record.nextAttemptAt),
-        Date.parse(record.retryUntil)
-      )
-      return { retryAfterSeconds: Math.max(1, Math.ceil((due - now) / 1000)) }
+    const completion = yield* history.completionDecision(messageId)
+    if (completion.outcome === 'retry_pending') {
+      yield* Effect.annotateLogsScoped({ outcome: completion.outcome })
+      return { retryAfterSeconds: completion.retryAfterSeconds }
     }
-    yield* Effect.annotateLogsScoped({ outcome: record?.status ?? 'skipped' })
+    yield* Effect.annotateLogsScoped({ outcome: completion.status })
     return ack
   })
 }

--- a/apps/background/src/webhook-consumer.ts
+++ b/apps/background/src/webhook-consumer.ts
@@ -3,16 +3,15 @@ import {
   starterEnv
 } from '@b2b-saas-starter/capabilities/runtime'
 import { WebhookEndpoints } from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
+import { WEBHOOK_USER_AGENT } from '@b2b-saas-starter/capabilities/developer-platform/webhook-delivery-plan'
 import {
-  type FailureLadderAction,
-  failureLadderNotification,
-  planDeliveryAttempt,
-  WEBHOOK_USER_AGENT
-} from '@b2b-saas-starter/capabilities/developer-platform/webhook-delivery-plan'
+  completeWebhookHttpObservation,
+  completeWebhookTerminalObservation
+} from '@b2b-saas-starter/capabilities/developer-platform/webhook-attempt-completion'
 import { validateWebhookUrl } from '@b2b-saas-starter/capabilities/developer-platform/webhook-url'
 import { WebhookQueueMessage } from '@b2b-saas-starter/capabilities/developer-platform/webhook-publisher'
 import { type CapabilityUnavailable } from '@b2b-saas-starter/capabilities/errors'
-import { NotificationFeed } from '@b2b-saas-starter/capabilities/notifications/notification-feed'
+import { type NotificationFeed } from '@b2b-saas-starter/capabilities/notifications/notification-feed'
 import { currentTraceId, TRACE_HEADER } from '@b2b-saas-starter/logger'
 import { DateTime, Effect, Result, Schema, type Scope } from 'effect'
 import { HttpBody, HttpClient } from 'effect/unstable/http'
@@ -48,42 +47,6 @@ function annotateMalformed(outcome: string): Effect.Effect<void, never, Scope.Sc
   return Effect.annotateLogsScoped({ outcome, skipReason: 'malformed_message' })
 }
 
-/**
- * The user-facing half of a delivery that gave up: one workspace-broadcast
- * Notification of kind `webhook.delivery_failed`, beside the audit event the
- * capability already batched with the terminal row. This is where the feed's
- * instant-email fan-out starts for the kind (ADR 0061). Best-effort — a feed
- * outage must not turn a settled delivery into a retry loop.
- */
-function notifyPermanentFailure(
-  message: WebhookQueueMessage,
-  endpointUrl: string
-): Effect.Effect<void, never, NotificationFeed> {
-  return Effect.gen(function* () {
-    const feed = yield* NotificationFeed
-    const detail = `${message.eventType} was rejected and will not be retried.`
-    yield* feed.create({
-      workspaceId: message.workspaceId,
-      userId: null,
-      kind: 'webhook.delivery_failed',
-      title: 'Webhook delivery failed',
-      message: `${endpointUrl}: ${detail}`,
-      event: {
-        type: 'webhook.permanent',
-        endpointUrl,
-        eventType: message.eventType
-      }
-    })
-  }).pipe(
-    // The cause goes on the log record whole; the wide event keeps the flag.
-    Effect.catchCause((cause) =>
-      Effect.logError('notification_create_failed', cause).pipe(
-        Effect.annotateLogs({ notificationCreate: 'failed' })
-      )
-    )
-  )
-}
-
 /** Fields every consumer stamps onto its wide event once decoded. */
 function annotateMessageFields(message: WebhookQueueMessage) {
   return Effect.annotateLogsScoped({
@@ -91,46 +54,6 @@ function annotateMessageFields(message: WebhookQueueMessage) {
     workspaceId: message.workspaceId,
     eventType: message.eventType
   })
-}
-
-/**
- * The user-facing half of a failure-ladder rung (ADR 0062 addendum): one
- * owner-targeted Notification of the existing `webhook.delivery_failed` kind,
- * its copy owned by `failureLadderNotification`. The ladder deliberately
- * rides the existing webhook kind — one preference knob for webhook failure
- * notices, one email template — instead of minting a second vocabulary entry
- * beside it. This is where the feed's email fan-out starts for the kind.
- * Best-effort — a feed outage must not fail an attempt whose row already
- * recorded.
- */
-function notifyFailureLadder(input: {
-  readonly failureAction: FailureLadderAction
-  readonly workspaceId: string
-  readonly url: string | null
-  readonly consecutiveFailures: number
-}): Effect.Effect<void, never, NotificationFeed | Scope.Scope> {
-  return Effect.gen(function* () {
-    yield* Effect.annotateLogsScoped({ consecutiveFailures: input.consecutiveFailures })
-    if (input.failureAction === 'silent') {
-      return
-    }
-    const feed = yield* NotificationFeed
-    yield* feed.notifyWorkspaceOwners({
-      workspaceId: input.workspaceId,
-      kind: 'webhook.delivery_failed',
-      ...failureLadderNotification({
-        url: input.url,
-        consecutiveFailures: input.consecutiveFailures
-      })
-    })
-  }).pipe(
-    // The cause goes on the log record whole; the wide event keeps the flag.
-    Effect.catchCause((cause) =>
-      Effect.logError('failure_ladder_notification_failed', cause).pipe(
-        Effect.annotateLogs({ notificationCreate: 'failed' })
-      )
-    )
-  )
 }
 
 /**
@@ -196,30 +119,16 @@ export function processWebhookMessage(
     if (!urlCheck.valid) {
       // Never-dispatched terminal row: resolves this message's delivery id and
       // records the payload, so the row stays replayable once the URL is fixed.
-      const recorded = yield* webhooks.recordTerminalDeliveryAttempt({
-        deliveryId,
-        endpointId: target.id,
-        workspaceId: message.workspaceId,
-        eventType: message.eventType,
+      yield* completeWebhookTerminalObservation({
+        message,
+        endpointUrl: target.url,
         attempts,
         status: 'failed_permanent',
-        failureReason: `Destination refused: ${urlCheck.reason}`,
-        payload: message.payload
+        failureReason: `Destination refused: ${urlCheck.reason}`
       })
       yield* Effect.annotateLogsScoped({
         outcome: 'failed_permanent',
         skipReason: `invalid_url: ${urlCheck.reason}`
-      })
-      if (!recorded.recorded) {
-        return 'ack' satisfies DeliveryOutcome
-      }
-      yield* notifyPermanentFailure(message, target.url)
-      // A refused URL is a failed attempt like any other — the ladder climbs.
-      yield* notifyFailureLadder({
-        workspaceId: message.workspaceId,
-        url: target.url,
-        failureAction: recorded.failureAction,
-        consecutiveFailures: recorded.consecutiveFailures
       })
       return 'ack' satisfies DeliveryOutcome
     }
@@ -287,45 +196,19 @@ export function processWebhookMessage(
     } else if (responseStatus < 200 || responseStatus >= 300) {
       failureReason = `Receiver returned HTTP ${responseStatus}`
     }
-    const plan = planDeliveryAttempt(responseStatus, attempts, finishedAt)
-    const recorded = yield* webhooks.recordDeliveryAttempt({
-      id: deliveryId,
-      endpointId: target.id,
-      // Terminal statuses batch an audit event with the attempt row inside
-      // the capability; the workspace id scopes it to the endpoint's owner.
-      workspaceId: message.workspaceId,
-      eventType: message.eventType,
-      status: plan.status,
+    const recorded = yield* completeWebhookHttpObservation({
+      message,
+      endpointUrl: target.url,
+      responseStatus,
       attempts,
+      finishedAt,
       durationMs,
       failureReason,
-      responseStatus: plan.responseStatus,
-      nextAttemptAt: plan.nextAttemptAt,
-      // Operator evidence columns: what was sent and what came back, so the
-      // deliveries drawer can replay or diagnose without re-deriving it.
-      payload: message.payload,
       requestHeaders,
       responseBody
     })
-    yield* Effect.annotateLogsScoped({ outcome: plan.status, responseStatus })
-    if (!recorded.recorded) {
-      if (recorded.status === 'failed') {
-        return 'retry' satisfies DeliveryOutcome
-      }
-      return 'ack' satisfies DeliveryOutcome
-    }
-    if (plan.status === 'failed_permanent') {
-      yield* notifyPermanentFailure(message, target.url)
-    }
-    // The failure ladder reacts to the streak the attempt left: warnings at
-    // the rungs, the auto-disable at the threshold (ADR 0062 addendum).
-    yield* notifyFailureLadder({
-      workspaceId: message.workspaceId,
-      url: target.url,
-      failureAction: recorded.failureAction,
-      consecutiveFailures: recorded.consecutiveFailures
-    })
-    return plan.outcome satisfies DeliveryOutcome
+    yield* Effect.annotateLogsScoped({ outcome: recorded.status, responseStatus })
+    return recorded.outcome satisfies DeliveryOutcome
   })
 }
 
@@ -375,32 +258,17 @@ export function processDeadLetterMessage(
     }
     const message = delivery.message
     yield* annotateMessageFields(message)
-    const webhooks = yield* WebhookEndpoints
     // The same row id the message's attempts resolved on the primary queue —
     // the exhausted row goes terminal in place instead of forking a second
     // row, and its recorded payload keeps it replayable.
-    const deliveryId = message.deliveryId
-    const recorded = yield* webhooks.recordTerminalDeliveryAttempt({
-      deliveryId,
-      endpointId: message.endpointId,
-      workspaceId: message.workspaceId,
-      eventType: message.eventType,
+    yield* completeWebhookTerminalObservation({
+      message,
       attempts: delivery.attempts,
       status: 'dead_lettered',
       failureReason: 'Queue retries exhausted',
-      payload: message.payload
+      endpointUrl: null
     })
     yield* Effect.annotateLogsScoped({ outcome: 'dead_lettered' })
-    if (!recorded.recorded) {
-      return
-    }
-    // Persistence decides whether terminal bookkeeping advances the streak.
-    yield* notifyFailureLadder({
-      workspaceId: message.workspaceId,
-      url: null,
-      failureAction: recorded.failureAction,
-      consecutiveFailures: recorded.consecutiveFailures
-    })
   })
 }
 

--- a/docs/adr/0073-standard-webhooks-and-delivery-attempt-history.md
+++ b/docs/adr/0073-standard-webhooks-and-delivery-attempt-history.md
@@ -55,7 +55,10 @@ cannot regress the summary, change the streak, or repeat a terminal audit.
 Different deliveries affect an endpoint's streak in database commit order.
 
 Automatic disable belongs to the same batch as the threshold-crossing attempt.
-The worker sends best-effort warnings only for accepted results. Dead-letter
+The Webhook Attempt completion module composes planning, persistence and
+best-effort warnings for accepted results. The worker supplies dispatch evidence
+and follows completion's queue disposition; duplicate or late observations use
+the persisted summary. Signing and HTTP dispatch remain in the worker. Dead-letter
 bookkeeping does not increment the streak again when HTTP attempts already
 exist. Notifications are best-effort; audit and disable durability do not depend
 on notification delivery.

--- a/packages/capabilities/src/billing/resource-admission.ts
+++ b/packages/capabilities/src/billing/resource-admission.ts
@@ -1,10 +1,5 @@
-import { type EffectDatabase } from '@b2b-saas-starter/db/service'
 import { Effect } from 'effect'
-import { count, type SQL } from 'drizzle-orm'
-import { type SQLiteTable } from 'drizzle-orm/sqlite-core'
-import { PlanLimitExceeded, type CapabilityUnavailable } from '../errors.ts'
-import { orUnavailable } from '../internal/unavailable.ts'
-import { type WorkspaceContext } from '../workspace-context.ts'
+import { PlanLimitExceeded } from '../errors.ts'
 import { Billing } from './billing.ts'
 import { limitFor, type EntitlementResource } from './plan-catalog.ts'
 
@@ -24,32 +19,3 @@ export const assertWithinPlanLimit = Effect.fn(
     )
   }
 })
-
-/**
- * The entitlement gate with its counting query beside it: counts the rows of
- * `table` matching `where` in the caller's store and asserts the workspace in
- * context is within the plan ceiling. Both mutating capabilities compose this,
- * so the "count active rows → compare against the plan" idiom exists once.
- */
-export function assertWithinPlanLimitFor(input: {
-  readonly resource: EntitlementResource
-  readonly db: EffectDatabase
-  /** Which capability name surfaces on a `CapabilityUnavailable` count failure. */
-  readonly capability: string
-  readonly table: SQLiteTable
-  readonly where?: SQL | undefined
-}): Effect.Effect<
-  void,
-  CapabilityUnavailable | PlanLimitExceeded,
-  WorkspaceContext | Billing
-> {
-  return Effect.gen(function* () {
-    const rows = yield* orUnavailable(input.capability)(
-      input.db.select({ value: count() }).from(input.table).where(input.where)
-    )
-    yield* assertWithinPlanLimit({
-      resource: input.resource,
-      used: rows[0]?.value ?? 0
-    })
-  })
-}

--- a/packages/capabilities/src/billing/resource-entitlements.AGENTS.md
+++ b/packages/capabilities/src/billing/resource-entitlements.AGENTS.md
@@ -1,6 +1,6 @@
 # Resource entitlements
 
-Creation admission and execution use Billing's request-time plan, including deadlines. Keep `plan-catalog.ts` pure; workspace context proves identity, not current paid access.
+This module owns creation counts and execution eligibility against Billing's request-time Effective Plan. Token admission counts current unrevoked, unexpired replacement leaves. Webhook admission counts all stored endpoints; execution counts enabled endpoints. Keep these purposes distinct. Workspace context proves identity, not current paid access.
 
 ## Contracts and ownership
 

--- a/packages/capabilities/src/billing/resource-entitlements.contract.ts
+++ b/packages/capabilities/src/billing/resource-entitlements.contract.ts
@@ -118,6 +118,15 @@ export function resourceEntitlementsContract(expect: typeof VitestExpect) {
     )
     yield* endpoints.update({ endpointId: first.endpoint.id, enabled: false })
     expect((yield* entitlements.getSelection()).webhookEndpointIds).toEqual([])
+    // Disabled endpoints stop dispatching but remain stored and consume the
+    // creation slot.
+    expect(
+      failureTag(
+        yield* Effect.exit(
+          endpoints.create({ url: 'https://example.com/disabled-slot', events: [] })
+        )
+      )
+    ).toBe('PlanLimitExceeded')
     expect(
       yield* endpoints.getDispatchTarget(first.endpoint.id, ctx.workspace.id)
     ).toBeNull()
@@ -166,5 +175,73 @@ export function resourceEntitlementsContract(expect: typeof VitestExpect) {
       apiTokenIds: [],
       webhookEndpointIds: []
     })
+  })
+}
+
+/** Admission-only contract against an empty Starter workspace. */
+export function resourceAdmissionContract(expect: typeof VitestExpect) {
+  return Effect.gen(function* () {
+    yield* TestClock.setTime(Date.parse('2026-09-01T00:00:00.000Z'))
+    const tokens = yield* ApiTokenRegistry
+    const endpoints = yield* WebhookEndpoints
+    const a = yield* tokens.create({
+      name: 'expires',
+      scopes: ['read'],
+      expiresAt: '2026-09-03T00:00:00.000Z'
+    })
+    const b = yield* tokens.create({ name: 'replace-me', scopes: ['read'] })
+    expect(
+      failureTag(yield* Effect.exit(tokens.create({ name: 'full', scopes: ['read'] })))
+    ).toBe('PlanLimitExceeded')
+
+    yield* tokens.revoke({ tokenId: a.id })
+    const c = yield* tokens.create({ name: 'after-revoke', scopes: ['read'] })
+    const replacement = yield* tokens.replace({
+      tokenId: b.id,
+      scopes: ['read'],
+      overlapSeconds: 60
+    })
+    expect(
+      failureTag(
+        yield* Effect.exit(tokens.create({ name: 'rotated-full', scopes: ['read'] }))
+      )
+    ).toBe('PlanLimitExceeded')
+    yield* tokens.revoke({ tokenId: replacement.id })
+    yield* tokens.create({ name: 'after-replacement-revoke', scopes: ['read'] })
+
+    yield* tokens.revoke({ tokenId: c.id })
+    const expiring = yield* tokens.create({
+      name: 'expires-for-admission',
+      scopes: ['read'],
+      expiresAt: '2026-09-03T00:00:00.000Z'
+    })
+    expect(expiring.expiresAt).toBe('2026-09-03T00:00:00.000Z')
+    expect(
+      failureTag(
+        yield* Effect.exit(tokens.create({ name: 'before-expiry', scopes: ['read'] }))
+      )
+    ).toBe('PlanLimitExceeded')
+    yield* TestClock.setTime(Date.parse('2026-09-03T00:00:00.000Z'))
+    yield* tokens.create({ name: 'after-expiry', scopes: ['read'] })
+
+    const first = yield* endpoints.create({
+      url: 'https://example.com/first',
+      events: []
+    })
+    expect(
+      failureTag(
+        yield* Effect.exit(
+          endpoints.create({ url: 'https://example.com/second', events: [] })
+        )
+      )
+    ).toBe('PlanLimitExceeded')
+    yield* endpoints.update({ endpointId: first.endpoint.id, enabled: false })
+    expect(
+      failureTag(
+        yield* Effect.exit(
+          endpoints.create({ url: 'https://example.com/disabled', events: [] })
+        )
+      )
+    ).toBe('PlanLimitExceeded')
   })
 }

--- a/packages/capabilities/src/billing/resource-entitlements.live.test.ts
+++ b/packages/capabilities/src/billing/resource-entitlements.live.test.ts
@@ -22,6 +22,7 @@ import { failureTag } from '../internal/failure-tag.ts'
 import { ResourceEntitlements } from './resource-entitlements.ts'
 import {
   resourceEntitlementsContract,
+  resourceAdmissionContract,
   resourceDeadlineCases
 } from './resource-entitlements.contract.ts'
 
@@ -56,6 +57,36 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })(
         })
       )
     }
+    it.effect(
+      'Live resource admission releases token states and retains disabled webhook slots',
+      () =>
+        Effect.gen(function* () {
+          const db = yield* Database
+          yield* db.delete(apiTokens).where(eq(apiTokens.workspaceId, 'wrk_live'))
+          yield* db
+            .delete(webhookEndpoints)
+            .where(eq(webhookEndpoints.workspaceId, 'wrk_live'))
+          yield* db
+            .delete(workspaceResourceSelections)
+            .where(eq(workspaceResourceSelections.workspaceId, 'wrk_live'))
+          yield* db
+            .delete(workspaceSubscriptions)
+            .where(eq(workspaceSubscriptions.workspaceId, 'wrk_live'))
+          yield* db.insert(workspaceSubscriptions).values({
+            workspaceId: 'wrk_live',
+            stripeCustomerId: 'cus_admission',
+            stripeSubscriptionId: 'sub_admission',
+            subscribedPlanId: 'starter',
+            updatedAt: '2026-09-01T00:00:00.000Z',
+            status: 'active',
+            paymentVerified: true,
+            lastPaymentAt: '2026-09-01T00:00:00.000Z'
+          })
+          yield* inWorkspace('live-lab', resourceAdmissionContract(expect), {
+            userId: 'usr_owner'
+          })
+        })
+    )
     it.effect('malformed stored selection fails in the typed channel', () =>
       Effect.gen(function* () {
         const d1 = yield* RawD1

--- a/packages/capabilities/src/billing/resource-entitlements.live.ts
+++ b/packages/capabilities/src/billing/resource-entitlements.live.ts
@@ -5,7 +5,7 @@ import {
 } from '@b2b-saas-starter/db/schema'
 import { Database, type RawD1 } from '@b2b-saas-starter/db/service'
 import { DateTime, Effect, Layer, Schema } from 'effect'
-import { and, eq, gt, isNull, or, sql } from 'drizzle-orm'
+import { and, count, eq, gt, isNull, or, sql } from 'drizzle-orm'
 import { Billing } from './billing.ts'
 import { AuditEventLog } from '../governance/audit-event-log.ts'
 import { auditedMutations } from '../governance/audited-mutation.ts'
@@ -22,10 +22,19 @@ import {
   resourceIds
 } from './resource-selection-policy.ts'
 import { ResourceEntitlements } from './resource-entitlements.ts'
+import { assertWithinPlanLimit } from './resource-admission.ts'
 
 const decodeSelection = Schema.decodeUnknownEffect(ResourceSelection)
 const encodeIds = Schema.encodeSync(Schema.fromJsonString(Schema.Array(Schema.String)))
 const unavailable = orUnavailable('resource-entitlements')
+function eligibleTokenWhere(workspaceId: string, now: string) {
+  return and(
+    eq(apiTokens.workspaceId, workspaceId),
+    isNull(apiTokens.revokedAt),
+    isNull(apiTokens.replacedByTokenId),
+    or(isNull(apiTokens.expiresAt), gt(apiTokens.expiresAt, now))
+  )
+}
 const readSelection = Effect.fn('ResourceSelections.read')(function* (
   workspaceId: string
 ) {
@@ -78,14 +87,7 @@ export const LiveResourceEntitlements: Layer.Layer<
           db
             .select({ id: apiTokens.id })
             .from(apiTokens)
-            .where(
-              and(
-                eq(apiTokens.workspaceId, workspaceId),
-                isNull(apiTokens.revokedAt),
-                isNull(apiTokens.replacedByTokenId),
-                or(isNull(apiTokens.expiresAt), gt(apiTokens.expiresAt, now))
-              )
-            )
+            .where(eligibleTokenWhere(workspaceId, now))
         ),
         unavailable(
           db
@@ -138,6 +140,30 @@ export const LiveResourceEntitlements: Layer.Layer<
       )
     })
     return ResourceEntitlements.of({
+      admitCreation: Effect.fn('ResourceEntitlements.admitCreation')(function* (input) {
+        const workspaceId = (yield* WorkspaceContext).workspace.id
+        const now = DateTime.formatIso(yield* DateTime.now)
+        let rows
+        if (input.resource === 'api_token') {
+          rows = yield* unavailable(
+            db
+              .select({ value: count() })
+              .from(apiTokens)
+              .where(eligibleTokenWhere(workspaceId, now))
+          )
+        } else {
+          rows = yield* unavailable(
+            db
+              .select({ value: count() })
+              .from(webhookEndpoints)
+              .where(eq(webhookEndpoints.workspaceId, workspaceId))
+          )
+        }
+        const used = rows[0]?.value ?? 0
+        yield* assertWithinPlanLimit({ ...input, used }).pipe(
+          Effect.provideService(Billing, billing)
+        )
+      }),
       getSelection,
       getSelectionForWorkspace,
       summarize,

--- a/packages/capabilities/src/billing/resource-entitlements.seed.test.ts
+++ b/packages/capabilities/src/billing/resource-entitlements.seed.test.ts
@@ -1,6 +1,6 @@
 import { CapabilityUnavailable } from '../errors.ts'
 import { failureTag } from '../internal/failure-tag.ts'
-import { Effect, Layer } from 'effect'
+import { Array, Effect, Exit, Layer } from 'effect'
 import { expect, it } from '@effect/vitest'
 import { SeedAuditEventLog, AuditEventLog } from '../governance/audit-event-log.ts'
 import { SeedNotificationFeed } from '../notifications/notification-feed.seed.ts'
@@ -8,21 +8,24 @@ import { SeedNotificationPreferences } from '../notifications/notification-prefe
 import { SeedAccountPreferences } from '../governance/account-preferences.ts'
 import { SeedApiTokenRegistry } from '../developer-platform/api-token-registry.seed.ts'
 import { SeedWebhookEndpoints } from '../developer-platform/webhook-endpoints.seed.ts'
+import { WebhookEndpoints } from '../developer-platform/webhook-endpoints.ts'
 import { SeedWebhookPublisher } from '../developer-platform/webhook-publisher.ts'
 import { ApiTokenRegistry } from '../developer-platform/api-token-registry.ts'
 import { SeedLayer } from '../layers.ts'
 import { seedWorkspaceRecord } from '../seed-fixture.ts'
 import { testWorkspaceContext } from '../workspace-context.ts'
 import { SeedBilling } from './billing.seed.ts'
+import { type SubscriptionState } from './billing.ts'
 import { ResourceEntitlements } from './resource-entitlements.ts'
 import { SeedResourceEntitlements } from './resource-entitlements.seed.ts'
 import {
   resourceEntitlementsContract,
+  resourceAdmissionContract,
   resourceDeadlineCases
 } from './resource-entitlements.contract.ts'
 
 function seedFixture(
-  state: (typeof resourceDeadlineCases)[number]['state'],
+  state: Partial<SubscriptionState>,
   audit: Layer.Layer<AuditEventLog> = SeedAuditEventLog([])
 ) {
   const feed = SeedNotificationFeed([]).pipe(
@@ -69,6 +72,52 @@ for (const scenario of resourceDeadlineCases) {
     )
   )
 }
+it.effect(
+  'Seed resource admission releases token states and retains disabled webhook slots',
+  () =>
+    resourceAdmissionContract(expect).pipe(
+      Effect.provide(
+        seedFixture({
+          status: 'active',
+          paymentVerified: true,
+          lastPaymentAt: '2026-09-01T00:00:00.000Z',
+          subscribedPlanId: 'starter'
+        })
+      )
+    )
+)
+it.effect(
+  'Seed webhook admission serializes concurrent creates at the Starter cap',
+  () =>
+    Effect.gen(function* () {
+      const endpoints = yield* WebhookEndpoints
+      const outcomes = yield* Effect.all(
+        [1, 2].map((id) =>
+          Effect.exit(
+            endpoints.create({
+              url: `https://example.com/concurrent-${id}`,
+              events: []
+            })
+          )
+        ),
+        { concurrency: 'unbounded' }
+      )
+      const successful = outcomes.filter(Exit.isSuccess)
+      const failed = outcomes.filter(Exit.isFailure)
+      expect(successful).toHaveLength(1)
+      expect(failed).toHaveLength(1)
+      expect(failureTag(Array.getUnsafe(failed, 0))).toBe('PlanLimitExceeded')
+    }).pipe(
+      Effect.provide(
+        seedFixture({
+          status: 'active',
+          paymentVerified: true,
+          lastPaymentAt: '2026-09-01T00:00:00.000Z',
+          subscribedPlanId: 'starter'
+        })
+      )
+    )
+)
 it.effect('full SeedLayer exposes the selection that rotation changes', () =>
   Effect.gen(function* () {
     const tokens = yield* ApiTokenRegistry

--- a/packages/capabilities/src/billing/resource-entitlements.seed.ts
+++ b/packages/capabilities/src/billing/resource-entitlements.seed.ts
@@ -1,4 +1,5 @@
 import { DateTime, Effect, Layer } from 'effect'
+import { assertWithinPlanLimit } from './resource-admission.ts'
 import { Billing } from './billing.ts'
 import { AuditEventLog } from '../governance/audit-event-log.ts'
 import { WorkspaceContext } from '../workspace-context.ts'
@@ -14,6 +15,7 @@ import {
 } from './resource-inventory.seed.ts'
 import {
   ResourceEntitlements,
+  type ResourceEntitlementInput,
   type ResourceSelectionInput,
   type ResourceEntitlementsInterface
 } from './resource-entitlements.ts'
@@ -43,6 +45,22 @@ export function SeedResourceEntitlements() {
         )
       })
       const service: ResourceEntitlementsInterface = {
+        admitCreation: Effect.fn('ResourceEntitlements.admitCreation')(function* (
+          input: ResourceEntitlementInput
+        ) {
+          const ctx = yield* WorkspaceContext
+          const now = DateTime.toEpochMillis(yield* DateTime.now)
+          const inventoryRows = inventory.available(ctx.workspace.id, now)
+          let used: number
+          if (input.resource === 'api_token') {
+            used = inventoryRows.apiTokenIds.length
+          } else {
+            used = inventory.known(ctx.workspace.id).webhookEndpointIds.length
+          }
+          yield* assertWithinPlanLimit({ ...input, used }).pipe(
+            Effect.provideService(Billing, billing)
+          )
+        }),
         getSelectionForWorkspace,
         getSelection: Effect.fn('ResourceEntitlements.getSelection')(function* () {
           return yield* getSelectionForWorkspace((yield* WorkspaceContext).workspace.id)

--- a/packages/capabilities/src/billing/resource-entitlements.ts
+++ b/packages/capabilities/src/billing/resource-entitlements.ts
@@ -2,6 +2,7 @@ import { Context, type Effect } from 'effect'
 
 import {
   type CapabilityUnavailable,
+  type PlanLimitExceeded,
   type ResourceSelectionRejected
 } from '../errors.ts'
 import {
@@ -34,6 +35,10 @@ export type ResourceEntitlementsInterface = {
     CapabilityUnavailable | ResourceSelectionRejected,
     WorkspaceContext
   >
+  /** Counts the resource's admitted rows and applies the request-time plan. */
+  readonly admitCreation: (
+    input: ResourceEntitlementInput
+  ) => Effect.Effect<void, CapabilityUnavailable | PlanLimitExceeded, WorkspaceContext>
   readonly summarize: (
     input: ResourceEntitlementInput
   ) => Effect.Effect<

--- a/packages/capabilities/src/developer-platform/api-token-registry.AGENTS.md
+++ b/packages/capabilities/src/developer-platform/api-token-registry.AGENTS.md
@@ -6,10 +6,10 @@ Workspace-scoped programmatic-access tokens for the REST and MCP surface. Tokens
 
 ## Entry Points & Contracts
 
-- `create` gates on the plan's token ceiling with `assertWithinPlanLimit` (billing owns the rule), audits `api_token.created`, and fans out a best-effort webhook projection that must never carry the plaintext.
+- Creation admission belongs to [Resource entitlements](../billing/resource-entitlements.AGENTS.md); token writes and audits stay here. Published projections must never carry plaintext.
 - `revoke` stamps `revokedAt`. Its where clause carries `workspaceId` and `isNull(revokedAt)`, so a double or cross-workspace revoke resolves `false` and emits no audit event and no webhook.
 - `verifyBearerToken` authenticates only: it reports the token's scopes and `requirePermission` decides. It fails `AuthorizationDenied` with `reason: 'invalid_token'`, this layer's single authorization-shaped failure, which `apps/api` answers as 401.
-- `verifyBearerToken` bumps `lastUsedAt` at most once per `LAST_USED_WRITE_INTERVAL_MS`, decided by the pure `shouldBumpLastUsedAt`. It emits no audit event; the per-request `api_token.used` event was dropped for flooding the log.
+- Bearer verification stays read-mostly and emits no audit event; preserve the throttle on `lastUsedAt` writes.
 - `replace` requires `apiToken:create` at the boundary. The shared policy preserves workspace, scope subset, and expiry; overlap is 0–86,400 seconds. D1 claims the source, inserts the replacement, and audits in one batch. Its mandatory workspace subquery makes a lost concurrent claim roll back. See ADR 0026 before changing this write.
 - `expiresAt <= now` fails bearer verification. Replaced parents remain usable only until their shortened expiry and cannot be replaced again.
 - `ApiTokenScope` is closed: widening it means a literal here plus a column constraint in the same migration.
@@ -17,11 +17,8 @@ Workspace-scoped programmatic-access tokens for the REST and MCP surface. Tokens
 ## Patterns & Pitfalls
 
 - Seed stores hashes for fixture and newly issued credentials. `seedApiTokenValue` in the fixture resolves the two documented credentials by ID; `scripts/seed.ts` uses the same mapping and scopes. Verification reads revocation and expiry on every call.
-- `hashApiToken` is shared with `scripts/seed.ts`; both must mint the same hash.
 
 ## Anti-patterns
 
 - No `tokenHash` on any returned DTO.
-- No per-request write added back to `verifyBearerToken`; it runs on every authenticated API request and stays read-mostly.
-- No non-emitting lifecycle mutation; `create` and `revoke` feed the admin audit view.
 - Not for Better Auth session tokens; those are a different principal in Better Auth's own tables.

--- a/packages/capabilities/src/developer-platform/api-token-registry.live.ts
+++ b/packages/capabilities/src/developer-platform/api-token-registry.live.ts
@@ -1,11 +1,9 @@
 import { prepareTokenSelectionRotation } from '../billing/resource-entitlements.live.ts'
-import { Billing } from '../billing/billing.ts'
 import { apiTokens, workspaces } from '@b2b-saas-starter/db/schema'
 import { Database, type BatchStatement, type RawD1 } from '@b2b-saas-starter/db/service'
 import { DateTime, Effect, Layer } from 'effect'
 import { and, desc, eq, gt, isNull, or, sql, type SQL } from 'drizzle-orm'
 
-import { assertWithinPlanLimitFor } from '../billing/resource-admission.ts'
 import { ApiTokenNotRotatable, AuthorizationDenied } from '../errors.ts'
 import {
   mintApiToken,
@@ -70,12 +68,11 @@ export function LiveApiTokenRegistry(
 ): Layer.Layer<
   ApiTokenRegistry,
   never,
-  Database | RawD1 | Billing | AuditEventLog | WebhookPublisher | ResourceEntitlements
+  Database | RawD1 | AuditEventLog | WebhookPublisher | ResourceEntitlements
 > {
   return Layer.effect(ApiTokenRegistry)(
     Effect.gen(function* () {
       const db = yield* Database
-      const billing = yield* Billing
       const audit = yield* AuditEventLog
       const publisher = yield* WebhookPublisher
       const entitlements = yield* ResourceEntitlements
@@ -142,21 +139,7 @@ export function LiveApiTokenRegistry(
           // Entitlement gate: the workspace's plan caps token count. The
           // rule and the counting both live in the billing capability, so no
           // caller can forget the gate.
-          yield* assertWithinPlanLimitFor({
-            resource: 'api_token',
-            db,
-            capability: 'api-token-registry',
-            table: apiTokens,
-            where: and(
-              eq(apiTokens.workspaceId, ctx.workspace.id),
-              isNull(apiTokens.revokedAt),
-              isNull(apiTokens.replacedByTokenId),
-              or(
-                isNull(apiTokens.expiresAt),
-                gt(apiTokens.expiresAt, DateTime.formatIso(now))
-              )
-            )
-          }).pipe(Effect.provideService(Billing, billing))
+          yield* entitlements.admitCreation({ resource: 'api_token' })
           const token = mintApiToken()
           const createdAt = DateTime.formatIso(now)
           const row = {

--- a/packages/capabilities/src/developer-platform/api-token-registry.seed.ts
+++ b/packages/capabilities/src/developer-platform/api-token-registry.seed.ts
@@ -2,10 +2,8 @@ import {
   SeedResourceInventory,
   SeedResourceInventoryLayer
 } from '../billing/resource-inventory.seed.ts'
-import { Billing } from '../billing/billing.ts'
 import { DateTime, Effect, Layer } from 'effect'
 
-import { assertWithinPlanLimit } from '../billing/resource-admission.ts'
 import { ResourceEntitlements } from '../billing/resource-entitlements.ts'
 import { ApiTokenNotRotatable, AuthorizationDenied } from '../errors.ts'
 import { newCapabilityId } from '../internal/ids.ts'
@@ -40,12 +38,11 @@ export function SeedApiTokenRegistry(
 ): Layer.Layer<
   ApiTokenRegistry,
   never,
-  Billing | AuditEventLog | WebhookPublisher | ResourceEntitlements
+  AuditEventLog | WebhookPublisher | ResourceEntitlements
 > {
   return Layer.effect(
     ApiTokenRegistry,
     Effect.gen(function* () {
-      const billing = yield* Billing
       const audit = yield* AuditEventLog
       const publisher = yield* WebhookPublisher
       const entitlements = yield* ResourceEntitlements
@@ -122,14 +119,7 @@ export function SeedApiTokenRegistry(
           const ctx = yield* WorkspaceContext
           const now = yield* DateTime.now
           const valid = yield* validateTokenCreation(input, DateTime.toEpochMillis(now))
-          yield* assertWithinPlanLimit({
-            resource: 'api_token',
-            used: activeIn(ctx.workspace.id).filter(
-              (entry) =>
-                entry.token.replacedByTokenId === null &&
-                !tokenIsExpired(entry.token.expiresAt, DateTime.toEpochMillis(now))
-            ).length
-          }).pipe(Effect.provideService(Billing, billing))
+          yield* entitlements.admitCreation({ resource: 'api_token' })
           const token = mintApiToken()
           const created: ApiToken = {
             id: yield* newCapabilityId('tok'),

--- a/packages/capabilities/src/developer-platform/developer-platform.contract.ts
+++ b/packages/capabilities/src/developer-platform/developer-platform.contract.ts
@@ -1,3 +1,5 @@
+import { webhookCompletionCases } from './webhook-attempt-completion.contract.ts'
+import { type NotificationFeed } from '../notifications/notification-feed.ts'
 import { webhookAttemptHistoryCases } from './webhook-attempt-history.contract.ts'
 import { Effect, Exit } from 'effect'
 import { type AuditActorTypeValue } from '@b2b-saas-starter/db/enums'
@@ -52,7 +54,11 @@ export type DeveloperPlatformContractCase = {
     | WebhookEndpointNotFound
     | WebhookDeliveryNotFound
     | WebhookDispatchRejected,
-    ApiTokenRegistry | WebhookEndpoints | AuditEventLog | WorkspaceContext
+    | ApiTokenRegistry
+    | WebhookEndpoints
+    | AuditEventLog
+    | WorkspaceContext
+    | NotificationFeed
   >
 }
 
@@ -70,6 +76,7 @@ export function developerPlatformContractCases(
 ): ReadonlyArray<DeveloperPlatformContractCase> {
   return [
     ...webhookAttemptHistoryCases(expect),
+    ...webhookCompletionCases(expect),
     {
       name: 'the same token mutation records the invocation actor in both adapters',
       assert: Effect.gen(function* () {

--- a/packages/capabilities/src/developer-platform/webhook-attempt-completion.contract.ts
+++ b/packages/capabilities/src/developer-platform/webhook-attempt-completion.contract.ts
@@ -1,0 +1,215 @@
+import { DateTime, Effect } from 'effect'
+import { CapabilityUnavailable } from '../errors.ts'
+import { AuditEventLog } from '../governance/audit-event-log.ts'
+import { type ContractExpect } from '../governance/contract-expect.ts'
+import { NotificationFeed } from '../notifications/notification-feed.ts'
+import { WorkspaceContext } from '../workspace-context.ts'
+import { type DeveloperPlatformContractCase } from './developer-platform.contract.ts'
+import {
+  completeWebhookHttpObservation,
+  completeWebhookTerminalObservation
+} from './webhook-attempt-completion.ts'
+import { WebhookEndpoints } from './webhook-endpoints.ts'
+
+function observation(eventType: string) {
+  return Effect.gen(function* () {
+    const webhooks = yield* WebhookEndpoints
+    const ctx = yield* WorkspaceContext
+    const { endpoint } = yield* webhooks.create({
+      url: `https://example.com/${eventType}`,
+      events: ['api_token.created']
+    })
+    return {
+      message: {
+        deliveryId: `whd_${eventType}`,
+        endpointId: endpoint.id,
+        workspaceId: ctx.workspace.id,
+        eventType,
+        payload: { event: eventType }
+      },
+      endpointUrl: endpoint.url,
+      responseStatus: 503,
+      attempts: 2,
+      finishedAt: yield* DateTime.now,
+      durationMs: 10,
+      failureReason: 'Receiver unavailable',
+      requestHeaders: {},
+      responseBody: null
+    }
+  })
+}
+
+export function webhookCompletionCases(
+  expect: ContractExpect
+): ReadonlyArray<DeveloperPlatformContractCase> {
+  return [
+    {
+      name: 'completion follows persisted results for duplicate and late HTTP observations',
+      assert: Effect.gen(function* () {
+        const input = yield* observation('completion_ordering')
+        const webhooks = yield* WebhookEndpoints
+        const audit = yield* AuditEventLog
+        const feed = yield* NotificationFeed
+        expect(yield* completeWebhookHttpObservation(input)).toEqual({
+          status: 'failed',
+          outcome: 'retry'
+        })
+        // Same ordinal already holds a retryable failure; a conflicting
+        // duplicate cannot acknowledge it or emit a permanent-failure notice.
+        expect(
+          yield* completeWebhookHttpObservation({ ...input, responseStatus: 410 })
+        ).toEqual({
+          status: 'failed',
+          outcome: 'retry'
+        })
+        expect(
+          yield* completeWebhookHttpObservation({
+            ...input,
+            attempts: 3,
+            responseStatus: 200
+          })
+        ).toEqual({
+          status: 'delivered',
+          outcome: 'ack'
+        })
+        expect(
+          yield* completeWebhookHttpObservation({
+            ...input,
+            attempts: 1,
+            responseStatus: 410
+          })
+        ).toEqual({
+          status: 'delivered',
+          outcome: 'ack'
+        })
+        const deliveries = yield* webhooks.listDeliveries({
+          endpointId: input.message.endpointId
+        })
+        expect(deliveries[0]).toMatchObject({
+          status: 'delivered',
+          attempts: 3,
+          responseStatus: 200,
+          nextAttemptAt: null
+        })
+        expect(
+          yield* webhooks.listDeliveryAttempts({ deliveryId: input.message.deliveryId })
+        ).toHaveLength(3)
+        expect(
+          (yield* audit.list({ eventType: 'webhook.delivery_failed' })).items.filter(
+            (row) => row.targetId === input.message.endpointId
+          )
+        ).toHaveLength(0)
+        expect(
+          (yield* feed.list).filter(
+            (row) =>
+              row.event?.type === 'webhook.permanent' &&
+              row.event.eventType === input.message.eventType
+          )
+        ).toHaveLength(0)
+      }).pipe(Effect.scoped)
+    },
+    {
+      name: 'completion emits terminal notifications and audits once across redelivery',
+      assert: Effect.gen(function* () {
+        const input = yield* observation('completion_terminal')
+        const webhooks = yield* WebhookEndpoints
+        const audit = yield* AuditEventLog
+        const feed = yield* NotificationFeed
+        const refused = { ...input, responseStatus: 410 }
+        yield* completeWebhookHttpObservation(refused)
+        yield* completeWebhookHttpObservation(refused)
+        expect(
+          (yield* feed.list).filter(
+            (row) =>
+              row.event?.type === 'webhook.permanent' &&
+              row.event.eventType === input.message.eventType
+          )
+        ).toHaveLength(1)
+        expect(
+          (yield* audit.list({ eventType: 'webhook.delivery_failed' })).items.filter(
+            (row) => row.targetId === input.message.endpointId
+          )
+        ).toHaveLength(1)
+
+        const queued = {
+          ...input,
+          message: {
+            ...input.message,
+            deliveryId: 'whd_completion_dlq',
+            eventType: 'completion_dlq'
+          },
+          attempts: 6
+        }
+        yield* completeWebhookHttpObservation(queued)
+        const terminal = {
+          message: queued.message,
+          attempts: 1,
+          status: 'dead_lettered',
+          failureReason: 'Queue retries exhausted',
+          endpointUrl: null
+        } satisfies Parameters<typeof completeWebhookTerminalObservation>[0]
+        expect(yield* completeWebhookTerminalObservation(terminal)).toEqual({
+          status: 'dead_lettered',
+          outcome: 'ack'
+        })
+        yield* completeWebhookTerminalObservation(terminal)
+        expect(
+          (yield* webhooks.listDeliveries({
+            endpointId: input.message.endpointId
+          })).find((row) => row.id === queued.message.deliveryId)
+        ).toMatchObject({ status: 'dead_lettered', attempts: 6, responseStatus: 503 })
+        expect(
+          (yield* feed.list).filter(
+            (row) =>
+              row.event?.type === 'webhook.dead_letter' &&
+              row.event.eventType === 'completion_dlq'
+          )
+        ).toHaveLength(1)
+        expect(
+          (yield* audit.list({
+            eventType: 'webhook.delivery_dead_lettered'
+          })).items.filter((row) => row.targetId === input.message.endpointId)
+        ).toHaveLength(1)
+      }).pipe(Effect.scoped)
+    },
+    {
+      name: 'notification failure cannot retry a settled webhook completion',
+      assert: Effect.gen(function* () {
+        const input = yield* observation('completion_notice_outage')
+        const webhooks = yield* WebhookEndpoints
+        const audit = yield* AuditEventLog
+        const feed = yield* NotificationFeed
+        const refused = { ...input, responseStatus: 410 }
+        const result = yield* completeWebhookHttpObservation(refused).pipe(
+          Effect.provideService(NotificationFeed, {
+            ...feed,
+            create: () =>
+              Effect.fail(
+                new CapabilityUnavailable({
+                  capability: 'notifications',
+                  reason: 'store unavailable'
+                })
+              )
+          })
+        )
+        expect(result).toEqual({ status: 'failed_permanent', outcome: 'ack' })
+        expect(
+          (yield* webhooks.listDeliveries({ endpointId: input.message.endpointId }))[0]
+        ).toMatchObject({ status: 'failed_permanent' })
+        expect(
+          (yield* audit.list({ eventType: 'webhook.delivery_failed' })).items.filter(
+            (row) => row.targetId === input.message.endpointId
+          )
+        ).toHaveLength(1)
+        yield* completeWebhookHttpObservation(refused)
+        expect(
+          (yield* feed.list).filter(
+            (row) =>
+              row.event?.type === 'webhook.permanent' &&
+              row.event.eventType === input.message.eventType
+          )
+        ).toHaveLength(0)
+      }).pipe(Effect.scoped)
+    }
+  ]
+}

--- a/packages/capabilities/src/developer-platform/webhook-attempt-completion.ts
+++ b/packages/capabilities/src/developer-platform/webhook-attempt-completion.ts
@@ -1,0 +1,173 @@
+import { type DateTime, Effect } from 'effect'
+
+import { NotificationFeed } from '../notifications/notification-feed.ts'
+import { WebhookEndpoints, type RecordedWebhookAttempt } from './webhook-endpoints.ts'
+import {
+  failureLadderNotification,
+  type FailureLadderAction,
+  planDeliveryAttempt,
+  type WebhookDeliveryStatus
+} from './webhook-delivery-plan.ts'
+import { type WebhookQueueMessage } from './webhook-publisher.ts'
+
+type WebhookAttemptCompletion = {
+  readonly status: WebhookDeliveryStatus
+  readonly outcome: 'ack' | 'retry'
+}
+
+const notifyPermanentFailure = Effect.fn(
+  'WebhookAttemptCompletion.notifyPermanentFailure'
+)(
+  function* (message: WebhookQueueMessage, endpointUrl: string) {
+    const feed = yield* NotificationFeed
+    yield* feed.create({
+      workspaceId: message.workspaceId,
+      userId: null,
+      kind: 'webhook.delivery_failed',
+      title: 'Webhook delivery failed',
+      message: `${endpointUrl}: ${message.eventType} was rejected and will not be retried.`,
+      event: {
+        type: 'webhook.permanent',
+        endpointUrl,
+        eventType: message.eventType
+      }
+    })
+  },
+  Effect.catchCause((cause) =>
+    Effect.logError('notification_create_failed', cause).pipe(
+      Effect.annotateLogs({ notificationCreate: 'failed' })
+    )
+  )
+)
+
+const notifyFailureLadder = Effect.fn('WebhookAttemptCompletion.notifyFailureLadder')(
+  function* (input: {
+    readonly failureAction: FailureLadderAction
+    readonly workspaceId: string
+    readonly url: string | null
+    readonly consecutiveFailures: number
+  }) {
+    yield* Effect.annotateLogsScoped({ consecutiveFailures: input.consecutiveFailures })
+    if (input.failureAction === 'silent') {
+      return
+    }
+    const feed = yield* NotificationFeed
+    yield* feed.notifyWorkspaceOwners({
+      workspaceId: input.workspaceId,
+      kind: 'webhook.delivery_failed',
+      ...failureLadderNotification({
+        url: input.url,
+        consecutiveFailures: input.consecutiveFailures
+      })
+    })
+  },
+  Effect.catchCause((cause) =>
+    Effect.logError('failure_ladder_notification_failed', cause).pipe(
+      Effect.annotateLogs({ notificationCreate: 'failed' })
+    )
+  )
+)
+
+const reactToAcceptedObservation = Effect.fn(
+  'WebhookAttemptCompletion.reactToAcceptedObservation'
+)(function* (input: {
+  readonly message: WebhookQueueMessage
+  readonly endpointUrl: string | null
+  readonly recorded: RecordedWebhookAttempt
+}) {
+  if (input.endpointUrl !== null && input.recorded.status === 'failed_permanent') {
+    yield* notifyPermanentFailure(input.message, input.endpointUrl)
+  }
+  yield* notifyFailureLadder({
+    workspaceId: input.message.workspaceId,
+    url: input.endpointUrl,
+    failureAction: input.recorded.failureAction,
+    consecutiveFailures: input.recorded.consecutiveFailures
+  })
+})
+
+type HttpObservationInput = {
+  readonly message: WebhookQueueMessage
+  readonly endpointUrl: string
+  readonly responseStatus: number
+  readonly attempts: number
+  readonly finishedAt: DateTime.Utc
+  readonly durationMs: number
+  readonly failureReason: string | null
+  readonly requestHeaders: Record<string, string>
+  readonly responseBody: string | null
+}
+
+/** Late and duplicate observations follow the persisted summary and never repeat warnings. */
+export const completeWebhookHttpObservation = Effect.fn(
+  'WebhookAttemptCompletion.completeHttpObservation'
+)(function* (input: HttpObservationInput) {
+  const webhooks = yield* WebhookEndpoints
+  const plan = planDeliveryAttempt(
+    input.responseStatus,
+    input.attempts,
+    input.finishedAt
+  )
+  const recorded = yield* webhooks.recordDeliveryAttempt({
+    id: input.message.deliveryId,
+    endpointId: input.message.endpointId,
+    workspaceId: input.message.workspaceId,
+    eventType: input.message.eventType,
+    status: plan.status,
+    attempts: input.attempts,
+    durationMs: input.durationMs,
+    failureReason: input.failureReason,
+    responseStatus: plan.responseStatus,
+    nextAttemptAt: plan.nextAttemptAt,
+    payload: input.message.payload,
+    requestHeaders: input.requestHeaders,
+    responseBody: input.responseBody
+  })
+  if (recorded.recorded) {
+    yield* reactToAcceptedObservation({
+      message: input.message,
+      endpointUrl: input.endpointUrl,
+      recorded
+    })
+  }
+  if (recorded.status === 'failed') {
+    return {
+      status: recorded.status,
+      outcome: 'retry'
+    } satisfies WebhookAttemptCompletion
+  }
+  return { status: recorded.status, outcome: 'ack' } satisfies WebhookAttemptCompletion
+})
+
+type TerminalObservationInput = {
+  readonly message: WebhookQueueMessage
+  readonly attempts: number
+  readonly status: 'failed_permanent' | 'dead_lettered'
+  readonly failureReason: string
+  readonly endpointUrl: string | null
+}
+
+/** Dead-letter broadcasts stay in persistence. A null URL retains its owner-warning wording. */
+export const completeWebhookTerminalObservation = Effect.fn(
+  'WebhookAttemptCompletion.completeTerminalObservation'
+)(function* (input: TerminalObservationInput) {
+  const webhooks = yield* WebhookEndpoints
+  const recorded = yield* webhooks.recordTerminalDeliveryAttempt({
+    deliveryId: input.message.deliveryId,
+    endpointId: input.message.endpointId,
+    workspaceId: input.message.workspaceId,
+    eventType: input.message.eventType,
+    attempts: input.attempts,
+    status: input.status,
+    failureReason: input.failureReason,
+    payload: input.message.payload
+  })
+  if (recorded.recorded) {
+    yield* reactToAcceptedObservation({
+      message: input.message,
+      endpointUrl: input.endpointUrl,
+      recorded
+    })
+  }
+  return { status: recorded.status, outcome: 'ack' } satisfies WebhookAttemptCompletion
+})

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.AGENTS.md
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.AGENTS.md
@@ -6,24 +6,22 @@ Webhook destinations and tooling; background dispatch uses [`webhook-publisher`]
 
 ## Entry Points & Contracts
 
-- Creation applies billing's plan ceiling and publishes a best-effort projection without the secret.
+- [Resource entitlements](../billing/resource-entitlements.AGENTS.md) owns creation admission; creation publishes a best-effort projection without the secret.
 - Replay creates an audited `pending` copy linked by `replayedFrom`; the source stays untouched (ADR 0062). Test sends use their delivery row as the record.
 - `/admin` calls `listGlobalDeliveries` and `replayDeliveryAsAdmin` without `WorkspaceContext`. Its boundary rechecks the system-admin session; replay resolves the workspace internally and audits the actual actor with `scope: system_admin`. Never fabricate membership. Workspace replay keeps its membership and permission gates.
-- Rotation keeps the replaced secret signing for 24h; `activeSigningSecrets` filters expiry lazily.
 - Background lookups use `(endpointId, workspaceId)` from the queue. Dispatch targets return all active signing secrets.
-- Dead letters record broadcast notifications, worded by `deadLetterNotification`.
-- Accepted failures batch the streak and threshold disable with the attempt; the worker only sends best-effort warnings for accepted results. Terminal bookkeeping after HTTP failures does not count another dispatch failure.
+- [Attempt completion](./webhook-attempt-completion.ts) owns queue disposition and accepted-only warnings. Persistence retains dead-letter broadcasts. Terminal bookkeeping after HTTP failures does not count another dispatch failure.
 
 ## Patterns & Pitfalls
 
-- `webhook-attempt-history.live.ts` atomically accepts immutable attempt observations, advances summaries, moves failure streaks, and auto-disables with guarded audits. Duplicate and late observations cannot repeat these effects. Read ADR 0073 before changing acceptance order or identity.
+- `webhook-attempt-history.live.ts` atomically accepts immutable attempt observations, advances summaries, moves failure streaks, and auto-disables with guarded audits. Read ADR 0073 before changing acceptance order or identity.
 - Global paging uses `(lastAttemptAt DESC, id DESC)`, with null times last in both adapters. Admin replay requires a terminal source and enabled endpoint. Queue failures remain visible after the pending copy commits.
 - Signing secrets are plaintext in D1 by design (HMAC needs them back); only `rotateSecret` and `getDispatchTarget` return them.
 
 ## Anti-patterns
 
 - No dispatch from a request path, no in-place delivery mutation to replay, no `successRate` recomputed in a route.
-- Every mutation's where clause carries `workspaceId`, never the endpoint id alone (regression test in `src/index.test.ts`).
+- Every mutation's where clause carries `workspaceId`, never the endpoint id alone.
 
 > TODO(intent): keyset paging for delivery summaries, `lastDeliveryAt` on the list projection.
 

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.live.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.live.ts
@@ -1,4 +1,3 @@
-import { Billing } from '../billing/billing.ts'
 import { makeLiveAttemptHistory } from './webhook-attempt-history.live.ts'
 import { Database, type RawD1 } from '@b2b-saas-starter/db/service'
 import {
@@ -11,7 +10,6 @@ import {
 import { DateTime, Effect, Layer } from 'effect'
 import { and, asc, count, desc, eq, inArray, sql, type SQL } from 'drizzle-orm'
 
-import { assertWithinPlanLimitFor } from '../billing/resource-admission.ts'
 import { ResourceEntitlements } from '../billing/resource-entitlements.ts'
 import { auditedMutations } from '../governance/audited-mutation.ts'
 import {
@@ -115,7 +113,6 @@ function updateMetadata(input: {
 export const LiveWebhookEndpoints: Layer.Layer<
   WebhookEndpoints,
   never,
-  | Billing
   | Database
   | RawD1
   | AuditEventLog
@@ -125,7 +122,6 @@ export const LiveWebhookEndpoints: Layer.Layer<
 > = Layer.effect(WebhookEndpoints)(
   Effect.gen(function* () {
     const db = yield* Database
-    const billing = yield* Billing
     const audit = yield* AuditEventLog
     const publisher = yield* WebhookPublisher
     const entitlements = yield* ResourceEntitlements
@@ -301,13 +297,7 @@ export const LiveWebhookEndpoints: Layer.Layer<
           yield* ensureValidWebhookUrl(input.url)
           const ctx = yield* WorkspaceContext
           // Entitlement gate: the workspace's plan caps endpoint count.
-          yield* assertWithinPlanLimitFor({
-            resource: 'webhook_endpoint',
-            db,
-            capability: 'webhook-endpoints',
-            table: webhookEndpoints,
-            where: eq(webhookEndpoints.workspaceId, ctx.workspace.id)
-          }).pipe(Effect.provideService(Billing, billing))
+          yield* entitlements.admitCreation({ resource: 'webhook_endpoint' })
           const signingSecret = randomWebhookSecret()
           const createdAt = yield* DateTime.now
           const endpoint = {

--- a/packages/capabilities/src/developer-platform/webhook-endpoints.seed.ts
+++ b/packages/capabilities/src/developer-platform/webhook-endpoints.seed.ts
@@ -2,13 +2,11 @@ import {
   SeedResourceInventory,
   SeedResourceInventoryLayer
 } from '../billing/resource-inventory.seed.ts'
-import { Billing } from '../billing/billing.ts'
 import { bestEffort } from '../internal/best-effort.ts'
 import { attemptEvidence } from './webhook-attempt-history.ts'
 import { DateTime, Duration, Effect, Layer } from 'effect'
 import { randomWebhookSecret } from '../crypto.ts'
 
-import { assertWithinPlanLimit } from '../billing/resource-admission.ts'
 import { ResourceEntitlements } from '../billing/resource-entitlements.ts'
 import { newCapabilityId } from '../internal/ids.ts'
 import { seedKeysetPage } from '../internal/keyset-cursor.ts'
@@ -161,11 +159,10 @@ export function SeedWebhookEndpoints(
 ): Layer.Layer<
   WebhookEndpoints,
   never,
-  Billing | AuditEventLog | WebhookPublisher | NotificationFeed | ResourceEntitlements
+  AuditEventLog | WebhookPublisher | NotificationFeed | ResourceEntitlements
 > {
   return Layer.effect(WebhookEndpoints)(
     Effect.gen(function* () {
-      const billing = yield* Billing
       const audit = yield* AuditEventLog
       const publisher = yield* WebhookPublisher
       const notificationFeed = yield* NotificationFeed
@@ -553,12 +550,7 @@ export function SeedWebhookEndpoints(
           const ctx = yield* WorkspaceContext
           // Same entitlement gate as Live — and because the store mutates, the
           // cap can actually trip here instead of being unreachable.
-          yield* assertWithinPlanLimit({
-            resource: 'webhook_endpoint',
-            used: endpoints.filter(
-              (endpoint) => endpoint.workspaceId === ctx.workspace.id
-            ).length
-          }).pipe(Effect.provideService(Billing, billing))
+          yield* entitlements.admitCreation({ resource: 'webhook_endpoint' })
           const endpoint: SeedEndpointRow = {
             id: yield* newCapabilityId('wh'),
             workspaceId: ctx.workspace.id,
@@ -589,7 +581,7 @@ export function SeedWebhookEndpoints(
             endpoint: toProjection(endpoint, deliveries),
             signingSecret: endpoint.signingSecret
           }
-        }),
+        }, inventory.lock.withPermits(1)),
         listDeliveries: (input) =>
           Effect.gen(function* () {
             const ctx = yield* WorkspaceContext

--- a/packages/capabilities/src/email-delivery/email-delivery.AGENTS.md
+++ b/packages/capabilities/src/email-delivery/email-delivery.AGENTS.md
@@ -6,13 +6,13 @@ Owns send claims and sanitized delivery evidence across auth, invitations and no
 
 ## Entry Points & Contracts
 
-[The contract](email-delivery.ts) separates trusted worker writes from scoped reads. Caller guards authorize self-history and System Admin history. Invitation reads require `WorkspaceContext` plus an upstream invitation permission check. Resolving a user at send time fixes the history association; provider events must never discover or change that association.
+[The contract](email-delivery.ts) separates trusted writes from scoped reads. Caller guards authorize self-history and System Admin history. Invitation reads require `WorkspaceContext` plus an upstream invitation permission check. Resolving a user at send time fixes the history association; provider events must never discover or change that association.
 
 ## Patterns & Pitfalls
 
 - Keep transport calls outside persistence. Claim tokens fence failed outcomes. A late accepted receipt survives lease renewal; the persisted accepted marker forbids future submission even when no delivery event arrives.
 - `trackedAttempt` owns claim, send-outcome persistence and metrics; transport adapters supply an effect producing sanitized outcomes and classify their own failures.
-- An interrupted attempt can be retried after its lease only for notifications/digests within the original creation window. Consumers must recheck relevance, permissions and preferences before claiming.
+- Retry timing belongs to `completionDecision`, including active-lease skips. Consumers recheck relevance, permissions and preferences before claiming, then follow completion even when sending was skipped. Notification/digest retries retain the original creation window.
 - Missing provider evidence is not proof of failure. An unmatched event may race the acceptance write; the trusted consumer retries it briefly.
 - Auth recovery uses the auth provider's fresh-credential flow. Retained records must never include rendered bodies, secret links, OTPs or raw provider payloads.
 - Changes to terminal ordering or retention belong in the shared Seed/Live contract cases. Retention expiry measures original creation time, so repeated events cannot keep evidence indefinitely.

--- a/packages/capabilities/src/email-delivery/email-delivery.contract.ts
+++ b/packages/capabilities/src/email-delivery/email-delivery.contract.ts
@@ -126,6 +126,24 @@ export function emailDeliveryContractCases(expect: typeof vitestExpect) {
         expect((yield* delivery.get('tracked-failure'))?.status).toBe(
           'temporary_failure'
         )
+        expect(yield* delivery.completionDecision('tracked-failure')).toEqual({
+          outcome: 'retry_pending',
+          status: 'temporary_failure',
+          retryAfterSeconds: 60
+        })
+        expect(yield* delivery.completionDecision('tracked')).toEqual({
+          outcome: 'ack',
+          status: 'accepted'
+        })
+        const active = yield* delivery.claim(input('active-lease'))
+        if (!active) {
+          expect.fail('expected active lease claim')
+        }
+        expect(yield* delivery.completionDecision('active-lease')).toEqual({
+          outcome: 'retry_pending',
+          status: 'queued',
+          retryAfterSeconds: 300
+        })
       })
     },
     {
@@ -337,9 +355,28 @@ export function emailDeliveryContractCases(expect: typeof vitestExpect) {
         })
         expect(yield* delivery.claim(input('ambiguous', 'digest'))).toBeNull()
         yield* TestClock.adjust('5 minutes')
-        expect(yield* delivery.claim(input('ambiguous', 'digest'))).not.toBeNull()
+        const retryClaim = yield* delivery.claim(input('ambiguous', 'digest'))
+        if (!retryClaim) {
+          expect.fail('expected the lease to expire')
+        }
+        expect(yield* delivery.completionDecision('ambiguous')).toEqual({
+          outcome: 'retry_pending',
+          status: 'ambiguous',
+          retryAfterSeconds: 300
+        })
+        yield* delivery.recordOutcome('ambiguous', retryClaim.token, {
+          status: 'ambiguous',
+          reason: 'timeout'
+        })
         expect((yield* delivery.get('ambiguous'))?.uncertain).toBe(true)
-        yield* TestClock.adjust('6 hours')
+        yield* TestClock.adjust('5 hours')
+        yield* TestClock.adjust('54 minutes')
+        expect(yield* delivery.completionDecision('ambiguous')).toEqual({
+          outcome: 'retry_pending',
+          status: 'ambiguous',
+          retryAfterSeconds: 1
+        })
+        yield* TestClock.adjust('1 minute')
         expect(yield* delivery.claim(input('ambiguous', 'digest'))).toBeNull()
         expect((yield* delivery.get('ambiguous'))?.reason).toBe('retry_window_expired')
       })

--- a/packages/capabilities/src/email-delivery/email-delivery.internal.ts
+++ b/packages/capabilities/src/email-delivery/email-delivery.internal.ts
@@ -5,6 +5,7 @@ import { WorkspaceContext } from '../workspace-context.ts'
 import {
   EmailDelivery,
   type ClaimEmail,
+  type EmailCompletionDecision,
   type EmailDeliveryRecord,
   type EmailProviderEvent,
   type SendOutcome
@@ -237,6 +238,30 @@ export function makeEmailDelivery(store: DeliveryStore): EmailDelivery['Service'
       })
     )
   })
+  const completionDecision = Effect.fn('EmailDelivery.completionDecision')(function* (
+    id: string
+  ) {
+    const record = yield* store.get(id)
+    if (
+      record === null ||
+      !['queued', 'temporary_failure', 'ambiguous'].includes(record.status)
+    ) {
+      return {
+        outcome: 'ack',
+        status: record?.status ?? 'skipped'
+      } satisfies EmailCompletionDecision
+    }
+    const now = yield* Clock.currentTimeMillis
+    const due = Math.min(
+      Date.parse(record.nextAttemptAt),
+      Date.parse(record.retryUntil)
+    )
+    return {
+      outcome: 'retry_pending',
+      status: record.status,
+      retryAfterSeconds: Math.max(1, Math.ceil((due - now) / 1000))
+    } satisfies EmailCompletionDecision
+  })
   const applyProviderEvent = Effect.fn('EmailDelivery.applyProviderEvent')(function* (
     event: EmailProviderEvent
   ) {
@@ -438,6 +463,7 @@ export function makeEmailDelivery(store: DeliveryStore): EmailDelivery['Service'
   })
   return EmailDelivery.of({
     trackedAttempt,
+    completionDecision,
     claim,
     recordOutcome,
     abandon,

--- a/packages/capabilities/src/email-delivery/email-delivery.ts
+++ b/packages/capabilities/src/email-delivery/email-delivery.ts
@@ -39,6 +39,17 @@ export type SendOutcome =
         | 'provider_rejected'
         | 'provider_suppressed'
     }
+
+export type EmailCompletionDecision =
+  | {
+      readonly outcome: 'ack'
+      readonly status: EmailDeliveryRecord['status'] | 'skipped'
+    }
+  | {
+      readonly outcome: 'retry_pending'
+      readonly status: EmailDeliveryRecord['status']
+      readonly retryAfterSeconds: number
+    }
 export const EmailProviderEvent = Schema.Struct({
   eventId: Schema.String,
   messageId: Schema.String,
@@ -67,6 +78,8 @@ export type EmailDeliveryInterface = {
     E | CapabilityUnavailable,
     R
   >
+  /** Converts persisted attempt evidence into the queue-facing completion. */
+  readonly completionDecision: (id: string) => Result<EmailCompletionDecision>
   readonly claim: (input: ClaimEmail) => Result<{ readonly token: string } | null>
   readonly recordOutcome: (
     id: string,

--- a/packages/capabilities/src/index.test.ts
+++ b/packages/capabilities/src/index.test.ts
@@ -117,9 +117,10 @@ describe('seed developer-platform contract', () => {
     SeedWebhookEndpoints([]).pipe(
       Layer.provide(auditLog),
       Layer.provide(publisher),
+      // Capture the feed this contract reads before SeedLayer supplies its own.
+      Layer.provide(notificationFeed),
       Layer.provide(SeedLayer),
-      Layer.provide(SeedResourceEntitlements().pipe(Layer.provide(SeedLayer))),
-      Layer.provide(notificationFeed)
+      Layer.provide(SeedResourceEntitlements().pipe(Layer.provide(SeedLayer)))
     ),
     notificationFeed
   )

--- a/packages/capabilities/src/layers.ts
+++ b/packages/capabilities/src/layers.ts
@@ -224,10 +224,7 @@ const SeedCore = Layer.mergeAll(
   // out webhooks below their interface; the shared fixture audit log and the
   // no-op Seed publisher are provided once on the merged layer so every member
   // sees the same instances.
-  SeedApiTokenRegistry(seedApiTokens).pipe(
-    Layer.provide(SeedGovernance),
-    Layer.provide(SeedEntitlements)
-  ),
+  SeedApiTokenRegistry(seedApiTokens).pipe(Layer.provide(SeedEntitlements)),
   SeedEntitlements,
   SeedAuditLog,
   SeedMcpClientConnections({
@@ -243,7 +240,7 @@ const SeedCore = Layer.mergeAll(
     seedDeliveries,
     undefined,
     seedDeliveryAttempts
-  ).pipe(Layer.provide(SeedGovernance), Layer.provide(SeedEntitlements)),
+  ).pipe(Layer.provide(SeedEntitlements)),
   SeedWebhookPublisher,
   SeedGovernance,
   SeedPlatformUserAdmin(seedSystemUsers, seedUserAdminMemberships),
@@ -375,10 +372,7 @@ export function makeLiveCapabilitiesLayer(
   return Layer.mergeAll(
     LiveEmailDelivery,
     LiveAccountLifecycle(options.accountLifecycleBinding, options.securityEvidence),
-    LiveApiTokenRegistry(options.securityEvidence).pipe(
-      Layer.provide(billing),
-      Layer.provide(entitlements)
-    ),
+    LiveApiTokenRegistry(options.securityEvidence).pipe(Layer.provide(entitlements)),
     LiveAuditEventLog,
     billing,
     entitlements,
@@ -387,7 +381,7 @@ export function makeLiveCapabilitiesLayer(
     accountPreferences,
     feed,
     LiveSsoConnections(options.ssoBinding),
-    LiveWebhookEndpoints.pipe(Layer.provide(billing), Layer.provide(entitlements)),
+    LiveWebhookEndpoints.pipe(Layer.provide(entitlements)),
     publisher,
     LiveWorkspaceInvitations(options.invitationBinding),
     LiveWorkspaceMembership(options.memberBinding, options.securityEvidence),


### PR DESCRIPTION
## Outcome

Resource creation callers assembled plan checks and inventory predicates, while queue workers interpreted persisted delivery state and coordinated failure notifications. Move those decisions into the capabilities that own them.

This implements the conversation-approved architecture refactor:

- AC-R1–R4: `ResourceEntitlements.admitCreation` owns resource-specific counts and the Billing decision. Token eligibility is shared with selection; disabled webhook endpoints still consume creation slots. Seed creation uses the existing mutation lock.
- AC-E1–E4: `EmailDelivery.completionDecision` owns lease/backoff timing and acknowledgement decisions. The notification worker still rechecks relevance and preferences before claiming.
- AC-W1–W4: webhook completion composes planning, atomic recording and accepted-only warnings. Duplicate or late observations follow the persisted summary, and notification failures cannot retry a settled attempt.

## Decisions

Keep existing Seed/Live adapters, audited resource writes, webhook persistence batches and delivery policies. Signing and HTTP remain in the worker. No new service tags, infrastructure, schema or compatibility paths. Update the affected intent docs and ADR 0073 to match ownership.

## Validation

Revision: `33bfb9ea481f946778060f865222cb3670e9393c`.

- Independent Standards review passed. Independent Spec review found a Seed concurrency gap; the lock repair and concurrent regression passed re-review.
- [CI run](https://github.com/brandhaug/b2b-saas-starter/actions/runs/34163033684) passed typecheck, lint, dead-code, generated Wrangler checks, the full test suite, scripts, operations, build and browser tests. Capabilities: 581 tests passed; coverage is 92.63% statements, 83.05% branches, 93.87% functions and 92.52% lines. Web: 609 tests passed.
- Local `pnpm run validate` passed static checks but stopped on Live D1 timeouts. An explicit two-worker rerun cleared seven of eight timeouts. The unchanged email retention test passed in about 32 seconds with a temporary diagnostic timeout; its committed 30-second limit remains unchanged and passed in CI.
- Remaining local API, email, SDK and background suites passed. The duplicate local web-unit rerun was stopped after CI passed. Script/operations checks, build, Wrangler drift check and local migration/seed passed. Local browser validation completed successfully: 24 passed immediately and three passed on retry. The retried cases were account-session revocation, audit navigation and passkey registration.

Regression coverage includes token revocation/replacement/expiry, disabled webhook slots, concurrent Seed creation, email active leases and retry-window limits, and composed webhook completion through Seed/Live adapters with observable audit and notification assertions.

## Risks and remaining work

No code or review blockers remain. Local full-command validation is limited by the documented D1 timeout; the full CI suite passed at the committed limits. No migration or reseeding changes required.
