### PR TITLE
fix(config): make recovery evidence optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@ STRIPE_PRICE_ID_TEAM=
 # Optional operator-provisioned Enterprise subscription price; no self-checkout.
 STRIPE_PRICE_ID_ENTERPRISE=
 SENTRY_DSN=
-# Production recovery evidence. Leave unset locally; production requires an
-# HTTPS append-only service outside the Cloudflare account and its bearer token.
+# Optional recovery evidence. When configured, use an HTTPS append-only service
+# outside the Cloudflare account and its bearer token.
 SECURITY_EVIDENCE_URL=
 SECURITY_EVIDENCE_TOKEN=
 POSTHOG_KEY=

--- a/.github/scripts/smoke-deployment.test.ts
+++ b/.github/scripts/smoke-deployment.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { main, probe } from './smoke-deployment.ts'
+
+function response(status: number, body: string): Response {
+  return new Response(body, { status })
+}
+
+await test('probe retries failed HTTP responses and succeeds after propagation', async () => {
+  let attempts = 0
+  const sleeps: Array<number> = []
+  await probe(
+    'api',
+    'https://api.example/health',
+    async () => {
+      attempts += 1
+      return response(attempts === 3 ? 200 : 500, 'warming up')
+    },
+    async (milliseconds) => {
+      sleeps.push(milliseconds)
+    }
+  )
+  assert.equal(attempts, 3)
+  assert.deepEqual(sleeps, [3000, 3000])
+})
+
+await test('probe includes the final status and response body in its failure', async () => {
+  await assert.rejects(
+    () =>
+      probe(
+        'web',
+        'https://web.example/',
+        async () => response(500, 'configuration is invalid'),
+        async () => {}
+      ),
+    /smoke probe failed for web \(HTTP 500\)[\s\S]*configuration is invalid/
+  )
+})
+
+await test('main probes the API health endpoint before the web root', async () => {
+  const urls: Array<string> = []
+  await main(
+    { API_URL: 'https://api.example', WEB_URL: 'https://web.example' },
+    async (url) => {
+      urls.push(url)
+      return response(200, 'ok')
+    },
+    async () => {}
+  )
+  assert.deepEqual(urls, ['https://api.example/health', 'https://web.example/'])
+})

