### PR TITLE
perf(web): avoid bulk article loading and redundant React work

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -55,6 +55,39 @@ test('public docs render', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Documentation' })).toBeVisible()
 })
 
+test('knowledge search loads metadata without downloading article bodies', async ({
+  page
+}) => {
+  // The E2E server is Vite dev, where compiled article requests retain .mdx.
+  const articleRequests: Array<string> = []
+  const articles = /\/content\/(?:docs|blog)\/.*\.mdx(?:\?|$)/
+  await page.route(articles, (route) => {
+    articleRequests.push(route.request().url())
+    return route.abort()
+  })
+  await page.goto('/sign-in')
+  await page.locator('form[data-hydrated="true"]').waitFor()
+  await page
+    .getByRole('button', { name: 'Search', exact: true })
+    .filter({ visible: true })
+    .click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('combobox').fill('Quickstart')
+  const quickstart = dialog.getByRole('option', { name: 'Quickstart', exact: true })
+  await expect(quickstart).toBeVisible()
+  expect(articleRequests).toEqual([])
+
+  await page.unroute(articles)
+  await quickstart.click()
+  await expect(
+    page.getByRole('heading', { name: 'Quickstart', exact: true })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('heading', { name: 'Prerequisites', exact: true })
+  ).toBeVisible()
+})
+
 test('unauthenticated workspace visit redirects to sign-in', async ({ page }) => {
   await page.goto('/workspaces/starter-lab')
   await page.waitForURL(/\/sign-in/)

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -1,18 +1,18 @@
 import {
   CircleCheckIcon,
   InfoIcon,
-  Loader2Icon,
   OctagonXIcon,
   TriangleAlertIcon
 } from 'lucide-react'
 import { Toaster as Sonner, type ToasterProps } from 'sonner'
+import { Spinner } from '@/components/ui/spinner'
 
 const TOASTER_ICONS = {
   success: <CircleCheckIcon className="size-4" />,
   info: <InfoIcon className="size-4" />,
   warning: <TriangleAlertIcon className="size-4" />,
   error: <OctagonXIcon className="size-4" />,
-  loading: <Loader2Icon className="size-4 motion-safe:animate-spin" />
+  loading: <Spinner />
 }
 
 // Sonner is themed through CSS custom properties, which `CSSProperties` alone

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -3,14 +3,15 @@ import { Loader2Icon } from 'lucide-react'
 
 function Spinner({ className, ...props }: React.ComponentProps<'svg'>) {
   return (
-    <Loader2Icon
-      data-slot="spinner"
-      // Decorative inline: the action's label carries the state ("Signing
-      // in…"), so an aria-label here only concatenated into button names.
-      aria-hidden="true"
-      className={cn('size-4 motion-safe:animate-spin', className)}
-      {...props}
-    />
+    <span data-slot="spinner" className="inline-flex motion-safe:animate-spin">
+      <Loader2Icon
+        // Decorative inline: the action's label carries the state ("Signing
+        // in…"), so an aria-label here only concatenated into button names.
+        aria-hidden="true"
+        className={cn('size-4', className)}
+        {...props}
+      />
+    </span>
   )
 }
 

--- a/apps/web/src/components/webhook-delivery-timeline.tsx
+++ b/apps/web/src/components/webhook-delivery-timeline.tsx
@@ -48,7 +48,7 @@ export function WebhookDeliveryTimeline({
         className="justify-self-start"
         aria-expanded={expanded}
         aria-controls={historyId}
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => setExpanded((current) => !current)}
       >
         {expanded ? m.hide_attempt_history() : m.view_attempt_history()}
       </Button>

--- a/apps/web/src/components/workspace-billing.tsx
+++ b/apps/web/src/components/workspace-billing.tsx
@@ -537,17 +537,15 @@ function formatBillingDate(value: string): string {
 
 function toggleResource(
   id: string,
-  selected: ReadonlyArray<string>,
   limit: number,
-  set: (ids: ReadonlyArray<string>) => void
+  set: (update: (selected: ReadonlyArray<string>) => ReadonlyArray<string>) => void
 ): void {
-  if (selected.includes(id)) {
-    set(selected.filter((item) => item !== id))
-    return
-  }
-  if (selected.length < limit) {
-    set([...selected, id])
-  }
+  set((selected) => {
+    if (selected.includes(id)) {
+      return selected.filter((item) => item !== id)
+    }
+    return selected.length < limit ? [...selected, id] : selected
+  })
 }
 
 function BillingResourceAccess({
@@ -695,14 +693,14 @@ function DowngradeResourceSelector({
           items={apiTokens}
           selected={tokenIds}
           disabled={selection.pending}
-          onToggle={(id) => toggleResource(id, tokenIds, 2, setTokenIds)}
+          onToggle={(id) => toggleResource(id, 2, setTokenIds)}
         />
         <ResourceChoices
           label={m.nav_webhook_endpoints()}
           items={webhookEndpoints}
           selected={webhookIds}
           disabled={selection.pending}
-          onToggle={(id) => toggleResource(id, webhookIds, 1, setWebhookIds)}
+          onToggle={(id) => toggleResource(id, 1, setWebhookIds)}
         />
       </div>
       <Button className="mt-4" disabled={selection.pending} onClick={save}>

--- a/apps/web/src/lib/blog.effects.ts
+++ b/apps/web/src/lib/blog.effects.ts
@@ -1,0 +1,30 @@
+import { type PostMeta } from './blog'
+
+type PostModule = {
+  readonly frontmatter: PostMeta['frontmatter']
+}
+
+// This glob is server-only. Metadata reads may load the compiled modules in the
+// worker, but the browser receives only the serialized frontmatter projection.
+const modules = import.meta.glob<PostModule>('../../content/blog/*.mdx')
+
+function getSlugFromPath(path: string): string {
+  return path.replace('../../content/blog/', '').replace('.mdx', '')
+}
+
+export async function loadAllPostMetaHandler(): Promise<ReadonlyArray<PostMeta>> {
+  // oxlint-disable-next-line effect/noNewPromise -- server-only content metadata boundary; Promise.all keeps the lazy module reads parallel
+  const metas = await Promise.all(
+    Object.entries(modules).map(async ([path, load]) => {
+      const mod = await load()
+      return {
+        slug: getSlugFromPath(path),
+        frontmatter: mod.frontmatter
+      } satisfies PostMeta
+    })
+  )
+  return metas.toSorted(
+    (a, b) =>
+      new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime()
+  )
+}

--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -1,4 +1,5 @@
 import { lazy, type ComponentType } from 'react'
+import { createServerFn } from '@tanstack/react-start'
 
 import { type MdxComponentProps } from '@/components/mdx-link'
 import { contentJsonLd } from '@/lib/json-ld'
@@ -28,35 +29,21 @@ type PostModule = {
 }
 
 // No `eager`: the compiled MDX must not ride the importing route's chunk.
-// oxlint-disable effect/noNewPromise -- this module is the promise boundary between router loaders (promise-shaped) and the Effect-native content; same exemption as packages/logger/src/providers.ts
 const modules = import.meta.glob<PostModule>('../../content/blog/*.mdx')
 
-function getSlugFromPath(path: string): string {
-  return path.replace('../../content/blog/', '').replace('.mdx', '')
-}
+/** Server-only metadata enumeration; the browser must not import every MDX body. */
+const loadAllPostMetaServerFn = createServerFn({ method: 'GET' }).handler(
+  async (): Promise<ReadonlyArray<PostMeta>> => {
+    const { loadAllPostMetaHandler } = await import('./blog.effects')
+    return loadAllPostMetaHandler()
+  }
+)
 
 let metaPromise: Promise<ReadonlyArray<PostMeta>> | undefined
 
-async function loadAllPostMeta(): Promise<ReadonlyArray<PostMeta>> {
-  const entries = Object.entries(modules)
-  const metas = await Promise.all(
-    entries.map(async ([path, load]) => {
-      const mod = await load()
-      return {
-        slug: getSlugFromPath(path),
-        frontmatter: mod.frontmatter
-      } satisfies PostMeta
-    })
-  )
-  return metas.toSorted(
-    (a, b) =>
-      new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime()
-  )
-}
-
 /** Every post's metadata, newest first. */
 export function getAllPostMeta(): Promise<ReadonlyArray<PostMeta>> {
-  metaPromise ??= loadAllPostMeta()
+  metaPromise ??= loadAllPostMetaServerFn()
   return metaPromise
 }
 

--- a/apps/web/src/lib/client-telemetry.test.tsx
+++ b/apps/web/src/lib/client-telemetry.test.tsx
@@ -1,0 +1,58 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { expect, it, vi } from 'vite-plus/test'
+import { ClientTelemetry } from './client-telemetry'
+
+const providers = vi.hoisted(() => {
+  let finishDownload: (() => void) | undefined
+  const sentryDownload = new Promise<void>((resolve) => {
+    finishDownload = resolve
+  })
+  if (finishDownload === undefined) {
+    throw new Error('Promise executor did not run synchronously')
+  }
+  return {
+    sentryDownload,
+    finishDownload,
+    sentryInit: vi.fn(),
+    posthogInit: vi.fn()
+  }
+})
+
+vi.mock('@sentry/react', async () => {
+  await providers.sentryDownload
+  return { getClient: () => undefined, init: providers.sentryInit }
+})
+
+vi.mock('posthog-js', () => ({
+  default: { __loaded: false, init: providers.posthogInit }
+}))
+
+it('starts analytics while error reporting downloads and cancels initialization on unmount', async () => {
+  const { rerender, unmount } = render(
+    <ClientTelemetry
+      config={{ sentryDsn: undefined, posthogKey: undefined, posthogHost: undefined }}
+    />
+  )
+  await act(async () => {})
+  expect(providers.posthogInit).not.toHaveBeenCalled()
+  expect(providers.sentryInit).not.toHaveBeenCalled()
+
+  rerender(
+    <ClientTelemetry
+      config={{
+        sentryDsn: 'https://public@example.com/1',
+        posthogKey: 'public-key',
+        posthogHost: undefined
+      }}
+    />
+  )
+  await waitFor(() => expect(providers.posthogInit).toHaveBeenCalledTimes(1))
+  expect(providers.sentryInit).not.toHaveBeenCalled()
+
+  unmount()
+  await act(async () => {
+    providers.finishDownload()
+    await vi.dynamicImportSettled()
+  })
+  expect(providers.sentryInit).not.toHaveBeenCalled()
+})

--- a/apps/web/src/lib/client-telemetry.tsx
+++ b/apps/web/src/lib/client-telemetry.tsx
@@ -36,17 +36,15 @@ export function ClientTelemetry({
 }: {
   readonly config: ClientTelemetryConfig
 }) {
+  const { sentryDsn, posthogKey, posthogHost } = config
   useEffect(() => {
-    // Explicit annotation: the cleanup closure mutates this after return, so
-    // control-flow analysis must not narrow it to `false`.
-    let cancelled: boolean = false
-    void (async () => {
-      if (config.sentryDsn) {
+    let cancelled = false
+    async function initializeSentry() {
+      if (sentryDsn) {
         const Sentry = await loadSentry()
-        // oxlint-disable-next-line typescript/no-unnecessary-condition -- the cleanup closure mutates `cancelled` after this runs
         if (!cancelled && Sentry.getClient() === undefined) {
           Sentry.init({
-            dsn: config.sentryDsn,
+            dsn: sentryDsn,
             // 100% traces would sample every browser session — an order of
             // magnitude noisier (and pricier) than the server's per-request
             // sampling. Errors stay at the SDK default (100%).
@@ -56,22 +54,26 @@ export function ClientTelemetry({
           })
         }
       }
-      if (config.posthogKey) {
+    }
+    async function initializePosthog() {
+      if (posthogKey) {
         const posthog = await loadPosthog()
-        // oxlint-disable-next-line eslint/no-underscore-dangle, typescript/no-unnecessary-condition -- PostHog's own readiness flag; the cleanup closure mutates `cancelled` after this runs
+        // oxlint-disable-next-line eslint/no-underscore-dangle -- PostHog's own readiness flag
         if (!cancelled && !posthog.__loaded) {
-          posthog.init(config.posthogKey, {
-            api_host: config.posthogHost ?? 'https://us.i.posthog.com',
+          posthog.init(posthogKey, {
+            api_host: posthogHost ?? 'https://us.i.posthog.com',
             capture_pageview: 'history_change',
             capture_pageleave: true,
             persistence: 'localStorage+cookie'
           })
         }
       }
-    })()
+    }
+    // oxlint-disable-next-line effect/noNewPromise -- independent browser SDK imports; Effect must stay out of the client bundle
+    void Promise.all([initializeSentry(), initializePosthog()])
     return () => {
       cancelled = true
     }
-  }, [config])
+  }, [sentryDsn, posthogKey, posthogHost])
   return null
 }

--- a/apps/web/src/lib/doc-categories.ts
+++ b/apps/web/src/lib/doc-categories.ts
@@ -1,0 +1,23 @@
+export const DOC_CATEGORIES = {
+  'getting-started': 'Getting started',
+  architecture: 'Architecture',
+  'capability-interfaces': 'Capability interfaces',
+  integrations: 'Integration surfaces',
+  operations: 'Operations',
+  governance: 'Governance'
+}
+
+export type DocCategory = keyof typeof DOC_CATEGORIES
+
+export function isDocCategory(value: string): value is DocCategory {
+  return Object.hasOwn(DOC_CATEGORIES, value)
+}
+
+export const DOC_CATEGORY_ORDER: ReadonlyArray<DocCategory> = [
+  'getting-started',
+  'architecture',
+  'capability-interfaces',
+  'integrations',
+  'operations',
+  'governance'
+]

--- a/apps/web/src/lib/docs.effects.ts
+++ b/apps/web/src/lib/docs.effects.ts
@@ -1,0 +1,39 @@
+import { DOC_CATEGORY_ORDER, type DocCategory, isDocCategory } from './doc-categories'
+import { type DocMeta } from './docs'
+
+type DocModule = {
+  readonly frontmatter: DocMeta['frontmatter']
+}
+
+// This glob is server-only. Metadata reads may load the compiled modules in the
+// worker, but the browser receives only the serialized frontmatter projection.
+const modules = import.meta.glob<DocModule>('../../content/docs/**/*.mdx')
+
+type DocPath = { category: string; slug: string }
+
+function parsePath(path: string): DocPath {
+  const relative = path.replace('../../content/docs/', '').replace('.mdx', '')
+  const parts = relative.split('/')
+  return { category: parts[0] ?? '', slug: parts.at(-1) ?? '' }
+}
+
+function asCategory(value: string): DocCategory {
+  return isDocCategory(value) ? value : 'getting-started'
+}
+
+export async function loadAllDocMetaHandler(): Promise<ReadonlyArray<DocMeta>> {
+  // oxlint-disable-next-line effect/noNewPromise -- server-only content metadata boundary; Promise.all keeps the lazy module reads parallel
+  const metas = await Promise.all(
+    Object.entries(modules).map(async ([path, load]) => {
+      const { category, slug } = parsePath(path)
+      const mod = await load()
+      return { slug, category, frontmatter: mod.frontmatter } satisfies DocMeta
+    })
+  )
+  return metas.toSorted((a, b) =>
+    a.category === b.category
+      ? a.frontmatter.order - b.frontmatter.order
+      : DOC_CATEGORY_ORDER.indexOf(asCategory(a.category)) -
+        DOC_CATEGORY_ORDER.indexOf(asCategory(b.category))
+  )
+}

--- a/apps/web/src/lib/docs.ts
+++ b/apps/web/src/lib/docs.ts
@@ -1,8 +1,12 @@
 import { lazy, type ComponentType } from 'react'
+import { createServerFn } from '@tanstack/react-start'
 
 import { type MdxComponentProps } from '@/components/mdx-link'
 import { contentJsonLd } from '@/lib/json-ld'
 import { m } from '@b2b-saas-starter/i18n/messages'
+import { isDocCategory } from './doc-categories'
+
+export { DOC_CATEGORY_ORDER } from './doc-categories'
 
 type DocFrontmatter = {
   readonly title: string
@@ -31,17 +35,15 @@ type DocModule = {
 }
 
 // No `eager`: the compiled MDX must not ride the importing route's chunk.
-// oxlint-disable effect/noNewPromise -- this module is the promise boundary between router loaders (promise-shaped) and the Effect-native content; same exemption as packages/logger/src/providers.ts
 const modules = import.meta.glob<DocModule>('../../content/docs/**/*.mdx')
 
-/** The two path segments a docs module's file path encodes. */
-type DocPath = { category: string; slug: string }
-
-function parsePath(path: string): DocPath {
-  const relative = path.replace('../../content/docs/', '').replace('.mdx', '')
-  const parts = relative.split('/')
-  return { category: parts[0] ?? '', slug: parts.at(-1) ?? '' }
-}
+/** Server-only metadata enumeration; the browser must not import every MDX body. */
+const loadAllDocMetaServerFn = createServerFn({ method: 'GET' }).handler(
+  async (): Promise<ReadonlyArray<DocMeta>> => {
+    const { loadAllDocMetaHandler } = await import('./docs.effects')
+    return loadAllDocMetaHandler()
+  }
+)
 
 /** Module path for one doc, or `undefined` when no such article exists. */
 function docPath(category: string, slug: string): string | undefined {
@@ -64,31 +66,10 @@ function docLoader(
 
 let metaPromise: Promise<ReadonlyArray<DocMeta>> | undefined
 
-async function loadAllDocMeta(): Promise<ReadonlyArray<DocMeta>> {
-  const entries = Object.entries(modules)
-  const metas = await Promise.all(
-    entries.map(async ([path, load]) => {
-      const { category, slug } = parsePath(path)
-      const mod = await load()
-      return { slug, category, frontmatter: mod.frontmatter } satisfies DocMeta
-    })
-  )
-  return metas.toSorted((a, b) =>
-    a.category === b.category
-      ? a.frontmatter.order - b.frontmatter.order
-      : DOC_CATEGORY_ORDER.indexOf(asCategory(a.category)) -
-        DOC_CATEGORY_ORDER.indexOf(asCategory(b.category))
-  )
-}
-
 /** Every doc's metadata, ordered by frontmatter `order` within its category. */
 export function getAllDocMeta(): Promise<ReadonlyArray<DocMeta>> {
-  metaPromise ??= loadAllDocMeta()
+  metaPromise ??= loadAllDocMetaServerFn()
   return metaPromise
-}
-
-function asCategory(value: string): DocCategory {
-  return isDocCategory(value) ? value : 'getting-started'
 }
 
 /**
@@ -133,21 +114,6 @@ export function getDocComponent(
 
 const componentCache = new Map<string, ComponentType<MdxComponentProps>>()
 
-export const DOC_CATEGORIES = {
-  'getting-started': 'Getting started',
-  architecture: 'Architecture',
-  'capability-interfaces': 'Capability interfaces',
-  integrations: 'Integration surfaces',
-  operations: 'Operations',
-  governance: 'Governance'
-}
-
-export type DocCategory = keyof typeof DOC_CATEGORIES
-
-export function isDocCategory(value: string): value is DocCategory {
-  return Object.hasOwn(DOC_CATEGORIES, value)
-}
-
 /** The display name for a category, falling back to the raw URL segment. */
 export function docCategoryName(category: string): string {
   if (!isDocCategory(category)) {
@@ -174,15 +140,6 @@ export function docCategoryName(category: string): string {
     }
   }
 }
-
-export const DOC_CATEGORY_ORDER: ReadonlyArray<DocCategory> = [
-  'getting-started',
-  'architecture',
-  'capability-interfaces',
-  'integrations',
-  'operations',
-  'governance'
-]
 
 /** Previous/next neighbours within a category, `null` at either end. */
 export type AdjacentDocs = {

--- a/apps/web/src/routes/account_.notifications.tsx
+++ b/apps/web/src/routes/account_.notifications.tsx
@@ -30,10 +30,14 @@ export const Route = createFileRoute('/account_/notifications')({
     const session = await requireSession(location.href)
     return { session }
   },
-  loader: async () => ({
-    ...(await loadNotificationPreferencesServerFn()),
-    deliveries: await loadOwnEmailDeliveryServerFn()
-  }),
+  loader: async () => {
+    // oxlint-disable-next-line effect/noNewPromise -- parallel client-safe server-fn calls; importing Effect here would ship its runtime
+    const [preferences, deliveries] = await Promise.all([
+      loadNotificationPreferencesServerFn(),
+      loadOwnEmailDeliveryServerFn()
+    ])
+    return { ...preferences, deliveries }
+  },
   component: AccountNotificationsRoute,
   head: () => ({ meta: [{ title: pageTitle(m.notification_preferences()) }] })
 })

--- a/apps/web/src/routes/sign-in.tsx
+++ b/apps/web/src/routes/sign-in.tsx
@@ -21,10 +21,14 @@ export const Route = createFileRoute('/sign-in')({
   // only (env-gated: with nothing configured the loader answers an empty list
   // and `null`, and the page renders exactly what it did before either
   // existed).
-  loader: async () => ({
-    socialProviders: await getSocialProviderIds(),
-    turnstileSiteKey: await getTurnstileSiteKey()
-  }),
+  loader: async () => {
+    // oxlint-disable-next-line effect/noNewPromise -- parallel client-safe server-fn calls; importing Effect here would ship its runtime
+    const [socialProviders, turnstileSiteKey] = await Promise.all([
+      getSocialProviderIds(),
+      getTurnstileSiteKey()
+    ])
+    return { socialProviders, turnstileSiteKey }
+  },
   component: SignInRoute,
   head: () => ({ meta: [{ title: pageTitle(m.public_meta_sign_in()) }] })
 })

--- a/apps/web/src/routes/sign-up.tsx
+++ b/apps/web/src/routes/sign-up.tsx
@@ -26,10 +26,14 @@ export const Route = createFileRoute('/sign-up')({
   validateSearch: redirectSearch,
   // Both server-only reads: the Turnstile site key and the active provider
   // ids are fetched in the loader; `null`/empty keeps their UI unmounted.
-  loader: async () => ({
-    turnstileSiteKey: await getTurnstileSiteKey(),
-    socialProviders: await getSocialProviderIds()
-  }),
+  loader: async () => {
+    // oxlint-disable-next-line effect/noNewPromise -- parallel client-safe server-fn calls; importing Effect here would ship its runtime
+    const [turnstileSiteKey, socialProviders] = await Promise.all([
+      getTurnstileSiteKey(),
+      getSocialProviderIds()
+    ])
+    return { turnstileSiteKey, socialProviders }
+  },
   component: SignUpRoute,
   head: () => ({ meta: [{ title: pageTitle(m.public_meta_sign_up()) }] })
 })

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -236,7 +236,12 @@ export default defineConfig(({ command, mode }) => {
         // Email templates are invoked directly (no React dispatcher) when
         // rendering HTML, so compiler-inserted hooks crash there.
         babel({
-          exclude: /packages[/\\]email[/\\]/,
+          // A custom exclude replaces the plugin defaults. Keep vendor and
+          // Rolldown runtime exclusions so dev does not recompile dependencies.
+          exclude: [
+            /[/\\]node_modules[/\\]|^\0rolldown\/runtime\.js$/,
+            /packages[/\\]email[/\\]/
+          ],
           presets: [reactCompilerPreset()]
         }),
         cloudflareWorkersDeployPlugin(


### PR DESCRIPTION
## Outcome

A full Vercel React best practices review found unnecessary article downloads, sequential independent reads, stale-state toggles, and redundant compiler work. This PR:

- Moves docs/blog metadata enumeration behind server functions, so indexes and search no longer download all 27 compiled article modules. Individual articles remain lazy-loaded.
- Runs independent sign-in, sign-up, notification-preference, and browser telemetry reads concurrently, and narrows telemetry effect dependencies to configuration values.
- Uses functional billing-resource and webhook-history toggles, animates spinner wrappers, and shares the spinner with Sonner.
- Restores Babel's default vendor/runtime exclusions alongside the email exclusion. The custom exclusion had caused React Compiler to process large vendor bundles during development.

## Decisions

Reviewed React components, hooks, routes, browser helpers, server loaders, build configuration, and React email templates across all eight rule categories. TanStack Query, TanStack Start boundaries, and React Compiler remain the existing mechanisms for caching, lazy loading, and memoization. Next.js RSC-only APIs do not apply here. Locale-dependent copy stays in request/render context; the metadata cache contains only static public content.

| Review category | Result |
| --- | --- |
| Waterfalls | Fixed independent route reads and telemetry initialization. |
| Bundle size | Fixed bulk MDX loading and compiler exclusions; retained existing lazy heavy modules. |
| Server performance | Public metadata caches and request-scoped identity preserved; RSC-only rules do not apply. |
| Client fetching | Existing TanStack Query deduplication and shared/passive listeners reviewed. |
| Re-renders | Fixed state toggles and effect dependencies; retained compiler memoization. |
| Rendering | Fixed SVG animation; reviewed hydration, font hints, and pagination. |
| JavaScript | Reviewed collection scans, immutable sorting, and cached helpers; no further concrete defect found. |
| Advanced patterns | Reviewed callback refs, SDK initialization guards, and cleanup. |

Independent Standards and Spec reviews found no remaining issues. Standards review also included the strict maintainability pass. Final repairs received targeted review.

## Validation

Tested revision: `ea021b35aaf8695e6905d60c009961b81e29dd60`.

- Typecheck, lint, formatting, dead-code/cycle check, build, client-bundle boundary guard, generated Wrangler drift check, local migration and seed passed.
- Web: 610 tests passed. API worker: 131. Background worker: 95. SDK: 10. HTTP contract: 1. React email: 29. Script checks: 36. Operations: 17. Other prerequisite package suites passed.
- Capability suite with explicit single-worker execution: 571 passed; one unchanged live email-retention test exceeded its explicit 30-second timeout. The default `pnpm run validate` run also encountered live D1 timeouts, so the remaining stages were run separately.
- The new browser regression passed: open search with article-body requests blocked, find Quickstart, then allow requests and open the article. A telemetry regression covers independent SDK initialization and cancellation on unmount.
- Full browser suite: 28 passed with one worker. Required GitHub CI, browser tests, and PR-title checks passed on this revision. CI includes the full package tests and capability coverage gate. The optional dependency audit and preview deployment also passed.

## Risks and remaining work

The local live email-retention timeout prevents claiming a clean aggregate local `pnpm run validate` result; GitHub CI passed the full test suite and coverage gate. No React findings or merge blockers remain. The PR is up to date with `master` and is not merged.
