### PR TITLE
chore(config): update env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ STRIPE_PRICE_ID_TEAM=
 # Optional operator-provisioned Enterprise subscription price; no self-checkout.
 STRIPE_PRICE_ID_ENTERPRISE=
 SENTRY_DSN=
+# Production recovery evidence. Leave unset locally; production requires an
+# HTTPS append-only service outside the Cloudflare account and its bearer token.
+SECURITY_EVIDENCE_URL=
+SECURITY_EVIDENCE_TOKEN=
 POSTHOG_KEY=
 POSTHOG_HOST=https://us.i.posthog.com
 CLOUDFLARE_EMAIL_FROM=
@@ -59,6 +63,30 @@ OTEL_EXPORTER_OTLP_HEADERS=
 SERVICE_VERSION=
 GIT_COMMIT_SHA=
 ENVIRONMENT=
+MAINTENANCE_MODE=
+
+# Retention policy overrides (optional; safe preview mode is the default).
+# Destructive cleanup also requires explicit recovery verification and an
+# operator-approved policy digest. RETENTION_DATABASE_TARGET is supplied by
+# the production deployment and should remain unset locally.
+RETENTION_CLEANUP_ENABLED=
+RETENTION_RECOVERY_VERIFIED=
+RETENTION_AUDIT_DAYS=
+RETENTION_NOTIFICATION_DAYS=
+RETENTION_INVITATION_DAYS=
+RETENTION_TOKEN_DAYS=
+RETENTION_EXPORT_DAYS=
+RETENTION_BILLING_DAYS=
+RETENTION_EMAIL_DAYS=
+RETENTION_UNRESOLVED_EMAIL_DAYS=
+RETENTION_BATCH_SIZE=
+RETENTION_WORK_BUDGET=
+RETENTION_POLICY_APPROVAL_DIGEST=
+RETENTION_PREVIEW_DIGEST=
+RETENTION_RECOVERY_EVIDENCE=
+RETENTION_POLICY_VERSION=
+RETENTION_POLICY_TARGET=
+RETENTION_DATABASE_TARGET=
 
 # Cloudflare D1 remote access (db:generate / db:migrate:remote via drizzle-kit)
 CLOUDFLARE_ACCOUNT_ID=


### PR DESCRIPTION
## Outcome

Update the root `.env.example` to match the canonical `ServerEnv` definition. Add the recovery-evidence, maintenance, retention-policy, and deployment-derived environment names with local-safe empty defaults and setup comments.

## Decisions

Production-only recovery evidence remains unset in local development. The example documents that it requires an HTTPS append-only service outside the Cloudflare account.

## Validation

- Confirmed every `ServerEnv` key is represented in `.env.example`.
- `git diff --check` passed.

## Risks and remaining work

None known.