--- a/.github/scripts/smoke-deployment.ts
+++ b/.github/scripts/smoke-deployment.ts
@@ -1,0 +1,72 @@
+import { setTimeout as delay } from 'node:timers/promises'
+
+type FetchLike = (input: string) => Promise<Response>
+type Sleep = (milliseconds: number) => Promise<void>
+
+const RETRIES = 5
+const RETRY_DELAY_MS = 3000
+const RESPONSE_PREVIEW_LENGTH = 4000
+
+function requiredEnv(name: string, env: NodeJS.ProcessEnv): string {
+  const value = env[name]
+  if (!value) {
+    throw new Error(`missing required environment variable ${name}`)
+  }
+  return value
+}
+
+function responseIsSuccessful(response: Response): boolean {
+  return response.status >= 200 && response.status < 400
+}
+
+export async function probe(
+  name: string,
+  url: string,
+  fetchImpl: FetchLike = fetch,
+  sleep: Sleep = delay
+): Promise<void> {
+  let lastFailure = 'no response'
+  let lastBody = ''
+
+  for (let attempt = 0; attempt <= RETRIES; attempt += 1) {
+    console.log(`Probing ${name} (${url}), attempt ${attempt + 1}/${RETRIES + 1}`)
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- retries must wait in sequence
+      const response = await fetchImpl(url)
+      // oxlint-disable-next-line no-await-in-loop -- the response belongs to this attempt
+      lastBody = await response.text()
+      if (responseIsSuccessful(response)) {
+        return
+      }
+      lastFailure = `HTTP ${response.status}`
+    } catch (error) {
+      console.error(`smoke probe request failed for ${name}`, error)
+      lastFailure = 'request failed'
+    }
+
+    if (attempt < RETRIES) {
+      // oxlint-disable-next-line no-await-in-loop -- retries must wait in sequence
+      await sleep(RETRY_DELAY_MS)
+    }
+  }
+
+  throw new Error(
+    `smoke probe failed for ${name} (${lastFailure})\nResponse body:\n${lastBody.slice(0, RESPONSE_PREVIEW_LENGTH)}`
+  )
+}
+
+export async function main(
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: FetchLike = fetch,
+  sleep: Sleep = delay
+): Promise<void> {
+  await probe('api', `${requiredEnv('API_URL', env)}/health`, fetchImpl, sleep)
+  await probe('web', `${requiredEnv('WEB_URL', env)}/`, fetchImpl, sleep)
+}
+
+if (process.argv[1] === import.meta.filename) {
+  main().catch((error: unknown) => {
+    console.error('deployment smoke test failed', error)
+    process.exitCode = 1
+  })
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,8 +219,4 @@ jobs:
       # lag right after the upload; `-f --retry-all-errors` makes any HTTP
       # failure (not just transport errors) retry, then fail the job.
       - name: Smoke test the deployment
-        run: |
-          for url in "$API_URL/health" "$WEB_URL/"; do
-            echo "Probing $url"
-            curl -fsS --retry 5 --retry-delay 3 --retry-all-errors "$url" > /dev/null
-          done
+        run: node .github/scripts/smoke-deployment.ts

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -84,8 +84,8 @@ The workflow and Alchemy's `prod` stage set `ENVIRONMENT=production`, enabling
 email verification and rejecting insecure auth secrets or URLs. Preserve that
 value in customer deployments.
 
-The workflow also forwards `SENTRY_DSN`, `MAINTENANCE_MODE`, and the independent
-security-evidence endpoint and token. See [operations setup](operations.md). To activate
+The workflow also forwards `SENTRY_DSN`, `MAINTENANCE_MODE`, and, when configured,
+the independent security-evidence endpoint and token. See [operations setup](operations.md). To activate
 optional providers (Stripe, Sentry, PostHog, Turnstile, Workers AI or
 OpenAI, OTLP export), add each secret to the `production` environment and
 forward it in the deploy job's `env` block. `packages/env/src/server.ts` owns

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,8 +61,8 @@ For backup configuration and executable restore commands, see
 
 ### Independent security evidence store
 
-Production web and API Workers require `SECURITY_EVIDENCE_URL` and the
-`SECURITY_EVIDENCE_TOKEN` secret. The URL must be an HTTPS service whose data,
+Production web and API Workers can use `SECURITY_EVIDENCE_URL` and the
+`SECURITY_EVIDENCE_TOKEN` secret. When configured, the URL must be an HTTPS service whose data,
 credentials, and recovery path are outside the production Cloudflare account.
 The Workers send `POST` requests with `Authorization: Bearer <token>` and
 `Content-Type: application/json`. The service must append the record

--- a/packages/env/src/server.test.ts
+++ b/packages/env/src/server.test.ts
@@ -71,10 +71,6 @@ describe('activeSocialProviders', () => {
 describe('auditRequiredEnv', () => {
   const realSecret = 'a-real-deployment-secret-at-least-32-chars-long'
   const realUrl = 'https://app.acme.test'
-  const recoveryEvidence = {
-    SECURITY_EVIDENCE_URL: 'https://evidence.acme.test/records',
-    SECURITY_EVIDENCE_TOKEN: 'independent-store-token'
-  }
 
   it('stays silent in local mode: no ENVIRONMENT means dev/test defaults are expected', () => {
     expect(auditRequiredEnv({})).toEqual({ mode: 'local', problems: [] })
@@ -104,14 +100,6 @@ describe('auditRequiredEnv', () => {
       key: 'BETTER_AUTH_URL',
       reason: 'missing'
     })
-    expect(audit.problems).toContainEqual({
-      key: 'SECURITY_EVIDENCE_URL',
-      reason: 'missing'
-    })
-    expect(audit.problems).toContainEqual({
-      key: 'SECURITY_EVIDENCE_TOKEN',
-      reason: 'missing'
-    })
   })
 
   it('rejects the local-dev default secret by value in production', () => {
@@ -119,7 +107,6 @@ describe('auditRequiredEnv', () => {
     // 40 chars, so only value rejection — not the length check — catches it.
     const audit = auditRequiredEnv({
       ENVIRONMENT: 'production',
-      ...recoveryEvidence,
       BETTER_AUTH_SECRET: 'local-dev-secret-change-me-minimum-32-chars',
       BETTER_AUTH_URL: realUrl
     })
@@ -134,7 +121,6 @@ describe('auditRequiredEnv', () => {
     // catches it.
     const audit = auditRequiredEnv({
       ENVIRONMENT: 'production',
-      ...recoveryEvidence,
       BETTER_AUTH_SECRET: 'dev-only-secret-3f8a1c9e57b24d6f8e0a4c7b9d2f16e8',
       BETTER_AUTH_URL: realUrl
     })
@@ -146,7 +132,6 @@ describe('auditRequiredEnv', () => {
   it('rejects Better Auth own fallback and short secrets', () => {
     const fallback = auditRequiredEnv({
       ENVIRONMENT: 'production',
-      ...recoveryEvidence,
       BETTER_AUTH_SECRET: 'better-auth-secret-12345678901234567890',
       BETTER_AUTH_URL: realUrl
     })
@@ -155,7 +140,6 @@ describe('auditRequiredEnv', () => {
     ])
     const short = auditRequiredEnv({
       ENVIRONMENT: 'production',
-      ...recoveryEvidence,
       BETTER_AUTH_SECRET: 'too-short-secret',
       BETTER_AUTH_URL: realUrl
     })
@@ -170,7 +154,6 @@ describe('auditRequiredEnv', () => {
     ]) {
       const audit = auditRequiredEnv({
         ENVIRONMENT: 'production',
-        ...recoveryEvidence,
         BETTER_AUTH_SECRET: realSecret,
         BETTER_AUTH_URL: url
       })
@@ -183,24 +166,10 @@ describe('auditRequiredEnv', () => {
   it('requires an https BETTER_AUTH_URL in production — http would mint non-Secure cookies', () => {
     const audit = auditRequiredEnv({
       ENVIRONMENT: 'production',
-      ...recoveryEvidence,
       BETTER_AUTH_SECRET: realSecret,
       BETTER_AUTH_URL: 'http://app.acme.test'
     })
     expect(audit.problems).toEqual([{ key: 'BETTER_AUTH_URL', reason: 'insecure' }])
-  })
-
-  it('requires an https security evidence store in production', () => {
-    const audit = auditRequiredEnv({
-      ENVIRONMENT: 'production',
-      ...recoveryEvidence,
-      SECURITY_EVIDENCE_URL: 'http://evidence.acme.test/records',
-      BETTER_AUTH_SECRET: realSecret,
-      BETTER_AUTH_URL: realUrl
-    })
-    expect(audit.problems).toEqual([
-      { key: 'SECURITY_EVIDENCE_URL', reason: 'insecure' }
-    ])
   })
 
   it('flags a production BETTER_AUTH_URL that does not parse as a URL at all', () => {
@@ -208,7 +177,6 @@ describe('auditRequiredEnv', () => {
     // scheme to check — "does not parse" is the answer, not a crash.
     const audit = auditRequiredEnv({
       ENVIRONMENT: 'production',
-      ...recoveryEvidence,
       BETTER_AUTH_SECRET: realSecret,
       BETTER_AUTH_URL: 'app.acme.test'
     })
@@ -230,7 +198,6 @@ describe('auditRequiredEnv', () => {
     expect(
       auditRequiredEnv({
         ENVIRONMENT: 'production',
-        ...recoveryEvidence,
         BETTER_AUTH_SECRET: realSecret,
         BETTER_AUTH_URL: realUrl
       })
@@ -245,7 +212,6 @@ describe('auditRequiredEnv', () => {
     expect(
       auditRequiredEnv({
         ENVIRONMENT: 'production',
-        ...recoveryEvidence,
         BETTER_AUTH_SECRET: realSecret,
         BETTER_AUTH_URL: realUrl,
         BETTER_AUTH_TRUSTED_ORIGINS:
@@ -264,7 +230,6 @@ describe('auditRequiredEnv', () => {
     ]) {
       const audit = auditRequiredEnv({
         ENVIRONMENT: 'production',
-        ...recoveryEvidence,
         BETTER_AUTH_SECRET: realSecret,
         BETTER_AUTH_URL: realUrl,
         BETTER_AUTH_TRUSTED_ORIGINS: origins

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -238,12 +238,7 @@ function isHttpsAuthUrl(value: string): boolean {
 }
 
 export type RequiredEnvProblem = {
-  readonly key:
-    | 'BETTER_AUTH_SECRET'
-    | 'BETTER_AUTH_URL'
-    | 'BETTER_AUTH_TRUSTED_ORIGINS'
-    | 'SECURITY_EVIDENCE_URL'
-    | 'SECURITY_EVIDENCE_TOKEN'
+  readonly key: 'BETTER_AUTH_SECRET' | 'BETTER_AUTH_URL' | 'BETTER_AUTH_TRUSTED_ORIGINS'
   readonly reason: 'missing' | 'placeholder' | 'too-short' | 'malformed' | 'insecure'
 }
 
@@ -327,7 +322,7 @@ function requiredEnvMode(source: RawEnvSource): RequiredEnvAudit['mode'] {
 }
 
 /**
- * Audit of the two required baseline vars, for a worker that consumes them
+ * Audit of the required baseline vars, for a worker that consumes them
  * (the web worker — auth's only consumer). `ENVIRONMENT` decides the stance:
  * unset means local development, where the shim's development values are
  * expected and the audit stays silent. A deployment that bypasses alchemy should set
@@ -364,17 +359,6 @@ export function auditRequiredEnv(source: RawEnvSource): RequiredEnvAudit {
     // every emailed link, so `http:` — or a value that does not parse as a
     // URL — is refused.
     problems.push({ key: 'BETTER_AUTH_URL', reason: 'insecure' })
-  }
-
-  if (mode === 'production') {
-    if (!hasValue(source.SECURITY_EVIDENCE_URL)) {
-      problems.push({ key: 'SECURITY_EVIDENCE_URL', reason: 'missing' })
-    } else if (!isHttpsAuthUrl(source.SECURITY_EVIDENCE_URL)) {
-      problems.push({ key: 'SECURITY_EVIDENCE_URL', reason: 'insecure' })
-    }
-    if (!hasValue(source.SECURITY_EVIDENCE_TOKEN)) {
-      problems.push({ key: 'SECURITY_EVIDENCE_TOKEN', reason: 'missing' })
-    }
   }
 
   // A malformed trusted origin silently weakens Better Auth's origin checks —


### PR DESCRIPTION
## Outcome

Make the independent security-evidence integration optional. Production workers continue to use it when configured, but missing evidence settings no longer cause the web worker to reject every request.

Replace the production deployment smoke-test shell loop with a typed TypeScript script. It retries the API health and web-root probes, and reports the final HTTP status and response body when a probe fails.

## Decisions

This PR is stacked on #327 because it includes the `.env.example` wording update from the same configuration change.

## Validation

- `pnpm run typecheck`
- `pnpm exec vitest run packages/env/src/server.test.ts` — 19 passed
- `node --test .github/scripts/smoke-deployment.test.ts` — 3 passed
- `git diff --check`

The combined web env-gate test could not load in this local environment because the `cloudflare:workers` module is unavailable outside the Worker test setup.

## Risks and remaining work

None known.
