### PR TITLE
refactor(web): compose tables and auth layouts

### DIFF
--- a/apps/web/src/components/admin-failed-deliveries.tsx
+++ b/apps/web/src/components/admin-failed-deliveries.tsx
@@ -1,7 +1,7 @@
 import { statusLabel } from '@/lib/value-labels'
 import { useState, useTransition } from 'react'
 import { type GlobalWebhookDelivery } from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
-import { DataTable, type DataTableColumnDef } from './data-table'
+import { DataTable, DataTableContent, type DataTableColumnDef } from './data-table'
 import { Panel } from './page/panel'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
@@ -151,11 +151,11 @@ export function AdminFailedDeliveries({
       <DataTable
         columns={columns()}
         data={page.items}
-        pageSize={20}
-        pager={false}
         tableLabel={m.failed_webhook_deliveries()}
         emptyMessage={m.no_terminal_webhook_failures()}
-      />
+      >
+        <DataTableContent />
+      </DataTable>
       <div className="flex flex-wrap gap-2">
         <Button variant="outline" disabled={pending} onClick={() => load()}>
           {m.refresh_newest()}

--- a/apps/web/src/components/auth/auth-card-form.tsx
+++ b/apps/web/src/components/auth/auth-card-form.tsx
@@ -22,9 +22,7 @@ export type SubscribableForm = {
  * The e2e hydration signal is set here by construction: every auth form gets
  * `data-hydrated` once React hydrates, with no per-route copy to forget.
  *
- * `form` may be `null` for a card that carries no form (e.g. the sent
- * confirmation on forgot-password); the children then render without a
- * `<form>` wrapper.
+ * Use AuthNoticeCard for confirmations and other content without a form.
  */
 export function AuthCardForm({
   title,
@@ -38,8 +36,7 @@ export function AuthCardForm({
 }: {
   readonly title: string
   readonly description?: ReactNode
-  /** `null` renders the children without a `<form>` wrapper. */
-  readonly form: SubscribableForm | null
+  readonly form: SubscribableForm
   /** The submit control — an `<AuthSubmitButton>` in practice. */
   readonly submit?: ReactNode
   /** Submit failure message; rendered as a destructive alert inside the form. */
@@ -53,23 +50,80 @@ export function AuthCardForm({
   // Hydration signal for e2e: interacting before React hydrates falls through
   // to a native GET submit, so the smoke test waits for this attribute.
   const hydrated = useClientValue(() => true, false)
+  return (
+    <AuthCardShell title={title} description={description} footer={footer}>
+      <form
+        data-hydrated={hydrated ? 'true' : undefined}
+        onSubmit={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          void form.handleSubmit()
+        }}
+        className="grid gap-4"
+      >
+        {children}
+        {submit}
+        <AuthErrorAlert error={error} />
+        {notice ? (
+          <Alert>
+            <AlertDescription>{notice}</AlertDescription>
+          </Alert>
+        ) : null}
+      </form>
+    </AuthCardShell>
+  )
+}
+
+export function AuthNoticeCard({
+  title,
+  description,
+  error,
+  footer,
+  children
+}: {
+  readonly title: string
+  readonly description?: ReactNode
+  readonly error?: string | null
+  readonly footer?: ReactNode
+  readonly children: ReactNode
+}) {
+  return (
+    <AuthCardShell title={title} description={description} footer={footer}>
+      <div className="grid gap-4">
+        {children}
+        <AuthErrorAlert error={error} />
+      </div>
+    </AuthCardShell>
+  )
+}
+
+function AuthErrorAlert({ error }: { readonly error: string | null | undefined }) {
   const errorRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (error) {
       errorRef.current?.focus()
     }
   }, [error])
-  // One alert for both branches: a card without a form (the consent page)
-  // still has errors to show.
-  const errorAlert = error ? (
+  return error ? (
     <Alert ref={errorRef} tabIndex={-1} variant="destructive">
       <AlertDescription>{error}</AlertDescription>
     </Alert>
   ) : null
+}
+
+function AuthCardShell({
+  title,
+  description,
+  footer,
+  children
+}: {
+  readonly title: string
+  readonly description?: ReactNode
+  readonly footer?: ReactNode
+  readonly children: ReactNode
+}) {
   return (
     <PublicLayout>
-      {/* `flex-1` fills the space PublicLayout's `min-h-dvh flex-col` leaves
-          between the header and its `mt-auto` footer — no hardcoded chrome height. */}
       <main
         id="main-content"
         className="mx-auto grid w-full max-w-md flex-1 place-items-center px-4 py-12"
@@ -82,31 +136,7 @@ export function AuthCardForm({
             ) : null}
           </CardHeader>
           <CardContent className="grid gap-4">
-            {form === null ? (
-              <div className="grid gap-4">
-                {children}
-                {errorAlert}
-              </div>
-            ) : (
-              <form
-                data-hydrated={hydrated ? 'true' : undefined}
-                onSubmit={(event) => {
-                  event.preventDefault()
-                  event.stopPropagation()
-                  void form.handleSubmit()
-                }}
-                className="grid gap-4"
-              >
-                {children}
-                {submit}
-                {errorAlert}
-                {notice ? (
-                  <Alert>
-                    <AlertDescription>{notice}</AlertDescription>
-                  </Alert>
-                ) : null}
-              </form>
-            )}
+            {children}
             {footer}
             <p className="text-center text-sm text-muted-foreground">
               <Link to="/help" reloadDocument className="underline underline-offset-4">

--- a/apps/web/src/components/auth/email-code-exchange.tsx
+++ b/apps/web/src/components/auth/email-code-exchange.tsx
@@ -94,46 +94,18 @@ type EmailCodeFormApi = ReactFormExtendedApi<
  * (`authErrorCopy`, the shared code table, with each flow's fallback) — so
  * the routes only supply the ports and the copy.
  *
- * `layout` picks the chrome: `"page"` renders both steps as standalone
- * `AuthCardForm`s (title + description per step, the footer slots); `"card"`
- * renders one `Card` with a single heading for embedding in a page that
- * already has a layout, with the resend row inside the form like the
- * verify-email page always showed it.
- *
  * `email` presets the address (the reset flow collects it in its fused
  * request form, so its exchange starts on the code step); without it the
  * flow starts on the email step.
  */
-export function EmailCodeExchange({
-  purpose,
-  send = sendEmailCodeWithAuthClient,
-  verify,
-  onVerified,
-  layout = 'page',
-  email,
-  title,
-  emailTitle = m.form_email_code(),
-  emailDescription,
-  emailFooter,
-  codeSentNotice,
-  codeSentNoticeFor,
-  codeSubmitLabel,
-  codeSubmittingLabel,
-  codeSubmitIcon,
-  codeFooter,
-  verifyErrorFallback = m.public_auth_verification_failed(),
-  renderExtraFields,
-  differentEmailLabel = m.use_different_email(),
-  onDifferentEmail
-}: {
+type EmailCodeExchangeProps = {
   readonly purpose: EmailCodePurpose
   readonly send?: SendEmailCode
   readonly verify: VerifyEmailCode
   readonly onVerified: () => void
-  readonly layout?: 'page' | 'card'
   /** A code was already sent here — start on the code step. */
   readonly email?: string
-  /** The code step's heading (the card's only heading in `card` layout). */
+  /** The code step's heading. */
   readonly title: string
   readonly emailTitle?: string
   readonly emailDescription?: string
@@ -145,17 +117,28 @@ export function EmailCodeExchange({
   readonly codeSubmitLabel: string
   readonly codeSubmittingLabel: string
   readonly codeSubmitIcon?: ReactNode
-  /** Rendered under the resend row in the card footer (`page` layout). */
+  /** Rendered under the resend row in the page footer. */
   readonly codeFooter?: ReactNode
   readonly verifyErrorFallback?: string
-  /** Extra fields between the code input and the submit button (the reset
-   * flow's password pair), rendered against the shared code form. */
+  /** Extra fields between the code input and the submit button. */
   readonly renderExtraFields?: (form: EmailCodeFormApi) => ReactNode
   readonly differentEmailLabel?: string
-  /** Overrides the built-in return to the email step (the reset flow goes
-   * back to its fused request form instead). */
+  /** Overrides the built-in return to the email step. */
   readonly onDifferentEmail?: () => void
-}) {
+}
+
+function useEmailCodeExchange({
+  purpose,
+  send = sendEmailCodeWithAuthClient,
+  verify,
+  onVerified,
+  email,
+  codeSentNotice,
+  codeSentNoticeFor,
+  verifyErrorFallback = m.public_auth_verification_failed(),
+  differentEmailLabel = m.use_different_email(),
+  onDifferentEmail
+}: EmailCodeExchangeProps) {
   const [step, setStep] = useState<'email' | 'code'>(
     email === undefined ? 'email' : 'code'
   )
@@ -245,162 +228,180 @@ export function EmailCodeExchange({
     </div>
   )
 
-  if (step === 'email') {
-    if (layout === 'card') {
-      return (
-        <Card className="w-full">
-          <CardHeader>
-            <CardTitle as="h2">{title}</CardTitle>
-          </CardHeader>
-          <CardContent className="grid gap-4">
-            <form
-              onSubmit={(event) => {
-                event.preventDefault()
-                event.stopPropagation()
-                void emailForm.handleSubmit()
-              }}
-              className="grid gap-4"
-            >
-              <emailForm.Field name="email" validators={{ onChange: emailValidator }}>
-                {(field) => (
-                  <FormTextField
-                    name={field.name}
-                    label={m.form_email()}
-                    type="email"
-                    placeholder={m.email_placeholder()}
-                    autoComplete="email"
-                    value={field.state.value}
-                    errors={field.state.meta.errors}
-                    onBlur={field.handleBlur}
-                    onChange={field.handleChange}
-                    required
-                  />
-                )}
-              </emailForm.Field>
-              <AuthSubmitButton
-                form={emailForm}
-                icon={<MailIcon className="size-4" />}
-                label={emailTitle}
-                submittingLabel={m.sending()}
-              />
-              {submitError ? (
-                <p role="alert" className="text-sm text-destructive">
-                  {submitError}
-                </p>
-              ) : null}
-            </form>
-          </CardContent>
-        </Card>
-      )
-    }
+  return { step, emailForm, codeForm, submitError, sentNotice, resendRow }
+}
+
+function EmailStepField({
+  form
+}: {
+  readonly form: ReturnType<typeof useEmailCodeExchange>['emailForm']
+}) {
+  return (
+    <form.Field name="email" validators={{ onChange: emailValidator }}>
+      {(field) => (
+        <FormTextField
+          name={field.name}
+          label={m.form_email()}
+          type="email"
+          placeholder={m.email_placeholder()}
+          autoComplete="email"
+          value={field.state.value}
+          errors={field.state.meta.errors}
+          onBlur={field.handleBlur}
+          onChange={field.handleChange}
+          required
+        />
+      )}
+    </form.Field>
+  )
+}
+
+function CodeStepFields({
+  form,
+  renderExtraFields
+}: {
+  readonly form: EmailCodeFormApi
+  readonly renderExtraFields: ((form: EmailCodeFormApi) => ReactNode) | undefined
+}) {
+  return (
+    <>
+      <form.Field name="code" validators={{ onChange: sixDigitCodeValidator }}>
+        {(field) => (
+          <OtpCodeInput
+            value={field.state.value}
+            onChange={field.handleChange}
+            // oxlint-disable-next-line jsx-a11y/no-autofocus -- the code step has exactly one field group, so focusing its first cell cannot surprise anyone mid-task
+            autoFocus
+          />
+        )}
+      </form.Field>
+      {renderExtraFields?.(form)}
+    </>
+  )
+}
+
+export function EmailCodeExchangePage(props: EmailCodeExchangeProps) {
+  const {
+    title,
+    emailTitle = m.form_email_code(),
+    emailDescription,
+    emailFooter,
+    codeSubmitLabel,
+    codeSubmittingLabel,
+    codeSubmitIcon,
+    codeFooter,
+    renderExtraFields
+  } = props
+  const exchange = useEmailCodeExchange(props)
+  if (exchange.step === 'email') {
     return (
       <AuthCardForm
         title={emailTitle}
         description={emailDescription}
-        form={emailForm}
+        form={exchange.emailForm}
         submit={
           <AuthSubmitButton
-            form={emailForm}
+            form={exchange.emailForm}
             icon={<MailIcon className="size-4" />}
             label={emailTitle}
-            submittingLabel="Sending…"
+            submittingLabel={m.sending()}
           />
         }
-        error={submitError}
+        error={exchange.submitError}
         footer={emailFooter}
       >
-        <emailForm.Field name="email" validators={{ onChange: emailValidator }}>
-          {(field) => (
-            <FormTextField
-              name={field.name}
-              label={m.form_email()}
-              type="email"
-              placeholder={m.email_placeholder()}
-              autoComplete="email"
-              value={field.state.value}
-              errors={field.state.meta.errors}
-              onBlur={field.handleBlur}
-              onChange={field.handleChange}
-              required
-            />
-          )}
-        </emailForm.Field>
+        <EmailStepField form={exchange.emailForm} />
       </AuthCardForm>
     )
   }
-
-  const codeField = (
-    <codeForm.Field name="code" validators={{ onChange: sixDigitCodeValidator }}>
-      {(field) => (
-        <OtpCodeInput
-          value={field.state.value}
-          onChange={field.handleChange}
-          // oxlint-disable-next-line jsx-a11y/no-autofocus -- the code step has exactly one field group, so focusing its first cell cannot surprise anyone mid-task
-          autoFocus
-        />
-      )}
-    </codeForm.Field>
-  )
-
-  if (layout === 'card') {
-    return (
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle as="h2">{title}</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-4">
-          <form
-            onSubmit={(event) => {
-              event.preventDefault()
-              event.stopPropagation()
-              void codeForm.handleSubmit()
-            }}
-            className="grid gap-4"
-          >
-            <p className="text-sm text-muted-foreground">{sentNotice}</p>
-            {codeField}
-            {renderExtraFields?.(codeForm)}
-            {resendRow}
-            <AuthSubmitButton
-              form={codeForm}
-              icon={codeSubmitIcon ?? <ShieldCheckIcon className="size-4" />}
-              label={codeSubmitLabel}
-              submittingLabel={codeSubmittingLabel}
-            />
-            {submitError ? (
-              <p role="alert" className="text-sm text-destructive">
-                {submitError}
-              </p>
-            ) : null}
-          </form>
-        </CardContent>
-      </Card>
-    )
-  }
-
   return (
     <AuthCardForm
       title={title}
-      description={sentNotice}
-      form={codeForm}
+      description={exchange.sentNotice}
+      form={exchange.codeForm}
       submit={
         <AuthSubmitButton
-          form={codeForm}
+          form={exchange.codeForm}
           icon={codeSubmitIcon ?? <ShieldCheckIcon className="size-4" />}
           label={codeSubmitLabel}
           submittingLabel={codeSubmittingLabel}
         />
       }
-      error={submitError}
+      error={exchange.submitError}
       footer={
         <div className="grid gap-3">
-          {resendRow}
+          {exchange.resendRow}
           {codeFooter}
         </div>
       }
     >
-      {codeField}
-      {renderExtraFields?.(codeForm)}
+      <CodeStepFields form={exchange.codeForm} renderExtraFields={renderExtraFields} />
     </AuthCardForm>
+  )
+}
+
+export function EmailCodeExchangeCard(props: EmailCodeExchangeProps) {
+  const {
+    title,
+    emailTitle = m.form_email_code(),
+    codeSubmitLabel,
+    codeSubmittingLabel,
+    codeSubmitIcon,
+    renderExtraFields
+  } = props
+  const exchange = useEmailCodeExchange(props)
+  const submit =
+    exchange.step === 'email' ? (
+      <AuthSubmitButton
+        form={exchange.emailForm}
+        icon={<MailIcon className="size-4" />}
+        label={emailTitle}
+        submittingLabel={m.sending()}
+      />
+    ) : (
+      <AuthSubmitButton
+        form={exchange.codeForm}
+        icon={codeSubmitIcon ?? <ShieldCheckIcon className="size-4" />}
+        label={codeSubmitLabel}
+        submittingLabel={codeSubmittingLabel}
+      />
+    )
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle as="h2">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            void (exchange.step === 'email'
+              ? exchange.emailForm.handleSubmit()
+              : exchange.codeForm.handleSubmit())
+          }}
+          className="grid gap-4"
+        >
+          {exchange.step === 'email' ? (
+            <EmailStepField form={exchange.emailForm} />
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">{exchange.sentNotice}</p>
+              <CodeStepFields
+                form={exchange.codeForm}
+                renderExtraFields={renderExtraFields}
+              />
+              {exchange.resendRow}
+            </>
+          )}
+          {submit}
+          {exchange.submitError ? (
+            <p role="alert" className="text-sm text-destructive">
+              {exchange.submitError}
+            </p>
+          ) : null}
+        </form>
+      </CardContent>
+    </Card>
   )
 }

--- a/apps/web/src/components/auth/sign-in-page.tsx
+++ b/apps/web/src/components/auth/sign-in-page.tsx
@@ -3,7 +3,7 @@ import { Link, useRouter } from '@tanstack/react-router'
 import { useForm } from '@tanstack/react-form'
 import { KeyRoundIcon, MailIcon } from 'lucide-react'
 import { type SsoRoutingDecision } from '@b2b-saas-starter/capabilities/governance/workspace-sso-connections'
-import { AuthCardForm } from '@/components/auth/auth-card-form'
+import { AuthCardForm, AuthNoticeCard } from '@/components/auth/auth-card-form'
 import { AuthSubmitButton } from '@/components/auth/auth-submit-button'
 import { emailValidator, passwordValidator } from '@/components/auth/auth-validators'
 import { DemoCredentialsFooter } from '@/components/auth/demo-credentials-footer'
@@ -298,22 +298,32 @@ export function SignInPage({
   })
 
   if (mode === 'link') {
+    if (linkSent) {
+      return (
+        <AuthNoticeCard
+          title={m.sign_in_with_email_link()}
+          description={m.email_link_description()}
+          error={submitError}
+          footer={signInFooter({ mode, redirect, socialProviders })}
+        >
+          <p role="alert" className="text-sm text-muted-foreground">
+            {linkSentMessage()}
+          </p>
+        </AuthNoticeCard>
+      )
+    }
     return (
       <AuthCardForm
         title={m.sign_in_with_email_link()}
         description={m.email_link_description()}
-        // The sent state is a confirmation, not a form — no wrapper, no
-        // hydration signal needed.
-        form={linkSent ? null : linkForm}
+        form={linkForm}
         submit={
-          linkSent ? undefined : (
-            <AuthSubmitButton
-              form={linkForm}
-              icon={<MailIcon className="size-4" />}
-              label={m.email_me_sign_in_link()}
-              submittingLabel={m.sending()}
-            />
-          )
+          <AuthSubmitButton
+            form={linkForm}
+            icon={<MailIcon className="size-4" />}
+            label={m.email_me_sign_in_link()}
+            submittingLabel={m.sending()}
+          />
         }
         error={submitError}
         notice={ssoNotice ?? twoFactorNotice}
@@ -323,45 +333,39 @@ export function SignInPage({
           socialProviders
         })}
       >
-        {linkSent ? (
-          <p role="alert" className="text-sm text-muted-foreground">
-            {linkSentMessage()}
-          </p>
-        ) : (
-          <>
-            <linkForm.Field name="email" validators={{ onChange: emailValidator }}>
-              {(field) => (
-                <FormTextField
-                  name={field.name}
-                  label={m.form_email()}
-                  type="email"
-                  placeholder="you@example.com"
-                  autoComplete="email"
-                  value={field.state.value}
-                  errors={field.state.meta.errors}
-                  onBlur={field.handleBlur}
-                  onChange={field.handleChange}
-                  required
-                />
-              )}
-            </linkForm.Field>
-            {turnstileSiteKey === null ? null : (
-              <TurnstileWidget siteKey={turnstileSiteKey} onToken={setTurnstileToken} />
+        <>
+          <linkForm.Field name="email" validators={{ onChange: emailValidator }}>
+            {(field) => (
+              <FormTextField
+                name={field.name}
+                label={m.form_email()}
+                type="email"
+                placeholder="you@example.com"
+                autoComplete="email"
+                value={field.state.value}
+                errors={field.state.meta.errors}
+                onBlur={field.handleBlur}
+                onChange={field.handleChange}
+                required
+              />
             )}
-            <Button
-              type="button"
-              variant="link"
-              onClick={() => {
-                setSubmitError(null)
-                setLinkSent(false)
-                setMode('password')
-              }}
-              className="justify-start p-0 text-sm"
-            >
-              {m.public_auth_sign_in_with_password_instead()}
-            </Button>
-          </>
-        )}
+          </linkForm.Field>
+          {turnstileSiteKey === null ? null : (
+            <TurnstileWidget siteKey={turnstileSiteKey} onToken={setTurnstileToken} />
+          )}
+          <Button
+            type="button"
+            variant="link"
+            onClick={() => {
+              setSubmitError(null)
+              setLinkSent(false)
+              setMode('password')
+            }}
+            className="justify-start p-0 text-sm"
+          >
+            {m.public_auth_sign_in_with_password_instead()}
+          </Button>
+        </>
       </AuthCardForm>
     )
   }

--- a/apps/web/src/components/command-palette-dialog.tsx
+++ b/apps/web/src/components/command-palette-dialog.tsx
@@ -23,15 +23,6 @@ import { m } from '@b2b-saas-starter/i18n/messages'
 // oxlint-disable effect/noNewPromise -- this module is the promise boundary between the palette (react) and the Effect-native content; same exemption as lib/docs.ts
 const knowledgeMeta = Promise.all([getAllDocMeta(), getAllPostMeta()])
 
-/** The palette's context value, flattened for the dialog's two consumers. */
-function usePaletteSession() {
-  const value = use(CommandPaletteContext)
-  return {
-    viewer: value?.viewer ?? null,
-    systemRole: value?.systemRole ?? null
-  }
-}
-
 /**
  * Docs and blog titles/descriptions as one searchable group — the promise is
  * the cached meta index, so opening the palette neither re-reads nor ships
@@ -89,22 +80,24 @@ function KnowledgeEntries({ close }: { readonly close: () => void }) {
  */
 // Loaded via dynamic import() in command-palette-loader.ts.
 // fallow-ignore-next-line unused-export
-export default function CommandPaletteDialog({
-  open,
-  onOpenChange
-}: {
-  readonly open: boolean
-  readonly onOpenChange: (open: boolean) => void
-}) {
+export default function CommandPaletteDialog() {
   const navigate = useNavigate()
   // Target the current workspace when inside one; outside a workspace the
   // command falls back to the workspace list — never a hardcoded workspace.
   const params = useParams({ strict: false })
   const workspaceSlug = params.workspaceSlug
-  const { viewer, systemRole } = usePaletteSession()
+  const palette = use(CommandPaletteContext)
+  if (palette === null) {
+    return null
+  }
+  const {
+    state,
+    actions,
+    meta: { viewer, systemRole }
+  } = palette
 
   function close() {
-    onOpenChange(false)
+    actions.setOpen(false)
   }
 
   const rows: Array<ReactNode> = []
@@ -164,7 +157,7 @@ export default function CommandPaletteDialog({
   }
 
   return (
-    <CommandDialog open={open} onOpenChange={onOpenChange}>
+    <CommandDialog open={state.open} onOpenChange={actions.setOpen}>
       <CommandInput
         placeholder={m.command_search_placeholder()}
         aria-label={m.command_search_label()}

--- a/apps/web/src/components/command-palette.test.tsx
+++ b/apps/web/src/components/command-palette.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { CommandPaletteProvider, SearchButton } from './command-palette'
+import { renderWithRouter } from '@/test/router-harness'
+
+// This test exercises navigation entries, independent of the content catalog.
+vi.mock('@/lib/docs', () => ({ getAllDocMeta: async () => [] }))
+vi.mock('@/lib/blog', () => ({ getAllPostMeta: async () => [] }))
+
+// jsdom has no layout observer; cmdk uses it only to size its list.
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: () => {}
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  Reflect.deleteProperty(Element.prototype, 'scrollIntoView')
+})
+
+describe('command palette permissions', () => {
+  it('offers owner and system-admin destinations on the first open', async () => {
+    await renderWithRouter(
+      <CommandPaletteProvider viewer={{ role: 'owner' }} systemRole="admin">
+        <SearchButton />
+      </CommandPaletteProvider>,
+      {
+        path: '/workspaces/$workspaceSlug',
+        initialEntry: '/workspaces/starter-lab',
+        destinations: ['/admin']
+      }
+    )
+    const [searchButton] = screen.getAllByRole('button', { name: 'Search' })
+    if (!searchButton) {
+      throw new Error('Search button missing')
+    }
+    fireEvent.click(searchButton)
+    expect(
+      await screen.findByRole('option', { name: 'API tokens' }, { timeout: 10_000 })
+    ).toBeTruthy()
+    expect(screen.getByRole('option', { name: 'System admin' })).toBeTruthy()
+  }, 15_000)
+
+  it('limits a member keyboard search to permitted destinations', async () => {
+    await renderWithRouter(
+      <CommandPaletteProvider viewer={{ role: 'member' }} systemRole="user">
+        <SearchButton />
+      </CommandPaletteProvider>,
+      {
+        path: '/workspaces/$workspaceSlug',
+        initialEntry: '/workspaces/starter-lab'
+      }
+    )
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true })
+    expect(await screen.findByRole('option', { name: 'Overview' })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: 'API tokens' })).toBeNull()
+    expect(screen.queryByRole('option', { name: 'System admin' })).toBeNull()
+  })
+})

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -10,13 +10,16 @@ import { useClientValue } from '@/lib/client-only-value'
 import { type Viewer } from '@/lib/permissions'
 import { m } from '@b2b-saas-starter/i18n/messages'
 
-export function CommandPaletteProvider({ children }: { readonly children: ReactNode }) {
+export function CommandPaletteProvider({
+  children,
+  viewer = null,
+  systemRole = null
+}: {
+  readonly children: ReactNode
+  readonly viewer?: Viewer
+  readonly systemRole?: string | null | undefined
+}) {
   const [open, setOpen] = useState(false)
-  // The workspace viewer and system role, set by `WorkspaceShell` while it is
-  // mounted (see the effect there). The dialog reads them to filter its
-  // workspace and admin entries to what the signed-in role can actually open.
-  const [viewer, setViewer] = useState<Viewer | null>(null)
-  const [systemRole, setSystemRole] = useState<string | null>(null)
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -32,12 +35,12 @@ export function CommandPaletteProvider({ children }: { readonly children: ReactN
 
   return (
     <CommandPaletteContext
-      value={{ open, setOpen, viewer, setViewer, systemRole, setSystemRole }}
+      value={{ state: { open }, actions: { setOpen }, meta: { viewer, systemRole } }}
     >
       {children}
       {open ? (
         <Suspense fallback={null}>
-          <CommandPaletteDialog open={open} onOpenChange={setOpen} />
+          <CommandPaletteDialog />
         </Suspense>
       ) : null}
     </CommandPaletteContext>
@@ -77,7 +80,7 @@ export function SearchButton() {
       <Button
         variant="outline"
         size="icon"
-        onClick={() => value?.setOpen(true)}
+        onClick={() => value?.actions.setOpen(true)}
         onMouseEnter={preloadCommandPalette}
         onFocus={preloadCommandPalette}
         aria-label={m.common_search()}
@@ -87,7 +90,7 @@ export function SearchButton() {
       </Button>
       <Button
         variant="outline"
-        onClick={() => value?.setOpen(true)}
+        onClick={() => value?.actions.setOpen(true)}
         onMouseEnter={preloadCommandPalette}
         onFocus={preloadCommandPalette}
         aria-label={m.common_search()}

--- a/apps/web/src/components/data-table-context.ts
+++ b/apps/web/src/components/data-table-context.ts
@@ -1,0 +1,33 @@
+import { createContext, use, type ReactNode } from 'react'
+import { type PaginationState, type SortingState } from '@tanstack/react-table'
+
+export type DataTableContextValue = {
+  readonly state: {
+    readonly sorting: SortingState
+    readonly globalFilter: string
+    readonly pagination: PaginationState
+  }
+  readonly actions: {
+    readonly setGlobalFilter: (value: string) => void
+    readonly previousPage: () => void
+    readonly nextPage: () => void
+  }
+  readonly meta: {
+    readonly filteredCount: number
+    readonly pageCount: number
+    readonly canPreviousPage: boolean
+    readonly canNextPage: boolean
+    readonly content: ReactNode
+  }
+}
+
+export const DataTableContext = createContext<DataTableContextValue | null>(null)
+
+export function useDataTableContext() {
+  const value = use(DataTableContext)
+  if (value === null) {
+    // oxlint-disable-next-line effect/noThrowStatement, effect/noNewError -- provider misuse is a programmer invariant handled by the render error boundary
+    throw new Error('DataTable controls must be rendered inside a DataTable')
+  }
+  return value
+}

--- a/apps/web/src/components/data-table.test.tsx
+++ b/apps/web/src/components/data-table.test.tsx
@@ -1,6 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vite-plus/test'
-import { DataTable, type DataTableColumnDef } from './data-table'
+import {
+  DataTable,
+  DataTableContent,
+  DataTableFilter,
+  DataTablePagination,
+  type DataTableColumnDef
+} from './data-table'
 
 type Row = {
   readonly name: string
@@ -22,18 +28,20 @@ const rows: ReadonlyArray<Row> = [
 
 describe('DataTable', () => {
   it('renders the empty message when there is no data', () => {
-    render(<DataTable columns={columns} data={[]} emptyMessage="No modules yet." />)
+    render(
+      <DataTable columns={columns} data={[]} emptyMessage="No modules yet.">
+        <DataTableContent />
+      </DataTable>
+    )
     screen.getByText('No modules yet.')
   })
 
   it('filters rows through the global filter input', () => {
     render(
-      <DataTable
-        columns={columns}
-        data={rows}
-        filter
-        filterPlaceholder="Filter modules…"
-      />
+      <DataTable columns={columns} data={rows}>
+        <DataTableFilter placeholder="Filter modules…" />
+        <DataTableContent />
+      </DataTable>
     )
     fireEvent.change(screen.getByLabelText('Filter modules…'), {
       target: { value: 'brav' }
@@ -44,7 +52,12 @@ describe('DataTable', () => {
   })
 
   it('paginates rows and disables controls at the boundaries', () => {
-    render(<DataTable columns={columns} data={rows} pageSize={2} />)
+    render(
+      <DataTable columns={columns} data={rows} pageSize={2}>
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
+    )
     screen.getByText(/Page 1 of 3/)
     screen.getByText('Alpha')
     expect(screen.queryByText('Charlie')).toBeNull()
@@ -65,13 +78,22 @@ describe('DataTable', () => {
   })
 
   it('keeps pagination controls rendered but disabled when everything fits on one page', () => {
-    render(<DataTable columns={columns} data={rows} pageSize={10} />)
+    render(
+      <DataTable columns={columns} data={rows} pageSize={10}>
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
+    )
     const next = screen.getByRole<HTMLButtonElement>('button', { name: 'Next' })
     expect(next.disabled).toBe(true)
   })
 
   it('sorts rows when a sortable header is toggled', () => {
-    render(<DataTable columns={columns} data={rows} />)
+    render(
+      <DataTable columns={columns} data={rows}>
+        <DataTableContent />
+      </DataTable>
+    )
     const sortButton = screen.getByRole('button', { name: /Sort by Name/ })
 
     fireEvent.click(sortButton)
@@ -81,5 +103,51 @@ describe('DataTable', () => {
     fireEvent.click(sortButton)
     bodyRows = screen.getAllByRole('row').slice(1)
     expect(bodyRows[0]?.textContent).toContain('Echo')
+  })
+
+  it('shares filter and pagination state and resets the page for filtered results', () => {
+    render(
+      <DataTable columns={columns} data={rows} pageSize={2}>
+        <header>
+          <DataTableFilter placeholder="Filter modules…" />
+        </header>
+        <DataTableContent />
+        <footer>
+          <DataTablePagination />
+        </footer>
+      </DataTable>
+    )
+
+    fireEvent.click(screen.getByRole<HTMLButtonElement>('button', { name: 'Next' }))
+    screen.getByText(/Page 2 of 3/)
+    fireEvent.change(screen.getByLabelText('Filter modules…'), {
+      target: { value: 'echo' }
+    })
+    screen.getByText('Echo')
+    expect(screen.queryByText(/Page 2 of/)).toBeNull()
+  })
+
+  it('renders every loaded row without client pagination, including after a refresh', () => {
+    const { rerender } = render(
+      <DataTable columns={columns} data={rows}>
+        <DataTableContent />
+      </DataTable>
+    )
+    const refreshedRows = [
+      ...rows,
+      { name: 'Foxtrot', category: 'catalog' },
+      { name: 'Golf', category: 'catalog' },
+      { name: 'Hotel', category: 'catalog' },
+      { name: 'India', category: 'catalog' },
+      { name: 'Juliet', category: 'catalog' },
+      { name: 'Kilo', category: 'catalog' }
+    ]
+    rerender(
+      <DataTable columns={columns} data={refreshedRows}>
+        <DataTableContent />
+      </DataTable>
+    )
+    expect(screen.getAllByRole('row')).toHaveLength(12)
+    screen.getByText('Kilo')
   })
 })

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -19,6 +19,7 @@ import {
   useTable,
   type CellData,
   type ColumnDef,
+  type ReactTable,
   type RowData,
   type SortingState
 } from '@tanstack/react-table'
@@ -34,10 +35,10 @@ import {
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 import { formatDateTime } from '@/lib/format-date'
+import { DataTableContext, useDataTableContext } from './data-table-context'
 
 const STICKY_CLASSES = 'sticky left-0 z-10 bg-card group-hover:bg-muted/50'
 
-/** Keep identifiers and request-local timestamps in mono tabular figures. */
 function isDate(cell: ReactNode | Date): cell is Date {
   return Object.prototype.toString.call(cell) === '[object Date]'
 }
@@ -46,8 +47,6 @@ function formatDateCell(value: Date) {
   return <span className="font-mono tabular-nums">{formatDateTime(value)}</span>
 }
 
-// v9 registers features explicitly (prerequisites before their slots). The
-// registered `sortFns` are the ones `sortFn: 'auto'` can resolve for a column.
 const dataTableFeatures = tableFeatures({
   columnFilteringFeature,
   filteredRowModel: createFilteredRowModel(),
@@ -61,14 +60,10 @@ const dataTableFeatures = tableFeatures({
   },
   rowPaginationFeature,
   paginatedRowModel: createPaginatedRowModel(),
-  // `row.getVisibleCells()` lives on this feature.
   columnVisibilityFeature
 })
 
-/** The feature set every `DataTable` column definition is typed against. */
 export type DataTableFeatures = typeof dataTableFeatures
-
-/** `ColumnDef` bound to `DataTable`'s feature set — use it in consumers. */
 export type DataTableColumnDef<TData extends RowData> = ColumnDef<
   DataTableFeatures,
   TData,
@@ -76,9 +71,7 @@ export type DataTableColumnDef<TData extends RowData> = ColumnDef<
 >
 
 type SortState = {
-  /** Appended to the sort button's accessible name. */
   readonly label: (input: { column: string }) => string
-  /** The `aria-sort` value for the header cell. */
   readonly aria: 'ascending' | 'descending' | 'none'
   readonly glyph: string | null
 }
@@ -89,8 +82,7 @@ const SORT_STATE = {
   false: { label: m.shell_table_sort, aria: 'none', glyph: null }
 } satisfies Record<'asc' | 'desc' | 'false', SortState>
 
-/** A column's header titles its sort button only when it is a plain string. */
-// oxlint-disable anti-slop/no-unknown-parameters, anti-slop/no-runtime-typeof -- column definitions arrive untyped from the table's public API; this probe is the parse step
+// oxlint-disable anti-slop/no-unknown-parameters, anti-slop/no-runtime-typeof
 function headerTitleOf(header: unknown, fallback: string): string {
   return typeof header === 'string' ? header : fallback
 }
@@ -99,34 +91,161 @@ function headerTitleOf(header: unknown, fallback: string): string {
 type DataTableProps<TData extends RowData> = {
   readonly columns: ReadonlyArray<DataTableColumnDef<TData>>
   readonly data: ReadonlyArray<TData>
-  /** Renders the global filter input above the table. */
-  readonly filter?: boolean
-  readonly filterPlaceholder?: string
   readonly pageSize?: number
   readonly emptyMessage?: string
-  /** Accessible name for the underlying `<table>` element. */
   readonly tableLabel?: string
-  /** Whether to render the count footer with the Previous/Next pager (default true). */
-  readonly pager?: boolean
+  readonly children: ReactNode
+}
+
+function DataTableTable<TData extends RowData>({
+  columns,
+  emptyMessage,
+  tableLabel,
+  table
+}: {
+  readonly columns: ReadonlyArray<DataTableColumnDef<TData>>
+  readonly emptyMessage: string
+  readonly tableLabel: string | undefined
+  readonly table: ReactTable<DataTableFeatures, TData>
+}) {
+  const rowModel = table.getRowModel()
+  return (
+    <Table aria-label={tableLabel}>
+      <TableHeader>
+        {table.getHeaderGroups().map((group) => (
+          <TableRow key={group.id}>
+            {group.headers.map((header) => {
+              const canSort = header.column.getCanSort()
+              const sortDir = header.column.getIsSorted()
+              const columnTitle = headerTitleOf(
+                header.column.columnDef.header,
+                header.column.id
+              )
+              const sortState = SORT_STATE[sortDir === false ? 'false' : sortDir]
+              const isSticky = header.column.columnDef.meta?.sticky === true
+              const label = flexRender(
+                header.column.columnDef.header,
+                header.getContext()
+              )
+              return (
+                <TableHead
+                  key={header.id}
+                  aria-sort={canSort ? sortState.aria : undefined}
+                  className={cn(isSticky && STICKY_CLASSES)}
+                >
+                  {canSort && label !== null ? (
+                    <Button
+                      variant="ghost"
+                      onClick={header.column.getToggleSortingHandler()}
+                      aria-label={sortState.label({ column: columnTitle })}
+                    >
+                      {label}
+                      {sortState.glyph}
+                    </Button>
+                  ) : (
+                    label
+                  )}
+                </TableHead>
+              )
+            })}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {rowModel.rows.length === 0 ? (
+          <TableRow>
+            <TableCell
+              colSpan={columns.length}
+              className="text-center text-sm text-muted-foreground"
+            >
+              {emptyMessage}
+            </TableCell>
+          </TableRow>
+        ) : (
+          rowModel.rows.map((row) => (
+            <TableRow key={row.id} className="group">
+              {row.getVisibleCells().map((cell) => {
+                const isSticky = cell.column.columnDef.meta?.sticky === true
+                const rendered = flexRender(
+                  cell.column.columnDef.cell,
+                  cell.getContext()
+                )
+                return (
+                  <TableCell key={cell.id} className={cn(isSticky && STICKY_CLASSES)}>
+                    {isDate(rendered) ? formatDateCell(rendered) : rendered}
+                  </TableCell>
+                )
+              })}
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+    </Table>
+  )
+}
+
+export function DataTableFilter({ placeholder }: { readonly placeholder?: string }) {
+  const { state, actions } = useDataTableContext()
+  const label = placeholder ?? m.shell_table_filter()
+  return (
+    <Input
+      value={state.globalFilter}
+      onChange={(event) => actions.setGlobalFilter(event.target.value)}
+      placeholder={label}
+      className="max-w-xs"
+      aria-label={placeholder ?? m.shell_table_filter_rows()}
+    />
+  )
+}
+
+export function DataTablePagination() {
+  const { state, actions, meta } = useDataTableContext()
+  return (
+    <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+      <span aria-live="polite">
+        {m.shell_table_page({
+          count: meta.filteredCount,
+          rows: formatNumber(meta.filteredCount, getLocale()),
+          page: formatNumber(state.pagination.pageIndex + 1, getLocale()),
+          pages: formatNumber(meta.pageCount, getLocale())
+        })}
+      </span>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={actions.previousPage}
+          disabled={!meta.canPreviousPage}
+        >
+          {m.shell_table_previous()}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={actions.nextPage}
+          disabled={!meta.canNextPage}
+        >
+          {m.shell_table_next()}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function DataTableContent() {
+  return useDataTableContext().meta.content
 }
 
 export function DataTable<TData extends RowData>({
   columns,
   data,
-  filter = false,
-  filterPlaceholder,
-  pageSize = 10,
+  pageSize,
   emptyMessage = m.shell_table_empty(),
   tableLabel,
-  pager = true
+  children
 }: DataTableProps<TData>) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
-
-  // `useTable` keys its internal state on input identities. Consumers pass
-  // module-scope constants or stable loader arrays, so the props are handed
-  // straight through — copying (`[...data]`) would re-allocate (and
-  // re-notify) every render.
   const table = useTable({
     features: dataTableFeatures,
     data,
@@ -134,128 +253,41 @@ export function DataTable<TData extends RowData>({
     state: { sorting, globalFilter },
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
-    initialState: { pagination: { pageIndex: 0, pageSize } }
+    manualPagination: pageSize === undefined,
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: pageSize ?? 10 }
+    }
   })
-
   const filteredCount = table.getFilteredRowModel().rows.length
-
   return (
-    <div className="grid gap-3">
-      {filter ? (
-        <Input
-          value={globalFilter}
-          onChange={(event) => setGlobalFilter(event.target.value)}
-          placeholder={filterPlaceholder ?? m.shell_table_filter()}
-          className="max-w-xs"
-          aria-label={filterPlaceholder ?? m.shell_table_filter_rows()}
-        />
-      ) : null}
-      <Table aria-label={tableLabel}>
-        <TableHeader>
-          {table.getHeaderGroups().map((group) => (
-            <TableRow key={group.id}>
-              {group.headers.map((header) => {
-                const canSort = header.column.getCanSort()
-                const sortDir = header.column.getIsSorted()
-                // A column's header is either a plain title or a render
-                // function; only the first can label the sort button, so fall
-                // back to the column id for the latter.
-                const columnTitle = headerTitleOf(
-                  header.column.columnDef.header,
-                  header.column.id
-                )
-                const sortState = SORT_STATE[sortDir === false ? 'false' : sortDir]
-                const isSticky = header.column.columnDef.meta?.sticky === true
-                const label = flexRender(
-                  header.column.columnDef.header,
-                  header.getContext()
-                )
-                return (
-                  <TableHead
-                    key={header.id}
-                    aria-sort={canSort ? sortState.aria : undefined}
-                    className={cn(isSticky && STICKY_CLASSES)}
-                  >
-                    {canSort && label !== null ? (
-                      <Button
-                        variant="ghost"
-                        onClick={header.column.getToggleSortingHandler()}
-                        aria-label={sortState.label({ column: columnTitle })}
-                      >
-                        {label}
-                        {sortState.glyph}
-                      </Button>
-                    ) : (
-                      label
-                    )}
-                  </TableHead>
-                )
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows.length === 0 ? (
-            <TableRow>
-              <TableCell
-                colSpan={columns.length}
-                className="text-center text-sm text-muted-foreground"
-              >
-                {emptyMessage}
-              </TableCell>
-            </TableRow>
-          ) : (
-            table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id} className="group">
-                {row.getVisibleCells().map((cell) => {
-                  const isSticky = cell.column.columnDef.meta?.sticky === true
-                  const rendered = flexRender(
-                    cell.column.columnDef.cell,
-                    cell.getContext()
-                  )
-                  return (
-                    <TableCell key={cell.id} className={cn(isSticky && STICKY_CLASSES)}>
-                      {isDate(rendered) ? formatDateCell(rendered) : rendered}
-                    </TableCell>
-                  )
-                })}
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-      {pager ? (
-        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
-          {/* Live: filter/pagination changes announce the new count, as the
-              audit trail's count already does. */}
-          <span aria-live="polite">
-            {m.shell_table_page({
-              count: filteredCount,
-              rows: formatNumber(filteredCount, getLocale()),
-              page: formatNumber(table.state.pagination.pageIndex + 1, getLocale()),
-              pages: formatNumber(table.getPageCount(), getLocale())
-            })}
-          </span>
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {m.shell_table_previous()}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {m.shell_table_next()}
-            </Button>
-          </div>
-        </div>
-      ) : null}
-    </div>
+    <DataTableContext
+      value={{
+        state: { sorting, globalFilter, pagination: table.state.pagination },
+        actions: {
+          setGlobalFilter: (filterValue: string) => {
+            setGlobalFilter(filterValue)
+            table.setPageIndex(0)
+          },
+          previousPage: () => table.previousPage(),
+          nextPage: () => table.nextPage()
+        },
+        meta: {
+          filteredCount,
+          pageCount: table.getPageCount(),
+          canPreviousPage: table.getCanPreviousPage(),
+          canNextPage: table.getCanNextPage(),
+          content: (
+            <DataTableTable
+              columns={columns}
+              emptyMessage={emptyMessage}
+              tableLabel={tableLabel}
+              table={table}
+            />
+          )
+        }
+      }}
+    >
+      <div className="grid gap-3">{children}</div>
+    </DataTableContext>
   )
 }

--- a/apps/web/src/components/email-delivery-panel.tsx
+++ b/apps/web/src/components/email-delivery-panel.tsx
@@ -1,6 +1,11 @@
 import { type EmailDeliveryRow } from '@/lib/server/email-delivery'
 import { m } from '@b2b-saas-starter/i18n/messages'
-import { DataTable, type DataTableColumnDef } from './data-table'
+import {
+  DataTable,
+  DataTableContent,
+  DataTablePagination,
+  type DataTableColumnDef
+} from './data-table'
 import { Panel } from './page/panel'
 import { formatDateTime } from '@/lib/format-date'
 
@@ -160,7 +165,10 @@ export function EmailDeliveryPanel({
         pageSize={10}
         tableLabel={m.email_delivery_title()}
         emptyMessage={m.email_delivery_empty()}
-      />
+      >
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
       <p className="text-sm text-muted-foreground">{m.email_delivery_warning()}</p>
     </Panel>
   )

--- a/apps/web/src/components/email-verification-banner.tsx
+++ b/apps/web/src/components/email-verification-banner.tsx
@@ -53,8 +53,7 @@ export function EmailVerificationBanner({
     // `role="status"`: the banner renders on every page load for an
     // unverified user — `role="alert"` would interrupt on load.
     // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- see above
-    <Alert role="status">
-      <MailWarningIcon />
+    <Alert role="status" icon={<MailWarningIcon />}>
       <AlertDescription className="flex flex-wrap items-center gap-3">
         <span className="flex-1">
           {m.workspace_email_unverified()}

--- a/apps/web/src/components/impersonation-banner.tsx
+++ b/apps/web/src/components/impersonation-banner.tsx
@@ -40,9 +40,13 @@ export function ImpersonationBanner({
     // `role="status"`, not `alert`: the banner is on the page from first paint
     // for the whole session — an assertive live region would interrupt on
     // every load.
-    // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- see above
-    <Alert role="status" variant="destructive" className="rounded-none border-x-0">
-      <UserRoundSearchIcon />
+    <Alert
+      // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- the persistent banner must not interrupt on each page load
+      role="status"
+      variant="destructive"
+      className="rounded-none border-x-0"
+      icon={<UserRoundSearchIcon />}
+    >
       <AlertDescription className="flex flex-wrap items-center gap-3">
         <span className="flex-1 text-foreground">
           {m.impersonating_notice({

--- a/apps/web/src/components/onboarding-checklist.test.tsx
+++ b/apps/web/src/components/onboarding-checklist.test.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react'
 import { type WorkspaceProgressProjection } from '@b2b-saas-starter/capabilities/workspace-projections'
 import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vite-plus/test'
@@ -23,7 +24,7 @@ async function renderChecklist(
   viewer: { readonly role: 'owner' | 'member' },
   dismiss: DismissOnboardingChecklist,
   data: WorkspaceProgressProjection = progress,
-  dismissalNote?: boolean
+  dismissalHint?: ReactNode
 ) {
   return renderWithRouter(
     <OnboardingChecklist
@@ -31,7 +32,7 @@ async function renderChecklist(
       progress={data}
       viewer={viewer}
       dismiss={dismiss}
-      {...(dismissalNote === undefined ? {} : { dismissalNote })}
+      {...(dismissalHint === undefined ? {} : { dismissalHint })}
     />,
     {
       path: '/workspaces/starter-lab',
@@ -81,7 +82,7 @@ describe('OnboardingChecklist', () => {
       { role: 'member' },
       vi.fn(async () => true),
       progress,
-      false
+      null
     )
     expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
     expect(

--- a/apps/web/src/components/onboarding-checklist.tsx
+++ b/apps/web/src/components/onboarding-checklist.tsx
@@ -4,7 +4,7 @@ import {
 } from '@b2b-saas-starter/capabilities/workspace-projections'
 import { Link } from '@tanstack/react-router'
 import { CircleCheckIcon, CircleIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { useServerAction } from '@/hooks/use-server-action'
@@ -105,17 +105,17 @@ export function OnboardingChecklist({
   progress,
   viewer,
   dismiss = dismissOnboardingChecklistServerFn,
-  dismissalNote = true
+  dismissalHint = m.onboarding_dismiss_owner_note()
 }: {
   readonly workspaceSlug: string
   readonly progress: WorkspaceProgressProjection
   readonly viewer: Viewer
   readonly dismiss?: DismissOnboardingChecklist
   /**
-   * Off on the read-only demo, where the note would name a dismiss control
-   * the page does not carry.
+   * Optional explanation for viewers without dismissal permission.
+   * The read-only demo supplies null because it has no dismiss control.
    */
-  readonly dismissalNote?: boolean | undefined
+  readonly dismissalHint?: ReactNode
 }) {
   const [justDismissed, setJustDismissed] = useState(false)
   const canDismiss = viewerCan(viewer, { onboarding: ['dismiss'] })
@@ -193,10 +193,8 @@ export function OnboardingChecklist({
           )
         })}
       </ul>
-      {canDismiss || !dismissalNote ? null : (
-        <p className="text-xs text-muted-foreground">
-          {m.onboarding_dismiss_owner_note()}
-        </p>
+      {canDismiss || !dismissalHint ? null : (
+        <p className="text-xs text-muted-foreground">{dismissalHint}</p>
       )}
       <ActionFeedback error={dismissal.error} />
     </Panel>

--- a/apps/web/src/components/public-layout.tsx
+++ b/apps/web/src/components/public-layout.tsx
@@ -6,7 +6,7 @@ import { BoxesIcon, MenuIcon } from 'lucide-react'
 // here instead of in __root.tsx: auth screens and the workspace app never
 // enter this layout and never pay for the font.
 import newsreaderLatinWoff2 from '@fontsource-variable/newsreader/files/newsreader-latin-opsz-normal.woff2?url'
-import { SearchButton } from '@/components/command-palette'
+import { SearchButton, CommandPaletteProvider } from '@/components/command-palette'
 import { GITHUB_URL } from '@/components/landing/github-url'
 import { Button } from '@/components/ui/button'
 import {
@@ -24,135 +24,137 @@ import { LanguageSwitcher } from '@/components/language-switcher'
 export function PublicLayout({ children }: { readonly children: ReactNode }) {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   return (
-    <div className="marketing flex min-h-dvh flex-col bg-background">
-      {/* Rendered in the tree, hoisted to <head> by React 19 — see the import
+    <CommandPaletteProvider>
+      <div className="marketing flex min-h-dvh flex-col bg-background">
+        {/* Rendered in the tree, hoisted to <head> by React 19 — see the import
           comment above. Deduped by href if the root ever preloads it again. */}
-      <link
-        rel="preload"
-        href={newsreaderLatinWoff2}
-        as="font"
-        type="font/woff2"
-        crossOrigin="anonymous"
-      />
-      <a
-        // oxlint-disable-next-line react-doctor/anchor-target-exists -- the target is owned by this layout's children: every public route renders its own <main id="main-content"> (routes/index.tsx, sign-in.tsx, pricing.tsx, …). The rule scans only the file declaring the link.
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-primary px-3 py-2 text-sm focus:text-primary-foreground"
-      >
-        {m.common_skip_to_content()}
-      </a>
-      <header className="sticky top-0 z-40 border-b border-border bg-background">
-        {/* `gap-3` on the narrow bar: the wordmark is nowrap (P3), so the
+        <link
+          rel="preload"
+          href={newsreaderLatinWoff2}
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+        <a
+          // oxlint-disable-next-line react-doctor/anchor-target-exists -- the target is owned by this layout's children: every public route renders its own <main id="main-content"> (routes/index.tsx, sign-in.tsx, pricing.tsx, …). The rule scans only the file declaring the link.
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-primary px-3 py-2 text-sm focus:text-primary-foreground"
+        >
+          {m.common_skip_to_content()}
+        </a>
+        <header className="sticky top-0 z-40 border-b border-border bg-background">
+          {/* `gap-3` on the narrow bar: the wordmark is nowrap (P3), so the
             16px gaps pushed Sign in 8px past a 390px viewport. */}
-        <div className="mx-auto flex h-16 max-w-7xl items-center gap-3 px-4 sm:px-6 md:gap-4">
-          <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
-            <SheetTrigger
-              render={
-                <Button variant="ghost" size="icon" className="lg:hidden">
-                  <MenuIcon className="size-5" />
-                  <span className="sr-only">{m.common_open_menu()}</span>
-                </Button>
-              }
-            />
-            <SheetContent side="left" className="flex flex-col gap-0">
-              <SheetHeader>
-                <SheetTitle>{m.common_menu()}</SheetTitle>
-                <SheetDescription className="sr-only">
-                  {m.common_site_navigation()}
-                </SheetDescription>
-              </SheetHeader>
-              <nav
-                aria-label={m.common_site_navigation()}
-                className="flex flex-col gap-1 px-4 pb-4"
-              >
-                {publicLinks().map((link) => (
-                  <Link
-                    key={link.to}
-                    to={link.to}
-                    reloadDocument={link.to === '/help'}
-                    onClick={() => setMobileNavOpen(false)}
-                    className="rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                  >
-                    {link.label}
-                  </Link>
-                ))}
-                <LanguageSwitcher />
-                <Button
-                  nativeButton={false}
-                  render={<Link to="/sign-in" />}
-                  onClick={() => setMobileNavOpen(false)}
-                  className="mt-2 max-md:w-full"
+          <div className="mx-auto flex h-16 max-w-7xl items-center gap-3 px-4 sm:px-6 md:gap-4">
+            <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+              <SheetTrigger
+                render={
+                  <Button variant="ghost" size="icon" className="lg:hidden">
+                    <MenuIcon className="size-5" />
+                    <span className="sr-only">{m.common_open_menu()}</span>
+                  </Button>
+                }
+              />
+              <SheetContent side="left" className="flex flex-col gap-0">
+                <SheetHeader>
+                  <SheetTitle>{m.common_menu()}</SheetTitle>
+                  <SheetDescription className="sr-only">
+                    {m.common_site_navigation()}
+                  </SheetDescription>
+                </SheetHeader>
+                <nav
+                  aria-label={m.common_site_navigation()}
+                  className="flex flex-col gap-1 px-4 pb-4"
                 >
-                  {m.form_sign_in()}
-                </Button>
-              </nav>
-            </SheetContent>
-          </Sheet>
-          <Link
-            to="/"
-            className="flex items-center gap-2 font-semibold whitespace-nowrap"
-          >
-            <span className="grid size-8 place-items-center rounded-md bg-primary text-primary-foreground">
-              <BoxesIcon className="size-4" />
-            </span>
-            B2B SaaS Starter
-          </Link>
-          <nav
-            aria-label={m.common_site_navigation()}
-            className="ml-auto hidden items-center gap-1 lg:flex"
-          >
-            {publicLinks().map((link) => (
-              <Link
-                key={link.to}
-                to={link.to}
-                reloadDocument={link.to === '/help'}
-                className="rounded-md px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                {link.label}
-              </Link>
-            ))}
-          </nav>
-          <SearchButton />
-          <div className="hidden lg:block">
-            <LanguageSwitcher />
+                  {publicLinks().map((link) => (
+                    <Link
+                      key={link.to}
+                      to={link.to}
+                      reloadDocument={link.to === '/help'}
+                      onClick={() => setMobileNavOpen(false)}
+                      className="rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    >
+                      {link.label}
+                    </Link>
+                  ))}
+                  <LanguageSwitcher />
+                  <Button
+                    nativeButton={false}
+                    render={<Link to="/sign-in" />}
+                    onClick={() => setMobileNavOpen(false)}
+                    className="mt-2 max-md:w-full"
+                  >
+                    {m.form_sign_in()}
+                  </Button>
+                </nav>
+              </SheetContent>
+            </Sheet>
+            <Link
+              to="/"
+              className="flex items-center gap-2 font-semibold whitespace-nowrap"
+            >
+              <span className="grid size-8 place-items-center rounded-md bg-primary text-primary-foreground">
+                <BoxesIcon className="size-4" />
+              </span>
+              B2B SaaS Starter
+            </Link>
+            <nav
+              aria-label={m.common_site_navigation()}
+              className="ml-auto hidden items-center gap-1 lg:flex"
+            >
+              {publicLinks().map((link) => (
+                <Link
+                  key={link.to}
+                  to={link.to}
+                  reloadDocument={link.to === '/help'}
+                  className="rounded-md px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </nav>
+            <SearchButton />
+            <div className="hidden lg:block">
+              <LanguageSwitcher />
+            </div>
+            <Button nativeButton={false} render={<Link to="/sign-in" />}>
+              {m.form_sign_in()}
+            </Button>
           </div>
-          <Button nativeButton={false} render={<Link to="/sign-in" />}>
-            {m.form_sign_in()}
-          </Button>
-        </div>
-      </header>
-      {children}
-      <footer className="mt-auto border-t border-border">
-        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-8 text-sm text-muted-foreground sm:px-6 md:flex-row md:items-center md:justify-between">
-          <span>{m.site_footer_tagline()}</span>
-          <div className="flex flex-wrap gap-4">
-            <Link
-              to="/privacy"
-              className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
-            >
-              {m.privacy()}
-            </Link>
-            <Link
-              to="/terms"
-              className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
-            >
-              {m.terms()}
-            </Link>
-            {/* /changelog redirects to the repository's releases, so link
+        </header>
+        {children}
+        <footer className="mt-auto border-t border-border">
+          <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-8 text-sm text-muted-foreground sm:px-6 md:flex-row md:items-center md:justify-between">
+            <span>{m.site_footer_tagline()}</span>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                to="/privacy"
+                className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
+              >
+                {m.privacy()}
+              </Link>
+              <Link
+                to="/terms"
+                className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
+              >
+                {m.terms()}
+              </Link>
+              {/* /changelog redirects to the repository's releases, so link
                 there directly — the footer should not bounce through a
                 redirect to leave the site. */}
-            <a
-              href={`${GITHUB_URL}/releases`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
-            >
-              {m.changelog()}
-              <span className="sr-only">{m.common_opens_new_tab()}</span>
-            </a>
+              <a
+                href={`${GITHUB_URL}/releases`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="py-2.5 underline-offset-4 hover:text-foreground hover:underline"
+              >
+                {m.changelog()}
+                <span className="sr-only">{m.common_opens_new_tab()}</span>
+              </a>
+            </div>
           </div>
-        </div>
-      </footer>
-    </div>
+        </footer>
+      </div>
+    </CommandPaletteProvider>
   )
 }

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -28,31 +28,16 @@ const alertVariants = cva(
   }
 )
 
-/**
- * A direct child that is an element without a `data-slot` prop is an icon —
- * every named child here (title, description, action) carries its slot, and
- * the cva grid reserves the first column for a direct-child `<svg>`.
- */
-function hasIconChild(children: React.ReactNode): boolean {
-  // A direct child that is not one of the named slots is the icon: every
-  // named child (title/description/action) is a known component here, so
-  // the cva grid's `has-[>svg]` column gets exactly one candidate.
-  return React.Children.toArray(children).some(
-    (child) =>
-      React.isValidElement(child) &&
-      child.type !== AlertTitle &&
-      child.type !== AlertDescription &&
-      child.type !== AlertAction
-  )
-}
-
 function Alert({
   className,
   variant,
   children,
+  icon = variant === 'destructive' ? <CircleAlertIcon aria-hidden="true" /> : null,
   ...props
-}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
-  const showDefaultIcon = variant === 'destructive' && !hasIconChild(children)
+}: React.ComponentProps<'div'> &
+  VariantProps<typeof alertVariants> & {
+    readonly icon?: React.ReactNode
+  }) {
   return (
     <div
       data-slot="alert"
@@ -60,7 +45,7 @@ function Alert({
       className={cn(alertVariants({ variant }), className)}
       {...props}
     >
-      {showDefaultIcon ? <CircleAlertIcon aria-hidden="true" /> : null}
+      {icon}
       {children}
     </div>
   )

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -37,11 +37,9 @@ function SheetContent({
   className,
   children,
   side = 'right',
-  showCloseButton = true,
   ...props
 }: SheetPrimitive.Popup.Props & {
   side?: 'top' | 'right' | 'bottom' | 'left'
-  showCloseButton?: boolean
 }) {
   return (
     <SheetPortal>
@@ -58,17 +56,15 @@ function SheetContent({
         {...props}
       >
         {children}
-        {showCloseButton && (
-          <SheetPrimitive.Close
-            data-slot="sheet-close"
-            render={
-              <Button variant="ghost" className="absolute top-3 right-3" size="icon" />
-            }
-          >
-            <XIcon />
-            <span className="sr-only">{m.common_close()}</span>
-          </SheetPrimitive.Close>
-        )}
+        <SheetPrimitive.Close
+          data-slot="sheet-close"
+          render={
+            <Button variant="ghost" className="absolute top-3 right-3" size="icon" />
+          }
+        >
+          <XIcon />
+          <span className="sr-only">{m.common_close()}</span>
+        </SheetPrimitive.Close>
       </SheetPrimitive.Popup>
     </SheetPortal>
   )

--- a/apps/web/src/components/workspace-audit-page.tsx
+++ b/apps/web/src/components/workspace-audit-page.tsx
@@ -22,7 +22,11 @@ import { PageHeader } from '@/components/page/page-header'
 import { Panel } from '@/components/page/panel'
 import { WorkspaceCrumb } from '@/components/page/workspace-crumb'
 import { Badge } from '@/components/ui/badge'
-import { DataTable, type DataTableColumnDef } from '@/components/data-table'
+import {
+  DataTable,
+  DataTableContent,
+  type DataTableColumnDef
+} from '@/components/data-table'
 import { WorkspaceShell } from '@/components/workspace-shell'
 import { auditActorTypeLabel, auditEventFilterOptions } from '@/lib/audit-labels'
 import { auditActorTypeVariant } from '@/lib/badge-variants'
@@ -271,18 +275,15 @@ export function WorkspaceAuditPage({
         ) : (
           <>
             {/* One row model for both tables: the same component renders the
-                admin users table, so column treatment, the mono `When` cell,
-                and the count footer cannot drift between them. `pager={false}`
-                drops `DataTable`'s own Previous/Next footer — this table pages
-                through the keyset button below, so a second, always-disabled
-                "Page 1 of 1" model would read as broken. */}
+                admin users table, so column treatment and the mono `When` cell
+                cannot drift between them. */}
             <DataTable
               columns={auditColumns()}
               data={events}
-              pageSize={100}
               tableLabel={m.audit_table_label()}
-              pager={false}
-            />
+            >
+              <DataTableContent />
+            </DataTable>
             <div className="flex items-center justify-end">
               {/* Keyset pagination has exactly one direction: older. The
                 button carries the opaque cursor back through the URL. */}

--- a/apps/web/src/components/workspace-billing.tsx
+++ b/apps/web/src/components/workspace-billing.tsx
@@ -3,7 +3,7 @@ import {
   type BillingSynchronizationStatus
 } from '@b2b-saas-starter/capabilities/billing/billing'
 import { Check, Minus, ExternalLink } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -90,12 +90,7 @@ export function PublicBillingPlans({
           <PlanTile
             key={plan.id}
             plan={plan}
-            currentPlanId={null}
-            canManageBilling={false}
-            stripeConfigured={stripeConfigured}
-            pendingPlan={null}
-            onUpgrade={() => undefined}
-            showExamplePrice={!stripeConfigured}
+            priceNote={stripeConfigured ? null : m.billing_example_price()}
           />
         ))}
       </div>
@@ -271,13 +266,22 @@ export function BillingPlans({
             <PlanTile
               key={plan.id}
               plan={plan}
-              currentPlanId={currentPlanId}
-              canManageBilling={canManageBilling}
-              stripeConfigured={stripeConfigured}
-              pendingPlan={upgrade.pendingInput ?? null}
-              onUpgrade={() => upgrade.run(plan.id)}
-              showExamplePrice={!stripeConfigured}
-            />
+              badge={
+                plan.id === currentPlanId ? (
+                  <Badge variant="neutral">{m.common_current()}</Badge>
+                ) : null
+              }
+              priceNote={stripeConfigured ? null : m.billing_example_price()}
+            >
+              <PlanAction
+                plan={plan}
+                currentPlanId={currentPlanId}
+                canManageBilling={canManageBilling}
+                stripeConfigured={stripeConfigured}
+                pendingPlan={upgrade.pendingInput ?? null}
+                onUpgrade={() => upgrade.run(plan.id)}
+              />
+            </PlanTile>
           ))}
         </div>
       </Panel>
@@ -291,33 +295,23 @@ export function BillingPlans({
  */
 function PlanTile({
   plan,
-  currentPlanId,
-  canManageBilling,
-  stripeConfigured,
-  pendingPlan,
-  onUpgrade,
-  showExamplePrice = false
+  badge,
+  priceNote,
+  children
 }: {
   readonly plan: BillingPlan
-  readonly currentPlanId: string | null
-  readonly canManageBilling: boolean
-  readonly stripeConfigured: boolean
-  readonly pendingPlan: string | null
-  readonly onUpgrade: () => void
-  readonly showExamplePrice?: boolean
+  readonly badge?: ReactNode
+  readonly priceNote: ReactNode
+  readonly children?: ReactNode
 }) {
   return (
     <div className="grid gap-2 rounded-none border border-border bg-muted p-4 content-start">
       <div className="flex items-center justify-between gap-2">
         <h3 className="font-semibold">{plan.name}</h3>
-        {plan.id === currentPlanId ? (
-          <Badge variant="neutral">{m.common_current()}</Badge>
-        ) : null}
+        {badge}
       </div>
       <p className="text-2xl font-semibold">{planPrice(plan)}</p>
-      {showExamplePrice ? (
-        <p className="text-xs text-muted-foreground">{m.billing_example_price()}</p>
-      ) : null}
+      {priceNote ? <p className="text-xs text-muted-foreground">{priceNote}</p> : null}
       <p className="text-sm text-muted-foreground">{planDescription(plan)}</p>
       <ul className="grid gap-1 text-sm text-muted-foreground">
         <EntitlementRow
@@ -337,14 +331,7 @@ function PlanTile({
           limit={plan.limits.webhookEndpoints}
         />
       </ul>
-      <PlanAction
-        plan={plan}
-        currentPlanId={currentPlanId}
-        canManageBilling={canManageBilling}
-        stripeConfigured={stripeConfigured}
-        pendingPlan={pendingPlan}
-        onUpgrade={onUpgrade}
-      />
+      {children}
     </div>
   )
 }

--- a/apps/web/src/components/workspace-dashboard-page.tsx
+++ b/apps/web/src/components/workspace-dashboard-page.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, type ReactNode } from 'react'
 import { AttentionFeed } from '@/components/attention-feed'
 import {
   LiveNotifications,
@@ -39,16 +39,16 @@ export function WorkspaceDashboardPage({
   data,
   systemRole,
   ports,
-  dismissalNote
+  dismissalHint
 }: {
   readonly data: WorkspaceDashboardPayload
   /** The signed-in user's Better Auth system role, for the shell's admin link. */
   readonly systemRole?: string | null
   /**
-   * False on the read-only demo, where no dismiss control exists for the
+   * Null on the read-only demo, where no dismiss control exists for the
    * checklist's member note to point at.
    */
-  readonly dismissalNote?: boolean | undefined
+  readonly dismissalHint?: ReactNode
   /** The server calls this page's children make, forwarded for tests. */
   readonly ports?: {
     readonly listNotifications?: ListNotifications
@@ -75,7 +75,7 @@ export function WorkspaceDashboardPage({
         workspaceSlug={workspace.slug}
         progress={progress}
         viewer={viewer}
-        dismissalNote={dismissalNote ?? true}
+        dismissalHint={dismissalHint}
         {...(ports?.dismissOnboardingChecklist === undefined
           ? {}
           : { dismiss: ports.dismissOnboardingChecklist })}

--- a/apps/web/src/components/workspace-shell.tsx
+++ b/apps/web/src/components/workspace-shell.tsx
@@ -1,5 +1,5 @@
 import { SupportDetails } from '@/components/support-details'
-import { type ReactNode, useEffect, useState, use } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { Link, useRouter } from '@tanstack/react-router'
 import {
   BellIcon,
@@ -32,10 +32,9 @@ import {
 } from '@/components/ui/sheet'
 import { useServerAction } from '@/hooks/use-server-action'
 import { authClient } from '@/lib/auth-client'
-import { SearchButton } from '@/components/command-palette'
+import { SearchButton, CommandPaletteProvider } from '@/components/command-palette'
 import { ImpersonationBanner } from '@/components/impersonation-banner'
 import { ActionFeedback } from '@/components/page/action-feedback'
-import { CommandPaletteContext } from '@/lib/command-palette-context'
 import { useImpersonation, type StopImpersonating } from '@/lib/impersonation'
 import { viewerCan, type Viewer } from '@/lib/permissions'
 import {
@@ -115,18 +114,6 @@ export function WorkspaceShell({
     },
     { failureMessage: m.auth_sign_out_failed(), invalidate: false }
   )
-  // Publish the viewer and system role to the command palette for as long as
-  // this shell is mounted, so its workspace and admin entries match what the
-  // signed-in role can open (and vanish on public pages, where no shell runs).
-  const palette = use(CommandPaletteContext)
-  useEffect(() => {
-    palette?.setViewer(viewer)
-    palette?.setSystemRole(systemRole ?? null)
-    return () => {
-      palette?.setViewer(null)
-      palette?.setSystemRole(null)
-    }
-  }, [palette, viewer, systemRole])
   const directory = useWorkspaceDirectory()
   // The header names the workspace on every page. The directory carries the
   // display name; the slug is the fallback when the page's payload has none.
@@ -151,124 +138,126 @@ export function WorkspaceShell({
     rememberWorkspace(router, { slug: workspaceSlug, name: workspaceName })
   }, [router, workspaceSlug, workspaceName])
   return (
-    <div className="grid min-h-dvh bg-background lg:grid-cols-[16rem_1fr]">
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-primary px-3 py-2 text-sm focus:text-primary-foreground"
-      >
-        {m.common_skip_to_content()}
-      </a>
-      <aside className="hidden border-r border-sidebar-border bg-sidebar text-sidebar-foreground p-4 lg:block">
-        <WorkspaceNav
-          workspace={sidebarWorkspace}
-          viewer={viewer}
-          systemRole={systemRole}
-        />
-      </aside>
-      <div className="min-w-0">
-        {impersonation === null ? null : (
-          <ImpersonationBanner
-            impersonation={impersonation}
-            {...(stopImpersonating === undefined ? {} : { stopImpersonating })}
+    <CommandPaletteProvider viewer={viewer} systemRole={systemRole}>
+      <div className="grid min-h-dvh bg-background lg:grid-cols-[16rem_1fr]">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-primary px-3 py-2 text-sm focus:text-primary-foreground"
+        >
+          {m.common_skip_to_content()}
+        </a>
+        <aside className="hidden border-r border-sidebar-border bg-sidebar text-sidebar-foreground p-4 lg:block">
+          <WorkspaceNav
+            workspace={sidebarWorkspace}
+            viewer={viewer}
+            systemRole={systemRole}
           />
-        )}
-        <div>
-          <header className="flex min-h-16 items-center gap-4 border-b border-border px-4 sm:px-6">
-            <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
-              <SheetTrigger
-                render={
-                  <Button variant="ghost" size="icon" className="lg:hidden">
-                    <MenuIcon className="size-5" />
-                    <span className="sr-only">{m.common_open_navigation()}</span>
-                  </Button>
-                }
-              />
-              <SheetContent
-                side="left"
-                className="flex flex-col gap-0 bg-sidebar text-sidebar-foreground border-sidebar-border"
-              >
-                <SheetHeader>
-                  <SheetTitle className="sr-only">
-                    {m.common_workspace_navigation()}
-                  </SheetTitle>
-                  <SheetDescription className="sr-only">
-                    {m.switch_workspace_sections()}
-                  </SheetDescription>
-                </SheetHeader>
-                <div className="p-4">
-                  <WorkspaceNav
-                    workspace={sidebarWorkspace}
-                    viewer={viewer}
-                    systemRole={systemRole}
-                    onNavigate={() => setMobileNavOpen(false)}
-                  />
-                </div>
-              </SheetContent>
-            </Sheet>
-            {workspaceSlug === null ? (
-              <div className="min-w-0 flex-1" />
-            ) : (
-              <Link
-                to="/workspaces/$workspaceSlug"
-                params={{ workspaceSlug }}
-                className="min-w-0 flex-1 truncate text-sm font-medium hover:underline underline-offset-2"
-                title={workspaceName ?? workspaceSlug}
-              >
-                {workspaceName}
-              </Link>
-            )}
-            <LanguageSwitcher />
-            <SearchButton />
-            {unreadCount === undefined ? null : (
-              // The badge is the notification feed's one always-visible entry
-              // point: it lands on the user-level notifications route, where
-              // the unread kinds are managed — same count, same label, now
-              // clickable.
-              <Badge
-                variant="neutral"
-                className="gap-1 font-mono tabular-nums"
-                render={
-                  <Link
-                    to="/account/notifications"
-                    aria-label={m.unread_notifications({ count: unreadCount })}
-                  />
-                }
-              >
-                <BellIcon className="size-3" />
-                {unreadCount}
-              </Badge>
-            )}
-            <UserMenu
-              workspaceSlug={workspaceSlug}
-              signingOut={signingOut}
-              systemRole={systemRole}
+        </aside>
+        <div className="min-w-0">
+          {impersonation === null ? null : (
+            <ImpersonationBanner
+              impersonation={impersonation}
+              {...(stopImpersonating === undefined ? {} : { stopImpersonating })}
             />
-          </header>
-          {signingOut.error === null ? null : (
-            <div className="border-b border-border px-4 py-2 sm:px-6">
-              <ActionFeedback error={signingOut.error} />
-            </div>
           )}
-        </div>
-        {/* One content width for every shell page — the page body centers at
-            `max-w-4xl` instead of each page picking its own column. */}
-        <main id="main-content" className="px-4 py-6 sm:px-6">
-          <div className="mx-auto grid w-full max-w-4xl gap-6">
-            {children}
-            <footer className="border-t border-border pt-6">
-              <SupportDetails
-                routeName={workspaceSlug === null ? 'application' : 'workspace'}
-                workspaceId={
-                  workspaceSlug === null
-                    ? undefined
-                    : findWorkspace(directory, workspaceSlug)?.id
-                }
+          <div>
+            <header className="flex min-h-16 items-center gap-4 border-b border-border px-4 sm:px-6">
+              <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+                <SheetTrigger
+                  render={
+                    <Button variant="ghost" size="icon" className="lg:hidden">
+                      <MenuIcon className="size-5" />
+                      <span className="sr-only">{m.common_open_navigation()}</span>
+                    </Button>
+                  }
+                />
+                <SheetContent
+                  side="left"
+                  className="flex flex-col gap-0 bg-sidebar text-sidebar-foreground border-sidebar-border"
+                >
+                  <SheetHeader>
+                    <SheetTitle className="sr-only">
+                      {m.common_workspace_navigation()}
+                    </SheetTitle>
+                    <SheetDescription className="sr-only">
+                      {m.switch_workspace_sections()}
+                    </SheetDescription>
+                  </SheetHeader>
+                  <div className="p-4">
+                    <WorkspaceNav
+                      workspace={sidebarWorkspace}
+                      viewer={viewer}
+                      systemRole={systemRole}
+                      onNavigate={() => setMobileNavOpen(false)}
+                    />
+                  </div>
+                </SheetContent>
+              </Sheet>
+              {workspaceSlug === null ? (
+                <div className="min-w-0 flex-1" />
+              ) : (
+                <Link
+                  to="/workspaces/$workspaceSlug"
+                  params={{ workspaceSlug }}
+                  className="min-w-0 flex-1 truncate text-sm font-medium hover:underline underline-offset-2"
+                  title={workspaceName ?? workspaceSlug}
+                >
+                  {workspaceName}
+                </Link>
+              )}
+              <LanguageSwitcher />
+              <SearchButton />
+              {unreadCount === undefined ? null : (
+                // The badge is the notification feed's one always-visible entry
+                // point: it lands on the user-level notifications route, where
+                // the unread kinds are managed — same count, same label, now
+                // clickable.
+                <Badge
+                  variant="neutral"
+                  className="gap-1 font-mono tabular-nums"
+                  render={
+                    <Link
+                      to="/account/notifications"
+                      aria-label={m.unread_notifications({ count: unreadCount })}
+                    />
+                  }
+                >
+                  <BellIcon className="size-3" />
+                  {unreadCount}
+                </Badge>
+              )}
+              <UserMenu
+                workspaceSlug={workspaceSlug}
+                signingOut={signingOut}
+                systemRole={systemRole}
               />
-            </footer>
+            </header>
+            {signingOut.error === null ? null : (
+              <div className="border-b border-border px-4 py-2 sm:px-6">
+                <ActionFeedback error={signingOut.error} />
+              </div>
+            )}
           </div>
-        </main>
+          {/* One content width for every shell page — the page body centers at
+            `max-w-4xl` instead of each page picking its own column. */}
+          <main id="main-content" className="px-4 py-6 sm:px-6">
+            <div className="mx-auto grid w-full max-w-4xl gap-6">
+              {children}
+              <footer className="border-t border-border pt-6">
+                <SupportDetails
+                  routeName={workspaceSlug === null ? 'application' : 'workspace'}
+                  workspaceId={
+                    workspaceSlug === null
+                      ? undefined
+                      : findWorkspace(directory, workspaceSlug)?.id
+                  }
+                />
+              </footer>
+            </div>
+          </main>
+        </div>
       </div>
-    </div>
+    </CommandPaletteProvider>
   )
 }
 

--- a/apps/web/src/lib/command-palette-context.ts
+++ b/apps/web/src/lib/command-palette-context.ts
@@ -2,19 +2,12 @@ import { createContext } from 'react'
 import { type Viewer } from '@/lib/permissions'
 
 type CommandPaletteContextValue = {
-  readonly open: boolean
-  readonly setOpen: (open: boolean) => void
-  /**
-   * The workspace viewer of the page rendering `WorkspaceShell`, or `null`
-   * outside the shell (public pages). The palette filters its workspace
-   * entries with it, so a member is never offered a section their role
-   * cannot read.
-   */
-  readonly viewer: Viewer | null
-  readonly setViewer: (viewer: Viewer | null) => void
-  /** The signed-in user's Better Auth system role, when known. */
-  readonly systemRole: string | null
-  readonly setSystemRole: (role: string | null) => void
+  readonly state: { readonly open: boolean }
+  readonly actions: { readonly setOpen: (open: boolean) => void }
+  readonly meta: {
+    readonly viewer: Viewer
+    readonly systemRole: string | null
+  }
 }
 
 export const CommandPaletteContext = createContext<CommandPaletteContextValue | null>(

--- a/apps/web/src/lib/workspace-directory.ts
+++ b/apps/web/src/lib/workspace-directory.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import { type WorkspaceListItemProjection } from '@b2b-saas-starter/capabilities/workspace-projections'
 
 /**
@@ -14,7 +14,7 @@ export type WorkspaceDirectory = ReadonlyArray<WorkspaceListItemProjection>
 export const WorkspaceDirectoryContext = createContext<WorkspaceDirectory | null>(null)
 
 export function useWorkspaceDirectory(): WorkspaceDirectory | null {
-  return useContext(WorkspaceDirectoryContext)
+  return use(WorkspaceDirectoryContext)
 }
 
 /**

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -22,7 +22,6 @@ import {
   Outlet,
   Scripts
 } from '@tanstack/react-router'
-import { CommandPaletteProvider } from '@/components/command-palette'
 import { Toaster } from '@/components/ui/sonner'
 import { ClientTelemetry } from '@/lib/client-telemetry'
 import { clientTelemetryConfigServerFn } from '@/lib/server/telemetry-config'
@@ -136,13 +135,11 @@ function RootDocument({ children }: { readonly children: ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        <CommandPaletteProvider>
-          <LocaleBootstrap />
-          {children}
-          {/* No `richColors`: success/warning paint from the same status tokens
+        <LocaleBootstrap />
+        {children}
+        {/* No `richColors`: success/warning paint from the same status tokens
               as badges and alerts (see ui/sonner.tsx), not Sonner's own hex. */}
-          <Toaster />
-        </CommandPaletteProvider>
+        <Toaster />
         {import.meta.env.DEV && (
           <Suspense>
             <TanStackRouterDevtools position="bottom-right" />

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -9,7 +9,13 @@ import { EmailDeliveryPanel } from '@/components/email-delivery-panel'
 import { loadAdminPage } from '@/lib/server/admin-loader'
 import { BanUserAction } from '@/components/ban-user-action'
 import { ImpersonateUserAction } from '@/components/impersonate-user-action'
-import { DataTable, type DataTableColumnDef } from '@/components/data-table'
+import {
+  DataTable,
+  DataTableContent,
+  DataTableFilter,
+  DataTablePagination,
+  type DataTableColumnDef
+} from '@/components/data-table'
 import { PageHeader } from '@/components/page/page-header'
 import { Panel } from '@/components/page/panel'
 import { WorkspaceShell } from '@/components/workspace-shell'
@@ -126,12 +132,14 @@ function AdminPage() {
         <DataTable
           columns={userColumns()}
           data={users}
-          filter
-          filterPlaceholder={m.admin_filter_users()}
           pageSize={5}
           tableLabel={m.admin_system_users()}
           emptyMessage={m.common_no_system_users()}
-        />
+        >
+          <DataTableFilter placeholder={m.admin_filter_users()} />
+          <DataTableContent />
+          <DataTablePagination />
+        </DataTable>
         <AdminUserActions users={users} />
       </Panel>
 
@@ -142,12 +150,14 @@ function AdminPage() {
         <DataTable
           columns={auditColumns()}
           data={events}
-          filter
-          filterPlaceholder={m.admin_filter_events()}
           pageSize={5}
           tableLabel={m.admin_audit_events()}
           emptyMessage={m.common_no_audit_events()}
-        />
+        >
+          <DataTableFilter placeholder={m.admin_filter_events()} />
+          <DataTableContent />
+          <DataTablePagination />
+        </DataTable>
       </Panel>
     </WorkspaceShell>
   )

--- a/apps/web/src/routes/demo.tsx
+++ b/apps/web/src/routes/demo.tsx
@@ -64,7 +64,7 @@ function DashboardDemo(data: WorkspaceDashboardPayload) {
       data={data}
       // The actorless demo carries no dismiss control anywhere, so the
       // checklist must not claim one in its member note.
-      dismissalNote={false}
+      dismissalHint={null}
       ports={{
         listNotifications: demoListNotifications(data.notifications),
         markNotificationsRead: demoMarkNotificationsRead

--- a/apps/web/src/routes/forgot-password.tsx
+++ b/apps/web/src/routes/forgot-password.tsx
@@ -8,11 +8,11 @@ import {
   type RequestPasswordReset
 } from '@/components/auth/auth-client-ports'
 import { emailValidator, passwordValidator } from '@/components/auth/auth-validators'
-import { EmailCodeExchange } from '@/components/auth/email-code-exchange'
+import { EmailCodeExchangePage } from '@/components/auth/email-code-exchange'
 import { AuthSubmitButton } from '@/components/auth/auth-submit-button'
 import { FormTextField } from '@/components/form-text-field'
 import { Button } from '@/components/ui/button'
-import { AuthCardForm } from '@/components/auth/auth-card-form'
+import { AuthCardForm, AuthNoticeCard } from '@/components/auth/auth-card-form'
 import { authClient } from '@/lib/auth-client'
 import { authErrorCopy } from '@/lib/auth-error-copy'
 import { m } from '@b2b-saas-starter/i18n/messages'
@@ -94,7 +94,7 @@ export function ForgotPasswordPage({
 
   if (stage === 'code') {
     return (
-      <EmailCodeExchange
+      <EmailCodeExchangePage
         purpose="forget-password"
         email={email}
         title={m.enter_your_code()}
@@ -176,34 +176,53 @@ export function ForgotPasswordPage({
     )
   }
 
+  if (stage === 'link-sent') {
+    return (
+      <AuthNoticeCard
+        title={m.reset_your_password()}
+        description={m.reset_password_description()}
+        footer={
+          <p className="text-center text-sm text-muted-foreground">
+            {m.remembered_it()}{' '}
+            <Link to="/sign-in" className="text-primary underline underline-offset-4">
+              {m.form_sign_in()}
+            </Link>
+          </p>
+        }
+      >
+        <p role="alert" className="text-sm text-muted-foreground">
+          {SENT_MESSAGE()}
+        </p>
+      </AuthNoticeCard>
+    )
+  }
+
   return (
     <AuthCardForm
       title={m.reset_your_password()}
       description={m.reset_password_description()}
       // The link-sent stage is a confirmation, not a form — no wrapper, no
       // hydration signal needed.
-      form={stage === 'form' ? form : null}
+      form={form}
       submit={
-        stage === 'form' ? (
-          <div className="grid gap-3">
-            <AuthSubmitButton
-              form={form}
-              icon={<MailQuestionIcon className="size-4" />}
-              label={m.form_send_reset_link()}
-              submittingLabel={m.sending()}
-            />
-            <Button
-              type="button"
-              variant="secondary"
-              disabled={!form.state.canSubmit || form.state.isSubmitting}
-              onClick={() => {
-                void sendCode()
-              }}
-            >
-              {m.email_code_instead()}
-            </Button>
-          </div>
-        ) : undefined
+        <div className="grid gap-3">
+          <AuthSubmitButton
+            form={form}
+            icon={<MailQuestionIcon className="size-4" />}
+            label={m.form_send_reset_link()}
+            submittingLabel={m.sending()}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!form.state.canSubmit || form.state.isSubmitting}
+            onClick={() => {
+              void sendCode()
+            }}
+          >
+            {m.email_code_instead()}
+          </Button>
+        </div>
       }
       error={submitError}
       footer={
@@ -215,28 +234,22 @@ export function ForgotPasswordPage({
         </p>
       }
     >
-      {stage === 'link-sent' ? (
-        <p role="alert" className="text-sm text-muted-foreground">
-          {SENT_MESSAGE()}
-        </p>
-      ) : (
-        <form.Field name="email" validators={{ onChange: emailValidator }}>
-          {(field) => (
-            <FormTextField
-              name={field.name}
-              label={m.form_email()}
-              type="email"
-              placeholder="you@example.com"
-              autoComplete="email"
-              value={field.state.value}
-              errors={field.state.meta.errors}
-              onBlur={field.handleBlur}
-              onChange={field.handleChange}
-              required
-            />
-          )}
-        </form.Field>
-      )}
+      <form.Field name="email" validators={{ onChange: emailValidator }}>
+        {(field) => (
+          <FormTextField
+            name={field.name}
+            label={m.form_email()}
+            type="email"
+            placeholder="you@example.com"
+            autoComplete="email"
+            value={field.state.value}
+            errors={field.state.meta.errors}
+            onBlur={field.handleBlur}
+            onChange={field.handleChange}
+            required
+          />
+        )}
+      </form.Field>
     </AuthCardForm>
   )
 }

--- a/apps/web/src/routes/oauth.consent.tsx
+++ b/apps/web/src/routes/oauth.consent.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { PlugZapIcon } from 'lucide-react'
-import { AuthCardForm } from '@/components/auth/auth-card-form'
+import { AuthNoticeCard } from '@/components/auth/auth-card-form'
 import { ActionFeedback } from '@/components/page/action-feedback'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
@@ -148,14 +148,13 @@ export function OAuthConsentPage({
   }
 
   return (
-    <AuthCardForm
+    <AuthNoticeCard
       title={m.oauth_connect_title({ client: clientName })}
       description={
         payload.client?.uri
           ? m.oauth_connect_with_uri({ uri: payload.client.uri })
           : m.oauth_connect_without_uri()
       }
-      form={null}
       error={error}
     >
       {request === null ? (
@@ -235,6 +234,6 @@ export function OAuthConsentPage({
           </div>
         </>
       )}
-    </AuthCardForm>
+    </AuthNoticeCard>
   )
 }

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -3,7 +3,7 @@ import { pageTitle } from '@/components/page/page-title'
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { useForm } from '@tanstack/react-form'
 import { KeyRoundIcon } from 'lucide-react'
-import { AuthCardForm } from '@/components/auth/auth-card-form'
+import { AuthCardForm, AuthNoticeCard } from '@/components/auth/auth-card-form'
 import { AuthSubmitButton } from '@/components/auth/auth-submit-button'
 import { passwordValidator } from '@/components/auth/auth-validators'
 import { FormTextField } from '@/components/form-text-field'
@@ -64,9 +64,8 @@ export function ResetPasswordPage({
   // state for every failure, same rule as the invitation accept page.
   if (!token || error) {
     return (
-      <AuthCardForm
+      <AuthNoticeCard
         title={m.reset_link_unusable()}
-        form={null}
         footer={
           <p className="text-center text-sm text-muted-foreground">
             <Link
@@ -79,7 +78,7 @@ export function ResetPasswordPage({
         }
       >
         <p className="text-sm text-muted-foreground">{m.reset_link_invalid()}</p>
-      </AuthCardForm>
+      </AuthNoticeCard>
     )
   }
 

--- a/apps/web/src/routes/sign-in_.email-code.tsx
+++ b/apps/web/src/routes/sign-in_.email-code.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
-import { EmailCodeExchange } from '@/components/auth/email-code-exchange'
+import { EmailCodeExchangePage } from '@/components/auth/email-code-exchange'
 import { pageTitle } from '@/components/page/page-title'
 import { authClient } from '@/lib/auth-client'
 import { redirectSearch, safeRedirect } from '@/lib/utils'
@@ -33,7 +33,7 @@ export function EmailCodeSignInPage({
 }) {
   const router = useRouter()
   return (
-    <EmailCodeExchange
+    <EmailCodeExchangePage
       purpose="sign-in"
       verify={({ email, otp }) => authClient.signIn.emailOtp({ email, otp })}
       onVerified={() => {

--- a/apps/web/src/routes/verify-email.tsx
+++ b/apps/web/src/routes/verify-email.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { pageTitle } from '@/components/page/page-title'
 import { CheckCircle2Icon, CircleAlertIcon } from 'lucide-react'
-import { EmailCodeExchange } from '@/components/auth/email-code-exchange'
+import { EmailCodeExchangeCard } from '@/components/auth/email-code-exchange'
 import { PublicLayout } from '@/components/public-layout'
 import { authClient } from '@/lib/auth-client'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -76,8 +76,7 @@ export function VerifyEmailPage({ error }: { readonly error?: string | undefined
           </CardContent>
         </Card>
         {error ? (
-          <EmailCodeExchange
-            layout="card"
+          <EmailCodeExchangeCard
             title={m.verify_with_code()}
             purpose="email-verification"
             verify={({ email, otp }) => authClient.emailOtp.verifyEmail({ email, otp })}

--- a/apps/web/src/routes/workspaces.tsx
+++ b/apps/web/src/routes/workspaces.tsx
@@ -31,8 +31,8 @@ export const Route = createFileRoute('/workspaces')({
 function WorkspacesLayout() {
   const directory: WorkspaceDirectory = Route.useLoaderData()
   return (
-    <WorkspaceDirectoryContext.Provider value={directory}>
+    <WorkspaceDirectoryContext value={directory}>
       <Outlet />
-    </WorkspaceDirectoryContext.Provider>
+    </WorkspaceDirectoryContext>
   )
 }


### PR DESCRIPTION
## Outcome

Review the web app and React email templates against all eight vercel-composition-patterns rules. Replace the supported composition problems while preserving the existing workflows and visual design.

- Compose table filters, content and pagination explicitly. Share their state through a typed provider, and render every loaded row for server-paginated tables.
- Scope command palettes to their public or workspace layout. Pass permissions directly instead of copying shell state upward through an effect.
- Separate auth forms from notice cards and email-code pages from embedded cards, sharing fields and exchange behavior.
- Compose billing actions, pricing notes, onboarding hints and alert icons. Remove the unused sheet-close visibility option and migrate the remaining React context usage.

Permission and domain flags, transient control state, and library render APIs remain appropriate. The reset-password field callback supplies shared form data, which the composition guide explicitly permits. The email templates had no actionable composition findings.

## Validation

- Independent Standards and Spec reviews passed, including re-review of the provider invariant repair.
- Tested revision: `7b58ec16c7f31b3180d1b50ced36b0d616cea3bb`. Type checking, lint, formatting and dead-code checks passed.
- Focused table/palette regression tests passed: 9 tests. Browser smoke verified the demo, Search/Escape, and desktop/mobile rendering. The design detector reported no findings.
- `pnpm run validate` was attempted twice. It stopped on timeouts in untouched backend live tests. The runner stripped the second attempt's worker-limit environment variable.
- Full workspace tests passed with `vp run -r --concurrency-limit 1 test --maxWorkers=2 --testTimeout=30000 --hookTimeout=60000`, including all 100 web test files.
- Script and operations tests, production builds, client boundary checks, generated Wrangler configuration drift checks, and local migration/seeding passed.
- Local full E2E: 24 passed, 2 failed during page-loading timeouts, and 1 passed on retry. The passkey timeout left its test credential behind; that credential was removed before the isolated rerun.
- Isolated rerun of account-session and passkey specs with one worker: all 3 tests passed.
- GitHub required CI, E2E and title checks passed on this revision. Optional audit and preview deployment passed.
- Regression coverage: [table composition and pagination](apps/web/src/components/data-table.test.tsx), [palette state ownership](apps/web/src/components/command-palette.test.tsx).
- Manual smoke: open `/demo`, open Search, dismiss with Escape, then inspect desktop and mobile layouts. All passed. Desktop and mobile screenshots were inspected locally.

## Risks and remaining work

No remaining review findings or CI blockers. Bare loading/error views do not install a command-palette shortcut; the shortcut is available when their public or workspace layout mounts.
