### PR TITLE
fix(authz): enforce interactive workspace isolation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,7 @@ SSO connections belong to Workspaces. The app enforces enabled/required status a
 
 API Tokens belong to one Workspace. Only token hashes are stored; verification checks revocation, expiry, and resource entitlements. REST is token-only.
 
-MCP also accepts OAuth access tokens issued by the web Worker. The API verifies issuer and audience, re-resolves membership, and rechecks consent before writes. Consent binds a client to one Workspace. Both credentials use the same operation catalog and permission checks. See [API tokens](docs/adr/0026-workspace-api-tokens.md) and [MCP OAuth](docs/adr/0068-oauth-for-interactive-mcp-clients-beside-api-tokens.md).
+MCP also accepts OAuth access tokens issued by the web Worker. The API verifies issuer and audience, re-resolves membership, and checks the immutable Workspace ID and current consent before reads, resources, and writes. Consent binds a client to one Workspace. Both credentials use the same operation catalog and permission checks. [Interactive isolation coverage](docs/security-workspace-isolation.md) records tested operations and evidence limits. See [API tokens](docs/adr/0026-workspace-api-tokens.md) and [MCP OAuth](docs/adr/0068-oauth-for-interactive-mcp-clients-beside-api-tokens.md).
 
 ### CORS & trusted origins
 

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -13,7 +13,7 @@ Cloudflare Worker for external REST clients and MCP. Serves the `StarterApi` con
 - A handler is `observed(...)` around `enforcePermission(permission, slug)` plus one capability call. Auth and the bucket come from `BearerAuth`, so no handler reads `Authorization`.
 - Endpoints name permissions, never scopes. [`authz`](../../packages/authz/AGENTS.md) owns the scope-to-permission map, so a token and a web session resolve through one `authorize()`.
 - `provideWorkspace` builds the only request-scoped service, `WorkspaceContext`; the rest are isolate-level, reached through `HttpRouter.provideRequest`.
-- MCP JWTs use OAuth verification; other credentials use API Token verification (ADR 0068). Tokens authorize by scopes; OAuth writes require explicit `mcp:write`, current matching consent, and Member re-resolved per call. Both use the `mcp` bucket; each write also consumes `rest_write` and `guardFailureResponse`. Router middleware gates the transport; `CurrentMcpCaller` travels through Effect RPC request-fiber context to each tool. Preserve `api_token` versus OAuth `user` audit provenance.
+- MCP JWTs use OAuth verification; other credentials use API Token verification (ADR 0068). Tokens authorize by scopes; OAuth tools and resources require current matching consent, the immutable Workspace ID, and Member re-resolved per call; writes additionally require `mcp:write`. Both use the `mcp` bucket; each write also consumes `rest_write` and `guardFailureResponse`. Router middleware gates the transport; `CurrentMcpCaller` travels through Effect RPC request-fiber context to each tool. Preserve `api_token` versus OAuth `user` audit provenance.
 
 ## Boundaries
 

--- a/apps/api/src/handlers.ts
+++ b/apps/api/src/handlers.ts
@@ -1,4 +1,3 @@
-import { workspaceSuspensionOperationForPermission } from '@b2b-saas-starter/capabilities/governance/workspace-suspension'
 import { tokenPrincipal, type PermissionRequest } from '@b2b-saas-starter/authz/client'
 import { type ListPageInput } from '@b2b-saas-starter/capabilities/internal/keyset-cursor'
 import { ApiTokenRegistry } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
@@ -62,14 +61,7 @@ function workspaceOperation<A, E, R>(
     Effect.gen(function* () {
       yield* enforcePermission(permission, slug)
       const principal = yield* ApiPrincipal
-      return yield* provideWorkspace(
-        env,
-        slug,
-        body,
-        undefined,
-        'api_token',
-        workspaceSuspensionOperationForPermission(permission)
-      ).pipe(
+      return yield* provideWorkspace(env, slug, body, undefined, 'api_token').pipe(
         Effect.provideService(OperationPrincipal, tokenPrincipal(principal.scopes)),
         Effect.provideService(OperationOrigin, new URL(webRequest(request).url).origin)
       )

--- a/apps/api/src/mcp-oauth.test.ts
+++ b/apps/api/src/mcp-oauth.test.ts
@@ -83,6 +83,8 @@ function accessToken(
 ): Promise<string> {
   return new SignJWT({
     sub: 'usr_demo',
+    client_id: 'https://mcp-client.example.com/oauth/client-metadata.json',
+    starter_consent_binding: 'con_example_mcp:0',
     scope: 'openid offline_access mcp:read',
     [MCP_WORKSPACE_ID_CLAIM]: 'wrk_starter',
     [MCP_WORKSPACE_SLUG_CLAIM]: 'starter-lab',
@@ -216,31 +218,33 @@ describe('POST /mcp with an OAuth access token', () => {
       })
   )
 
-  it.effect('a member authorizes as their role, not as the token claim', () =>
-    Effect.gen(function* () {
-      const { privateKey, jwks } = yield* Effect.promise(theAuthority)
-      stubJwksFetch(jwks)
-      const handler = buildWebHandler(env).handler
-      // `usr_dev` is a plain member of the seed workspace; a member cannot
-      // read the audit log even if the token claims otherwise.
-      const token = yield* Effect.promise(() =>
-        accessToken(privateKey, {
-          sub: 'usr_dev',
-          [MCP_WORKSPACE_ROLE_CLAIM]: 'owner'
-        })
-      )
-      const res = yield* Effect.promise(() =>
-        callTool(handler, `Bearer ${token}`, 'list_audit_events')
-      )
-      const body = yield* jsonBody(res, CallToolBody)
-      expect(body.result.isError).toBe(true)
-      expect(body.result.content[0]?.text).toContain('denied:')
+  it.effect(
+    "a member cannot borrow another user's consent despite an owner role claim",
+    () =>
+      Effect.gen(function* () {
+        const { privateKey, jwks } = yield* Effect.promise(theAuthority)
+        stubJwksFetch(jwks)
+        const handler = buildWebHandler(env).handler
+        // The fixture consent belongs to usr_demo. Membership alone cannot
+        // authorize this client as usr_dev, even for an ordinary read.
+        const token = yield* Effect.promise(() =>
+          accessToken(privateKey, {
+            sub: 'usr_dev',
+            [MCP_WORKSPACE_ROLE_CLAIM]: 'owner'
+          })
+        )
+        const res = yield* Effect.promise(() =>
+          callTool(handler, `Bearer ${token}`, 'list_audit_events')
+        )
+        const body = yield* jsonBody(res, CallToolBody)
+        expect(body.result.isError).toBe(true)
+        expect(body.result.content[0]?.text).toContain('denied:')
 
-      const allowed = yield* Effect.promise(() =>
-        callTool(handler, `Bearer ${token}`, 'list_notifications')
-      )
-      expect((yield* jsonBody(allowed, CallToolBody)).result.isError).toBeUndefined()
-    })
+        const allowed = yield* Effect.promise(() =>
+          callTool(handler, `Bearer ${token}`, 'list_notifications')
+        )
+        expect((yield* jsonBody(allowed, CallToolBody)).result.isError).toBe(true)
+      })
   )
 
   it.effect('the key set is fetched once across requests', () =>

--- a/apps/api/src/mcp-write-authority.test.ts
+++ b/apps/api/src/mcp-write-authority.test.ts
@@ -232,12 +232,15 @@ for (const revoke of ['revoke', 'reduceGrant', 'oldCredential'] satisfies Readon
           (yield* call(client, 'create_api_token', { name: 'first', scopes: ['read'] }))
             .isError
         ).not.toBe(true)
-        const before = yield* call(client, 'list_audit_events')
+        const observer = mcpClient(harness.handler, `Bearer ${SEED_API_TOKEN}`)
+        yield* Effect.promise(() => observer.initialize())
+        const before = yield* call(observer, 'list_audit_events')
         harness[revoke]()
         expect(
           (yield* call(client, 'delete_webhook', { endpointId: 'wh_release' })).isError
         ).toBe(true)
-        expect(yield* call(client, 'list_audit_events')).toEqual(before)
+        expect((yield* call(client, 'list_audit_events')).isError).toBe(true)
+        expect(yield* call(observer, 'list_audit_events')).toEqual(before)
       })
   )
 }

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -3,20 +3,14 @@ import { WorkspaceMembership } from '@b2b-saas-starter/capabilities/governance/w
 import { AuditEventLog } from '@b2b-saas-starter/capabilities/governance/audit-event-log'
 import { WebhookEndpoints } from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
 import { WorkspaceExports } from '@b2b-saas-starter/capabilities/governance/workspace-export'
-import {
-  WorkspaceSuspensionService,
-  workspaceSuspensionOperationForPermission,
-  type WorkspaceSuspensionOperation
-} from '@b2b-saas-starter/capabilities/governance/workspace-suspension'
+import { WorkspaceSuspensionService } from '@b2b-saas-starter/capabilities/governance/workspace-suspension'
 import { McpClientConnections } from '@b2b-saas-starter/capabilities/developer-platform/mcp-client-connections'
 import { mcpMutationOperations } from './mcp-mutations.ts'
 import { clientKey } from '@b2b-saas-starter/rate-limit'
 import {
-  memberPrincipal,
-  tokenPrincipal,
-  type Principal
-} from '@b2b-saas-starter/authz/client'
-import { requirePermission } from '@b2b-saas-starter/authz/guard'
+  MCP_READ_SCOPE,
+  MCP_WRITE_SCOPE
+} from '@b2b-saas-starter/authz/mcp-access-token'
 import {
   mirroredRestPath,
   READ_OPERATIONS,
@@ -54,11 +48,11 @@ import {
   ToolJsonSchema as ToolJsonSchemaCodec
 } from 'effect/unstable/ai/McpSchema'
 
-import { WorkspaceContext } from '@b2b-saas-starter/capabilities/workspace-context'
+import { type WorkspaceContext } from '@b2b-saas-starter/capabilities/workspace-context'
 
 import {
   authenticateMcpCaller,
-  authorizeMcpMutation,
+  authorizeMcpOperation,
   enforceRateLimitKey,
   bearerToken,
   verifyMcpCredential,
@@ -371,29 +365,6 @@ function requireCaller(): Effect.Effect<McpCaller, InternalError> {
 }
 
 /**
- * Who a tool authorizes as. An API Token is its scopes. An OAuth caller is the
- * Member the workspace layer just resolved — from the membership table, not
- * from the token's role claim — so a member removed since consenting is
- * refused with `WorkspaceNotFound` while the layer builds, and a role change
- * applies on the next call. (The `ctx.actor === null` half is the context
- * type's honesty: this route always builds the layer with the caller's
- * `ActorRef`, so the null case is not reachable here.)
- */
-function callerPrincipal(
-  caller: McpCaller
-): Effect.Effect<Principal | null, never, WorkspaceContext> {
-  if (caller.kind === 'token') {
-    return Effect.succeed(tokenPrincipal(caller.token.scopes))
-  }
-  return Effect.map(WorkspaceContext, (ctx) => {
-    if (ctx.actor === null) {
-      return null
-    }
-    return memberPrincipal(ctx.actor.role)
-  })
-}
-
-/**
  * Runs one operation's guard + read on the caller's workspace: the workspace
  * layer resolves this call's tenant (and, for an OAuth caller, proves the
  * Member still belongs to it). `Effect.result` sits OUTSIDE the workspace
@@ -407,18 +378,16 @@ function bridgedRead(
   body: Effect.Effect<
     unknown,
     CapabilityReadError,
-    CapabilityReadServices | WorkspaceContext
-  >,
-  operation: WorkspaceSuspensionOperation = 'product'
-): Effect.Effect<ToolOutcome, never, CapabilityReadServices> {
+    CapabilityReadServices | McpClientConnections | WorkspaceContext
+  >
+): Effect.Effect<ToolOutcome, never, CapabilityReadServices | McpClientConnections> {
   return Effect.result(
     provideWorkspace(
       env,
       caller.token.workspaceSlug,
       body,
       mcpCallerActor(caller),
-      mcpCallerActorType(caller),
-      operation
+      mcpCallerActorType(caller)
     )
   )
 }
@@ -476,14 +445,17 @@ function registerTools(env: ApiEnv) {
     const registry = yield* McpServer
     // The isolate-level capability services, captured once: tool invocations
     // resolve them from this context rather than rebuilding any graph.
-    const services = (yield* Effect.context<CapabilityReadServices>()).pipe(
+    const services = (yield* Effect.context<
+      CapabilityReadServices | McpClientConnections
+    >()).pipe(
       Context.pick(
         NotificationFeed,
         WorkspaceMembership,
         ApiTokenRegistry,
         WebhookEndpoints,
         WorkspaceSuspensionService,
-        AuditEventLog
+        AuditEventLog,
+        McpClientConnections
       )
     )
 
@@ -500,24 +472,16 @@ function registerTools(env: ApiEnv) {
             const caller = yield* requireCaller()
             const invoke = yield* decodeOperationInput(operation, payload)
             // One guard + one capability read, on the caller's workspace.
-            // `requirePermission` needs a Scope, which only exists inside the
+            // The operation guard needs a Scope, which only exists inside the
             // Effect runtime, hence the scoped wrapper here rather than in the
             // capability itself. The decoded input rides to the same read the
             // REST route serves — the two surfaces page identically.
             const guarded = Effect.gen(function* () {
-              yield* requirePermission(
-                yield* callerPrincipal(caller),
-                operation.permission
-              )
+              yield* authorizeMcpOperation(caller, operation.permission, MCP_READ_SCOPE)
               return yield* invoke
             }).pipe(Effect.scoped)
 
-            const outcome = yield* bridgedRead(
-              env,
-              caller,
-              guarded,
-              workspaceSuspensionOperationForPermission(operation.permission)
-            )
+            const outcome = yield* bridgedRead(env, caller, guarded)
             return outcomeToToolResult(outcome)
           }).pipe(
             // Defects at this seam answer with the generic body, the way a
@@ -602,9 +566,10 @@ function registerMutationTools(env: ApiEnv) {
             const caller = verified.success
             const invoke = yield* operation.decode(payload ?? {}).pipe(invalidParams)
             const guarded = Effect.gen(function* () {
-              const principal = yield* authorizeMcpMutation(
+              const principal = yield* authorizeMcpOperation(
                 caller,
-                operation.permission
+                operation.permission,
+                MCP_WRITE_SCOPE
               )
               return yield* invoke.pipe(
                 Effect.provideService(OperationPrincipal, principal),
@@ -617,8 +582,7 @@ function registerMutationTools(env: ApiEnv) {
                 caller.token.workspaceSlug,
                 guarded,
                 mcpCallerActor(caller),
-                mcpCallerActorType(caller),
-                workspaceSuspensionOperationForPermission(operation.permission)
+                mcpCallerActorType(caller)
               )
             )
             return outcomeToToolResult(outcome)
@@ -659,9 +623,10 @@ function registerOverviewResource(env: ApiEnv) {
     content: Effect.gen(function* () {
       const caller = yield* requireCaller()
       const guarded = Effect.gen(function* () {
-        yield* requirePermission(
-          yield* callerPrincipal(caller),
-          READ_OPERATIONS.overview.permission
+        yield* authorizeMcpOperation(
+          caller,
+          READ_OPERATIONS.overview.permission,
+          MCP_READ_SCOPE
         )
         return yield* READ_OPERATIONS.overview.read()
       }).pipe(Effect.scoped)

--- a/apps/api/src/request-guards.ts
+++ b/apps/api/src/request-guards.ts
@@ -1,8 +1,7 @@
 import { McpClientConnections } from '@b2b-saas-starter/capabilities/developer-platform/mcp-client-connections'
 import {
   WorkspaceSuspensionService,
-  workspaceSuspensionOperationForPermission,
-  type WorkspaceSuspensionOperation
+  workspaceSuspensionOperationForPermission
 } from '@b2b-saas-starter/capabilities/governance/workspace-suspension'
 import { withHttpInvocation } from '@b2b-saas-starter/logger'
 import { requirePermission } from '@b2b-saas-starter/authz/guard'
@@ -22,7 +21,8 @@ import {
   type ActorRef
 } from '@b2b-saas-starter/capabilities/workspace-context'
 import {
-  MCP_WRITE_SCOPE,
+  type MCP_READ_SCOPE,
+  type MCP_WRITE_SCOPE,
   type McpAccessTokenPrincipal
 } from '@b2b-saas-starter/authz/mcp-access-token'
 import {
@@ -318,7 +318,8 @@ export function webRequest(request: HttpServerRequest.HttpServerRequest): Reques
 }
 
 /**
- * Resolves the request's workspace and provides it to `body`.
+ * Resolves the request's workspace and provides it to `body`. REST and MCP
+ * operation guards enforce suspension after proving caller authority.
  *
  * Only `WorkspaceContext` is built here. Every other capability service is
  * request-independent and lives on the isolate-level layer `http.ts` hands to
@@ -335,15 +336,9 @@ export function provideWorkspace<A, E, R>(
   slug: string,
   body: Effect.Effect<A, E, R>,
   actor: ActorRef | undefined,
-  actorType: AuditActorTypeValue,
-  operation: WorkspaceSuspensionOperation = 'product'
+  actorType: AuditActorTypeValue
 ) {
-  return Effect.gen(function* () {
-    const ctx = yield* WorkspaceContext
-    const suspension = yield* WorkspaceSuspensionService
-    yield* suspension.requireAllowed(ctx.workspace.id, operation)
-    return yield* body
-  }).pipe(
+  return body.pipe(
     Effect.provide(selectWorkspaceContextLayer(starterEnv(env), slug, actor, actorType))
   )
 }
@@ -406,10 +401,11 @@ export function bearerAuth(env: ApiEnv): Layer.Layer<BearerAuth> {
   )
 }
 
-/** Current workspace identity, role, and consent constrain every MCP mutation. */
-export const authorizeMcpMutation = Effect.fn('Mcp.authorizeMutation')(function* (
+/** Current Workspace identity, role, and consent constrain every MCP operation. */
+export const authorizeMcpOperation = Effect.fn('Mcp.authorizeOperation')(function* (
   caller: McpCaller,
-  permission: PermissionRequest
+  permission: PermissionRequest,
+  requiredScope: typeof MCP_READ_SCOPE | typeof MCP_WRITE_SCOPE
 ) {
   const ctx = yield* WorkspaceContext
   if (ctx.workspace.id !== caller.token.workspaceId) {
@@ -429,7 +425,7 @@ export const authorizeMcpMutation = Effect.fn('Mcp.authorizeMutation')(function*
     principal = memberPrincipal(ctx.actor.role)
     const token = caller.token
     if (
-      !token.scopes.includes(MCP_WRITE_SCOPE) ||
+      !token.scopes.includes(requiredScope) ||
       token.clientId === undefined ||
       token.consentBinding === undefined
     ) {
@@ -445,7 +441,7 @@ export const authorizeMcpMutation = Effect.fn('Mcp.authorizeMutation')(function*
     })
     if (
       grant?.binding !== token.consentBinding ||
-      !grant.scopes.includes(MCP_WRITE_SCOPE)
+      !grant.scopes.includes(requiredScope)
     ) {
       return yield* new AuthorizationDenied({
         reason: AUTHORIZATION_DENIED_REASONS.insufficientPermission
@@ -453,5 +449,10 @@ export const authorizeMcpMutation = Effect.fn('Mcp.authorizeMutation')(function*
     }
   }
   yield* requirePermission(principal, permission)
+  const suspension = yield* WorkspaceSuspensionService
+  yield* suspension.requireAllowed(
+    ctx.workspace.id,
+    workspaceSuspensionOperationForPermission(permission)
+  )
   return principal
 })

--- a/apps/api/src/workspace-isolation-mcp.live.test.ts
+++ b/apps/api/src/workspace-isolation-mcp.live.test.ts
@@ -1,0 +1,296 @@
+import { McpClientConnections } from '@b2b-saas-starter/capabilities/developer-platform/mcp-client-connections'
+import { RateLimiter } from '@b2b-saas-starter/api'
+import {
+  LIVE_SUITE_TIMEOUT,
+  TestDatabase,
+  TestD1
+} from '@b2b-saas-starter/capabilities/testing/live-harness'
+import { selectCapabilitiesLayer } from '@b2b-saas-starter/capabilities/runtime'
+import { expect, layer } from '@effect/vitest'
+import { Effect, Layer, Schema } from 'effect'
+import { HttpRouter } from 'effect/unstable/http'
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from 'jose'
+import { mcpProtocolLayer } from './mcp.ts'
+import { makeOAuthTokenVerifier, OAuthTokenVerifier } from './oauth-access-token.ts'
+import { jsonBody, mcpClient } from './test-utils.ts'
+
+const decodeRecord = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(Schema.Struct({ id: Schema.String }))
+)
+const rpcError = Schema.Struct({
+  error: Schema.Struct({ code: Schema.Number, message: Schema.String }),
+  result: Schema.optional(Schema.Json)
+})
+const resourceResult = Schema.Struct({
+  result: Schema.Struct({
+    contents: Schema.Array(Schema.Struct({ text: Schema.String }))
+  })
+})
+const envelope = Schema.Struct({
+  result: Schema.Struct({
+    isError: Schema.optional(Schema.Boolean),
+    content: Schema.Array(Schema.Struct({ text: Schema.String })),
+    structuredContent: Schema.optional(Schema.Json)
+  })
+})
+function call(
+  client: ReturnType<typeof mcpClient>,
+  name: string,
+  args: Schema.Json = {}
+) {
+  return Effect.promise(() => client.rpc('tools/call', { name, arguments: args })).pipe(
+    Effect.flatMap((response) => jsonBody(response, envelope)),
+    Effect.map((body) => body.result)
+  )
+}
+function resource(client: ReturnType<typeof mcpClient>) {
+  return Effect.promise(() =>
+    client.rpc('resources/read', { uri: 'workspace://overview' })
+  )
+}
+function expectResourceDenied(client: ReturnType<typeof mcpClient>) {
+  return resource(client).pipe(
+    Effect.flatMap((response) => jsonBody(response, rpcError)),
+    Effect.map((body) => {
+      expect(body.error.code).toBe(-32_603)
+      expect(body.error.message).toContain('denied:')
+      expect(body.error.message).not.toContain('private.example')
+      expect(body.result).toBeUndefined()
+      return body
+    })
+  )
+}
+function execute(sql: string, ...values: ReadonlyArray<string>) {
+  return Effect.flatMap(TestD1, (db) =>
+    Effect.promise(() =>
+      db
+        .prepare(sql)
+        .bind(...values)
+        .run()
+    )
+  )
+}
+
+layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })(
+  'MCP OAuth Workspace isolation',
+  (it) => {
+    it.effect(
+      'AC-2.1/AC-2.2/AC-2.3: one user in two Workspaces cannot reuse consent or stale Workspace authority',
+      () =>
+        Effect.gen(function* () {
+          const DB = yield* TestD1
+          yield* execute(`INSERT INTO workspace_members (id,workspaceId,userId,role) VALUES
+      ('mem_isolation_multi_a','wrk_dev_contract','usr_joiner','owner'),
+      ('mem_isolation_multi_b','wrk_other','usr_joiner','owner'),
+      ('mem_isolation_other','wrk_other','usr_outsider','owner')`)
+          yield* execute(
+            `INSERT INTO oauth_client (id,clientId,redirectUris,disabled) VALUES ('client-isolation','isolation-client','[]',0)`
+          )
+          yield* execute(`INSERT INTO oauth_consent (id,userId,clientId,referenceId,scopes) VALUES
+      ('consent-isolation-a','usr_joiner','isolation-client','wrk_dev_contract','["mcp:read","mcp:write"]'),
+      ('consent-isolation-b','usr_joiner','isolation-client','wrk_other','["mcp:read","mcp:write"]'),
+      ('consent-isolation-other','usr_outsider','isolation-client','wrk_other','["mcp:read","mcp:write"]'),
+      ('consent-isolation-owner','usr_owner','isolation-client','wrk_dev_contract','["mcp:read"]')`)
+          const issuer = 'https://issuer.test/api/auth'
+          const audience = 'https://api.test/mcp'
+          const keys = yield* Effect.promise(() => generateKeyPair('EdDSA'))
+          const jwk = yield* Effect.promise(() => exportJWK(keys.publicKey))
+          const { handler } = HttpRouter.toWebHandler(
+            mcpProtocolLayer({ DB }).pipe(
+              Layer.provide(
+                Layer.mergeAll(
+                  selectCapabilitiesLayer({ DB }),
+                  Layer.succeed(OAuthTokenVerifier)(
+                    makeOAuthTokenVerifier(
+                      { issuer, audience },
+                      createLocalJWKSet({ keys: [jwk] })
+                    )
+                  ),
+                  Layer.succeed(RateLimiter)({ take: () => Effect.succeed(true) })
+                )
+              )
+            ),
+            { disableLogger: true }
+          )
+          function clientFor(
+            userId: string,
+            workspaceId: string,
+            workspaceSlug: string,
+            consent: string,
+            scopes = 'mcp:read mcp:write'
+          ) {
+            return Effect.promise(() =>
+              new SignJWT({
+                sub: userId,
+                client_id: 'isolation-client',
+                scope: scopes,
+                starter_workspace_id: workspaceId,
+                starter_workspace_slug: workspaceSlug,
+                starter_workspace_role: 'owner',
+                starter_consent_binding: `${consent}:0`
+              })
+                .setProtectedHeader({ alg: 'EdDSA' })
+                .setIssuer(issuer)
+                .setAudience(audience)
+                .setIssuedAt()
+                .setExpirationTime('1h')
+                .sign(keys.privateKey)
+            ).pipe(Effect.map((jwt) => mcpClient(handler, `Bearer ${jwt}`)))
+          }
+          const a = yield* clientFor(
+            'usr_joiner',
+            'wrk_dev_contract',
+            'dev-contract-lab',
+            'consent-isolation-a'
+          )
+          const b = yield* clientFor(
+            'usr_joiner',
+            'wrk_other',
+            'other-lab',
+            'consent-isolation-b'
+          )
+          const other = yield* clientFor(
+            'usr_outsider',
+            'wrk_other',
+            'other-lab',
+            'consent-isolation-other'
+          )
+          const owner = yield* clientFor(
+            'usr_owner',
+            'wrk_dev_contract',
+            'dev-contract-lab',
+            'consent-isolation-owner',
+            'mcp:read'
+          )
+          for (const client of [a, b, other, owner]) {
+            yield* Effect.promise(() => client.initialize())
+          }
+          for (const client of [a, b, other, owner]) {
+            expect((yield* call(client, 'get_workspace_overview')).isError).not.toBe(
+              true
+            )
+          }
+          const overviewResource = yield* resource(owner).pipe(
+            Effect.flatMap((response) => jsonBody(response, resourceResult))
+          )
+          expect(overviewResource.result.contents[0]?.text).toContain(
+            'dev-contract-lab'
+          )
+          expect(
+            (yield* call(owner, 'create_webhook', {
+              url: 'https://blocked.example',
+              events: ['api_token.created']
+            })).isError
+          ).toBe(true)
+          const created = yield* call(other, 'create_webhook', {
+            url: 'https://private.example/mcp',
+            events: ['api_token.created']
+          })
+          expect(created.isError).not.toBe(true)
+          const endpoint = yield* decodeRecord(created.content[0]?.text)
+          const before = yield* call(b, 'list_webhooks')
+          const auditBefore = yield* call(b, 'list_audit_events')
+          const rejected = yield* call(a, 'update_webhook', {
+            endpointId: endpoint.id,
+            enabled: false,
+            workspaceSlug: 'other-lab'
+          })
+          expect(rejected.isError).toBe(true)
+          expect(rejected.content[0]?.text).toBe('webhook endpoint not found')
+          expect(
+            (yield* call(a, 'list_webhook_deliveries', { endpointId: endpoint.id }))
+              .content[0]?.text
+          ).toBe('[]')
+          // Even a signed token naming B must not borrow a grant issued for A.
+          const reused = yield* clientFor(
+            'usr_joiner',
+            'wrk_other',
+            'other-lab',
+            'consent-isolation-a'
+          )
+          yield* Effect.promise(() => reused.initialize())
+          expect(
+            (yield* call(reused, 'delete_webhook', { endpointId: endpoint.id })).isError
+          ).toBe(true)
+          expect((yield* call(reused, 'get_workspace_overview')).isError).toBe(true)
+          yield* expectResourceDenied(reused)
+          expect(yield* call(b, 'list_webhooks')).toEqual(before)
+          expect(yield* call(b, 'list_audit_events')).toEqual(auditBefore)
+          // Current membership wins over the owner role stamped in this same JWT.
+          yield* execute(
+            `UPDATE workspace_members SET role='member' WHERE id='mem_isolation_multi_b'`
+          )
+          expect((yield* call(b, 'list_webhooks')).isError).toBe(true)
+          expect(
+            (yield* call(b, 'delete_webhook', { endpointId: endpoint.id })).isError
+          ).toBe(true)
+          expect((yield* call(b, 'get_workspace_overview')).isError).not.toBe(true)
+          expect((yield* call(b, 'list_notifications')).isError).not.toBe(true)
+          yield* execute(
+            `DELETE FROM workspace_members WHERE id='mem_isolation_multi_b'`
+          )
+          const removed = yield* call(b, 'get_workspace_overview')
+          expect(removed.isError).toBe(true)
+          expect(removed.content[0]?.text).toBe('workspace not found')
+          expect(removed.structuredContent).toBeUndefined()
+          expect((yield* call(a, 'get_workspace_overview')).isError).not.toBe(true)
+          expect(yield* call(other, 'list_webhooks')).toEqual(before)
+          const revoked = yield* Effect.flatMap(McpClientConnections, (connections) =>
+            connections.revoke({
+              userId: 'usr_joiner',
+              connectionId: 'consent-isolation-a'
+            })
+          ).pipe(Effect.provide(selectCapabilitiesLayer({ DB })))
+          expect(revoked).toBe(true)
+          const revokedRead = yield* call(a, 'get_workspace_overview')
+          expect(revokedRead.isError).toBe(true)
+          yield* expectResourceDenied(a)
+          yield* execute(
+            `INSERT INTO oauth_consent (id,userId,clientId,referenceId,scopes) VALUES ('consent-isolation-a-new','usr_joiner','isolation-client','wrk_dev_contract','["mcp:read","mcp:write"]')`
+          )
+          const restored = yield* clientFor(
+            'usr_joiner',
+            'wrk_dev_contract',
+            'dev-contract-lab',
+            'consent-isolation-a-new'
+          )
+          yield* Effect.promise(() => restored.initialize())
+          expect((yield* call(restored, 'list_webhooks')).isError).not.toBe(true)
+          // Reassigning a slug must not retarget an already issued token to B.
+          yield* execute(
+            `INSERT INTO workspace_members (id,workspaceId,userId,role) VALUES ('mem_isolation_multi_b','wrk_other','usr_joiner','owner')`
+          )
+          yield* execute(
+            `UPDATE workspaces SET slug='renamed-a' WHERE id='wrk_dev_contract'`
+          )
+          yield* execute(
+            `UPDATE workspaces SET slug='dev-contract-lab' WHERE id='wrk_other'`
+          )
+          for (const status of ['active', 'suspended']) {
+            yield* execute(
+              'UPDATE workspaces SET suspensionStatus=? WHERE id=?',
+              status,
+              'wrk_other'
+            )
+            const retargeted = yield* call(restored, 'list_webhooks')
+            expect(retargeted.isError).toBe(true)
+            expect(retargeted.content[0]?.text).not.toContain('private.example')
+            expect(retargeted.structuredContent).toBeUndefined()
+            yield* expectResourceDenied(restored)
+          }
+          yield* execute(
+            `UPDATE workspaces SET suspensionStatus='active' WHERE id='wrk_other'`
+          )
+          const rebound = yield* clientFor(
+            'usr_joiner',
+            'wrk_other',
+            'dev-contract-lab',
+            'consent-isolation-b'
+          )
+          yield* Effect.promise(() => rebound.initialize())
+          expect(yield* call(rebound, 'list_webhooks')).toEqual(before)
+        }),
+      120_000
+    )
+  }
+)

--- a/apps/api/src/workspace-isolation-rest.live.test.ts
+++ b/apps/api/src/workspace-isolation-rest.live.test.ts
@@ -1,0 +1,304 @@
+import { hashApiToken } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
+import {
+  LIVE_SUITE_TIMEOUT,
+  TestDatabase,
+  TestD1
+} from '@b2b-saas-starter/capabilities/testing/live-harness'
+import { expect, layer } from '@effect/vitest'
+import { Effect, Schema } from 'effect'
+import { buildWebHandler } from './http.ts'
+import { jsonBody } from './test-utils.ts'
+
+const record = Schema.Struct({ id: Schema.String })
+const page = Schema.Struct({
+  items: Schema.Array(record),
+  nextCursor: Schema.NullOr(Schema.String)
+})
+const allow = { limit: () => Promise.resolve({ success: true }) }
+
+layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })(
+  'REST Workspace isolation',
+  (it) => {
+    it.effect(
+      'AC-2.1/AC-2.2/AC-2.3: substituted Workspace and record IDs disclose nothing and leave foreign state intact',
+      () =>
+        Effect.gen(function* () {
+          const DB = yield* TestD1
+          const own = 'bsk_isolation_rest_own'
+          const foreign = 'bsk_isolation_rest_foreign'
+          const reader = 'bsk_isolation_rest_reader'
+          for (const [id, workspaceId, token, scopes] of [
+            ['tok_isolation_own', 'wrk_dev_contract', own, '["admin"]'],
+            ['tok_isolation_foreign', 'wrk_other', foreign, '["admin"]'],
+            ['tok_isolation_reader', 'wrk_dev_contract', reader, '["read"]']
+          ] satisfies ReadonlyArray<readonly [string, string, string, string]>) {
+            const hash = yield* Effect.promise(() => hashApiToken(token))
+            yield* Effect.promise(() =>
+              DB.prepare(
+                `INSERT INTO api_tokens (id,workspace_id,name,token_prefix,token_hash,scopes,created_at) VALUES (?, ?, 'Isolation', 'bsk_test', ?, ?, '2026-01-01T00:00:00Z')`
+              )
+                .bind(id, workspaceId, hash, scopes)
+                .run()
+            )
+          }
+          yield* Effect.promise(() =>
+            DB.prepare(`INSERT INTO notifications (id,workspace_id,title,message,created_at) VALUES
+            ('not_rest_a1','wrk_dev_contract','Own first','Own','2026-01-01T00:00:00Z'),
+            ('not_rest_a2','wrk_dev_contract','Own second','Own','2026-01-02T00:00:00Z'),
+            ('not_rest_b1','wrk_other','Private first','Private','2026-01-01T00:00:00Z'),
+            ('not_rest_b2','wrk_other','Private second','Private','2026-01-02T00:00:00Z')`).run()
+          )
+          let queued = 0
+          const { handler } = buildWebHandler({
+            DB,
+            RATE_LIMITER_REST: allow,
+            RATE_LIMITER_REST_WRITE: allow,
+            WEBHOOK_QUEUE: {
+              send: () => {
+                queued += 1
+                return Promise.resolve()
+              },
+              sendBatch: () => Promise.resolve()
+            }
+          })
+          function request(
+            token: string,
+            slug: string,
+            path: string,
+            method = 'GET',
+            body?: string
+          ) {
+            const options: RequestInit = {
+              method,
+              headers: {
+                authorization: `Bearer ${token}`,
+                'content-type': 'application/json'
+              }
+            }
+            if (body !== undefined) {
+              options.body = body
+            }
+            return Effect.promise(() =>
+              handler(
+                new Request(`https://api.test/workspaces/${slug}/${path}`, options)
+              )
+            )
+          }
+          const created = yield* request(
+            foreign,
+            'other-lab',
+            'webhooks',
+            'POST',
+            '{"url":"https://private.example/hook","events":["api_token.created"]}'
+          )
+          expect(created.status).toBe(201)
+          const endpoint = yield* jsonBody(created, record)
+          const ownCreated = yield* request(
+            own,
+            'dev-contract-lab',
+            'webhooks',
+            'POST',
+            '{"url":"https://own.example/hook","events":["api_token.created"]}'
+          )
+          expect(ownCreated.status).toBe(201)
+          const ownEndpoint = yield* jsonBody(ownCreated, record)
+          expect((yield* request(reader, 'dev-contract-lab', 'overview')).status).toBe(
+            200
+          )
+          expect(
+            (yield* request(
+              reader,
+              'dev-contract-lab',
+              `webhooks/${ownEndpoint.id}`,
+              'DELETE'
+            )).status
+          ).toBe(403)
+          const sent = yield* request(
+            foreign,
+            'other-lab',
+            `webhooks/${endpoint.id}/test-event`,
+            'POST'
+          )
+          expect(sent.status).toBe(201)
+          const delivery = yield* jsonBody(
+            sent,
+            Schema.Struct({ deliveryId: Schema.String })
+          )
+          yield* Effect.promise(() =>
+            DB.prepare(
+              `INSERT INTO webhook_delivery_attempts (id,delivery_id,attempts,phase,status,attempted_at,response_body) VALUES ('attempt_rest_foreign',?,1,'http','failed','2026-01-01T00:00:00Z','Private receiver response')`
+            )
+              .bind(delivery.deliveryId)
+              .run()
+          )
+          const foreignDeliveries = yield* request(
+            foreign,
+            'other-lab',
+            `webhooks/${endpoint.id}/deliveries`
+          ).pipe(Effect.flatMap((response) => jsonBody(response, Schema.Array(record))))
+          expect(foreignDeliveries).toEqual([{ id: delivery.deliveryId }])
+          const foreignAttempts = yield* request(
+            foreign,
+            'other-lab',
+            `webhooks/deliveries/${delivery.deliveryId}/attempts`
+          ).pipe(
+            Effect.flatMap((response) =>
+              jsonBody(
+                response,
+                Schema.Array(
+                  Schema.Struct({
+                    id: Schema.String,
+                    responseBody: Schema.NullOr(Schema.String)
+                  })
+                )
+              )
+            )
+          )
+          expect(foreignAttempts).toEqual([
+            { id: 'attempt_rest_foreign', responseBody: 'Private receiver response' }
+          ])
+          const before = yield* request(foreign, 'other-lab', 'webhooks').pipe(
+            Effect.flatMap((r) => jsonBody(r, Schema.Json))
+          )
+          const auditBefore = yield* request(foreign, 'other-lab', 'audit-events').pipe(
+            Effect.flatMap((r) => jsonBody(r, Schema.Json))
+          )
+          const foreignPage = yield* request(
+            foreign,
+            'other-lab',
+            'notifications?limit=1'
+          ).pipe(Effect.flatMap((response) => jsonBody(response, page)))
+          expect(foreignPage.items).toEqual([{ id: 'not_rest_b2' }])
+          expect(foreignPage.nextCursor).not.toBeNull()
+          const cursor = encodeURIComponent(foreignPage.nextCursor ?? '')
+          const resumed = yield* request(
+            foreign,
+            'other-lab',
+            `notifications?limit=1&cursor=${cursor}`
+          ).pipe(Effect.flatMap((response) => jsonBody(response, page)))
+          expect(resumed.items).toEqual([{ id: 'not_rest_b1' }])
+          expect(resumed.nextCursor).toBeNull()
+          const substituted = yield* request(
+            own,
+            'dev-contract-lab',
+            `notifications?limit=10&cursor=${cursor}`
+          ).pipe(Effect.flatMap((response) => jsonBody(response, page)))
+          expect(substituted.items.map((item) => item.id)).toEqual([
+            'not_rest_a2',
+            'not_rest_a1'
+          ])
+          expect(substituted.nextCursor).toBeNull()
+          const queuedBefore = queued
+          for (const slug of ['other-lab', 'missing-lab']) {
+            for (const path of [
+              'overview',
+              'webhooks?limit=1',
+              'audit-events?limit=1',
+              `webhooks/${endpoint.id}/deliveries`
+            ]) {
+              const denied = yield* request(own, slug, path)
+              expect(denied.status).toBe(403)
+              expect(yield* jsonBody(denied, Schema.Json)).toEqual({
+                _tag: 'AuthorizationDenied',
+                reason: 'token_workspace_mismatch'
+              })
+            }
+          }
+          for (const [method, suffix, body] of [
+            ['PATCH', '', '{"enabled":false}'],
+            ['DELETE', '', undefined],
+            ['POST', '/rotate-secret', undefined],
+            ['POST', '/test-event', undefined]
+          ] satisfies ReadonlyArray<readonly [string, string, string | undefined]>) {
+            const foreignResult = yield* request(
+              own,
+              'dev-contract-lab',
+              `webhooks/${endpoint.id}${suffix}`,
+              method,
+              body
+            )
+            const absentResult = yield* request(
+              own,
+              'dev-contract-lab',
+              `webhooks/missing${suffix}`,
+              method,
+              body
+            )
+            expect(foreignResult.status).toBe(404)
+            expect(yield* jsonBody(foreignResult, Schema.Json)).toEqual({
+              _tag: 'WebhookEndpointNotFound',
+              endpointId: endpoint.id
+            })
+            expect(yield* jsonBody(absentResult, Schema.Json)).toEqual({
+              _tag: 'WebhookEndpointNotFound',
+              endpointId: 'missing'
+            })
+          }
+          for (const path of [
+            `webhooks/${endpoint.id}/deliveries`,
+            `webhooks/deliveries/${delivery.deliveryId}/attempts`
+          ]) {
+            const hidden = yield* request(own, 'dev-contract-lab', path)
+            expect(hidden.status).toBe(200)
+            expect(yield* jsonBody(hidden, Schema.Json)).toEqual([])
+          }
+          const replay = yield* request(
+            own,
+            'dev-contract-lab',
+            `webhooks/deliveries/${delivery.deliveryId}/replay`,
+            'POST'
+          )
+          expect(replay.status).toBe(404)
+          const ownPage = yield* request(
+            own,
+            'dev-contract-lab',
+            'webhooks?limit=1'
+          ).pipe(Effect.flatMap((r) => jsonBody(r, page)))
+          expect(ownPage.items).toEqual([{ id: ownEndpoint.id }])
+          expect(ownPage.nextCursor).toBeNull()
+          expect(
+            yield* request(foreign, 'other-lab', 'webhooks').pipe(
+              Effect.flatMap((r) => jsonBody(r, Schema.Json))
+            )
+          ).toEqual(before)
+          expect(
+            yield* request(foreign, 'other-lab', 'audit-events').pipe(
+              Effect.flatMap((r) => jsonBody(r, Schema.Json))
+            )
+          ).toEqual(auditBefore)
+          expect(queued).toBe(queuedBefore)
+          expect(
+            (yield* request(
+              own,
+              'dev-contract-lab',
+              'api-tokens/tok_isolation_foreign',
+              'DELETE'
+            )).status
+          ).toBe(200)
+          expect((yield* request(foreign, 'other-lab', 'overview')).status).toBe(200)
+          expect(
+            (yield* request(
+              own,
+              'dev-contract-lab',
+              'api-tokens/tok_isolation_own',
+              'DELETE'
+            )).status
+          ).toBe(200)
+          expect((yield* request(own, 'dev-contract-lab', 'overview')).status).toBe(401)
+          expect(
+            (yield* request(
+              own,
+              'dev-contract-lab',
+              `webhooks/${ownEndpoint.id}`,
+              'DELETE'
+            )).status
+          ).toBe(401)
+          const retained = yield* request(reader, 'dev-contract-lab', 'webhooks').pipe(
+            Effect.flatMap((response) => jsonBody(response, page))
+          )
+          expect(retained.items).toEqual([{ id: ownEndpoint.id }])
+        }),
+      120_000
+    )
+  }
+)

--- a/apps/api/src/workspace-suspension.live.test.ts
+++ b/apps/api/src/workspace-suspension.live.test.ts
@@ -57,6 +57,12 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })(
       () =>
         Effect.gen(function* () {
           const DB = yield* TestD1
+          yield* execute(
+            `INSERT INTO oauth_client (id,clientId,redirectUris,disabled) VALUES ('client-suspension','suspension-client','[]',0)`
+          )
+          yield* execute(
+            `INSERT INTO oauth_consent (id,userId,clientId,referenceId,scopes) VALUES ('consent-suspension','usr_owner','suspension-client','wrk_dev_contract','["mcp:read"]')`
+          )
           const issuer = 'https://issuer.test/api/auth'
           const audience = 'https://api.test/mcp'
           const keys = yield* Effect.promise(() => generateKeyPair('EdDSA'))
@@ -83,6 +89,8 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })(
             return Effect.promise(() =>
               new SignJWT({
                 sub: userId,
+                client_id: 'suspension-client',
+                starter_consent_binding: 'consent-suspension:0',
                 scope: 'mcp:read',
                 starter_workspace_id: 'wrk_dev_contract',
                 starter_workspace_slug: 'dev-contract-lab',

--- a/apps/web/src/lib/server/workspace-isolation.live.test.ts
+++ b/apps/web/src/lib/server/workspace-isolation.live.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment node
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vite-plus/test'
+import { Effect, ManagedRuntime } from 'effect'
+import {
+  TestDatabase,
+  TestD1
+} from '@b2b-saas-starter/capabilities/testing/live-harness'
+import { fixtureSession } from '@/test/fixture-session'
+import type * as AuthModule from './auth'
+
+// Only session lookup and Worker bindings are substituted. The handlers resolve
+// membership and permissions through the production Live capabilities on local D1.
+const actor = vi.hoisted(() => ({ userId: 'usr_owner' }))
+vi.mock('./auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthModule>()),
+  requireRequestSession: async () => fixtureSession(actor)
+}))
+const database = ManagedRuntime.make(TestDatabase)
+function execute(sql: string, ...values: ReadonlyArray<string>) {
+  return database.runPromise(
+    Effect.flatMap(TestD1, (db) =>
+      Effect.promise(() =>
+        db
+          .prepare(sql)
+          .bind(...values)
+          .run()
+      )
+    )
+  )
+}
+
+beforeAll(async () => {
+  const DB = await database.runPromise(TestD1)
+  vi.doMock('cloudflare:workers', () => ({ env: { DB } }))
+  await execute(`INSERT INTO workspace_members (id,workspaceId,userId,role) VALUES
+    ('mem_isolation_other','wrk_other','usr_outsider','owner'),
+    ('mem_isolation_multi_a','wrk_dev_contract','usr_joiner','owner'),
+    ('mem_isolation_multi_b','wrk_other','usr_joiner','member')`)
+  await execute(`INSERT INTO notifications (id,workspace_id,title,message,created_at) VALUES
+    ('not_isolation_a','wrk_dev_contract','Own announcement','Own message','2026-01-01T00:00:00Z'),
+    ('not_isolation_b','wrk_other','Private announcement','Foreign message','2026-01-01T00:00:00Z')`)
+}, 120_000)
+beforeEach(() => {
+  actor.userId = 'usr_owner'
+})
+afterAll(async () => {
+  await database.dispose()
+})
+
+describe('browser server handler Workspace isolation', () => {
+  it('AC-2.1/AC-2.3: distinct users and a multi-Workspace user receive only their authorized page segments and counts', async () => {
+    const { loadWorkspaceDashboardHandler: dashboard } =
+      await import('./workspace-dashboard.effects')
+    const { loadWorkspaceWebhooksHandler: webhooks } =
+      await import('./webhooks.effects')
+    const own = await dashboard({ workspaceSlug: 'dev-contract-lab' })
+    expect(own.viewer).toEqual({ role: 'owner' })
+    expect(own.notifications.map((notification) => notification.id)).toEqual([
+      'not_isolation_a'
+    ])
+    expect(own.unreadCount).toBe(1)
+    const missing = dashboard({ workspaceSlug: 'missing-lab' })
+    await expect(missing).rejects.toEqual({ isNotFound: true })
+    await expect(dashboard({ workspaceSlug: 'other-lab' })).rejects.toEqual({
+      isNotFound: true
+    })
+    actor.userId = 'usr_outsider'
+    const other = await dashboard({ workspaceSlug: 'other-lab' })
+    expect(other.notifications.map((notification) => notification.id)).toEqual([
+      'not_isolation_b'
+    ])
+    expect(other.unreadCount).toBe(1)
+    await expect(dashboard({ workspaceSlug: 'dev-contract-lab' })).rejects.toEqual({
+      isNotFound: true
+    })
+    actor.userId = 'usr_joiner'
+    const fullAccess = await dashboard({ workspaceSlug: 'dev-contract-lab' })
+    expect(fullAccess.viewer).toEqual({
+      role: 'owner'
+    })
+    const limited = await dashboard({ workspaceSlug: 'other-lab' })
+    expect(limited.viewer).toEqual({ role: 'member' })
+    expect(limited.notifications.map((notification) => notification.id)).toEqual([
+      'not_isolation_b'
+    ])
+    expect(limited).toMatchObject({
+      webhooks: null,
+      apiTokens: null,
+      invitations: null,
+      auditEvents: null,
+      unreadCount: 1
+    })
+    await expect(webhooks({ workspaceSlug: 'other-lab' })).rejects.toMatchObject({
+      name: 'ForbiddenError'
+    })
+  }, 120_000)
+
+  it('AC-2.2/AC-2.3: foreign record IDs and slugs cannot mutate records, read secondary data, or add audit events', async () => {
+    const webhooks = await import('./webhooks.effects')
+    const { loadWorkspaceAuditEventsHandler: audit } =
+      await import('./workspace-audit.effects')
+    actor.userId = 'usr_outsider'
+    const created = await webhooks.createWebhookEndpointHandler({
+      workspaceSlug: 'other-lab',
+      url: 'https://private.example/browser',
+      events: ['api_token.created']
+    })
+    const foreignId = created.endpoint.id
+    const before = await webhooks.loadWorkspaceWebhooksHandler({
+      workspaceSlug: 'other-lab'
+    })
+    const auditBefore = await audit({ workspaceSlug: 'other-lab', filters: {} })
+    expect(auditBefore.events.length).toBeGreaterThan(0)
+    actor.userId = 'usr_owner'
+    await expect(
+      webhooks.updateWebhookEndpointHandler({
+        workspaceSlug: 'other-lab',
+        endpointId: foreignId,
+        enabled: false
+      })
+    ).rejects.toEqual({ isNotFound: true })
+    for (const endpointId of [foreignId, 'missing-endpoint']) {
+      await expect(
+        webhooks.updateWebhookEndpointHandler({
+          workspaceSlug: 'dev-contract-lab',
+          endpointId,
+          enabled: false
+        })
+      ).rejects.toMatchObject({ _tag: 'WebhookEndpointNotFound' })
+      await expect(
+        webhooks.rotateWebhookSecretHandler({
+          workspaceSlug: 'dev-contract-lab',
+          endpointId
+        })
+      ).rejects.toMatchObject({ _tag: 'WebhookEndpointNotFound' })
+      await expect(
+        webhooks.sendTestEventHandler({ workspaceSlug: 'dev-contract-lab', endpointId })
+      ).rejects.toMatchObject({ _tag: 'WebhookEndpointNotFound' })
+    }
+    const hiddenAudit = await audit({
+      workspaceSlug: 'dev-contract-lab',
+      filters: {},
+      event: auditBefore.events[0]?.id ?? 'missing-event'
+    })
+    expect(hiddenAudit.selectedEvent).toBeNull()
+    expect(hiddenAudit.events).toEqual([])
+    expect(hiddenAudit.nextCursor).toBeNull()
+    actor.userId = 'usr_outsider'
+    expect(
+      await webhooks.loadWorkspaceWebhooksHandler({ workspaceSlug: 'other-lab' })
+    ).toEqual(before)
+    expect(await audit({ workspaceSlug: 'other-lab', filters: {} })).toEqual(
+      auditBefore
+    )
+    // A legitimate update proves the mutation can reach persistence.
+    expect(
+      await webhooks.updateWebhookEndpointHandler({
+        workspaceSlug: 'other-lab',
+        endpointId: foreignId,
+        enabled: false
+      })
+    ).toMatchObject({ id: foreignId, enabled: false })
+  }, 120_000)
+
+  it('AC-2.2/AC-2.3: the same session observes role demotion and membership removal before reads and writes', async () => {
+    const { loadWorkspaceDashboardHandler: dashboard } =
+      await import('./workspace-dashboard.effects')
+    const webhooks = await import('./webhooks.effects')
+    actor.userId = 'usr_joiner'
+    const created = await webhooks.createWebhookEndpointHandler({
+      workspaceSlug: 'dev-contract-lab',
+      url: 'https://own.example/browser',
+      events: ['api_token.created']
+    })
+    await execute(
+      `UPDATE workspace_members SET role='member' WHERE id='mem_isolation_multi_a'`
+    )
+    const demoted = await dashboard({ workspaceSlug: 'dev-contract-lab' })
+    expect(demoted).toMatchObject({
+      viewer: { role: 'member' },
+      webhooks: null,
+      apiTokens: null,
+      invitations: null,
+      auditEvents: null
+    })
+    await expect(
+      webhooks.updateWebhookEndpointHandler({
+        workspaceSlug: 'dev-contract-lab',
+        endpointId: created.endpoint.id,
+        enabled: false
+      })
+    ).rejects.toMatchObject({ name: 'ForbiddenError' })
+    await execute(`DELETE FROM workspace_members WHERE id='mem_isolation_multi_a'`)
+    await expect(dashboard({ workspaceSlug: 'dev-contract-lab' })).rejects.toEqual({
+      isNotFound: true
+    })
+    await expect(
+      webhooks.rotateWebhookSecretHandler({
+        workspaceSlug: 'dev-contract-lab',
+        endpointId: created.endpoint.id
+      })
+    ).rejects.toEqual({ isNotFound: true })
+    // Removing access to A does not remove this user's legitimate membership in B.
+    const remainingAccess = await dashboard({ workspaceSlug: 'other-lab' })
+    expect(remainingAccess.viewer).toEqual({
+      role: 'member'
+    })
+    actor.userId = 'usr_owner'
+    const page = await webhooks.loadWorkspaceWebhooksHandler({
+      workspaceSlug: 'dev-contract-lab'
+    })
+    expect(
+      page.endpoints.find((endpoint) => endpoint.id === created.endpoint.id)
+    ).toMatchObject({ enabled: true, deliveries: [] })
+  }, 120_000)
+})

--- a/docs/adr/0068-oauth-for-interactive-mcp-clients-beside-api-tokens.md
+++ b/docs/adr/0068-oauth-for-interactive-mcp-clients-beside-api-tokens.md
@@ -2,6 +2,6 @@
 
 Interactive MCP clients use browser consent and OAuth; automation can use workspace API tokens. The web worker issues audience-bound credentials and the API worker verifies issuer, signature, audience, and expiry. REST remains token-only. Missing OAuth configuration leaves MCP token access available.
 
-Each consent selects one workspace. Tool execution rereads membership instead of trusting the role claim. Mutations also check the current grant and consent version. Connection revocation removes consent and associated credentials; write tokens also bind to a consent version, as defined in [ADR 0072](./0072-workspace-operation-catalog.md).
+Each consent selects one workspace. Tool and resource execution reread membership, compare the immutable Workspace ID, and check the current grant and consent version before exposing data or suspension details. Writes additionally require `mcp:write`, as defined in [ADR 0072](./0072-workspace-operation-catalog.md). Connection revocation removes consent and associated credentials; existing tokens lose read and write access on their next operation.
 
 Client metadata fetches reject unsafe hosts and redirects but cannot pin DNS resolution in Workers. Proof-of-possession tokens are refused because the resource server does not implement DPoP. Consent creation and its audit are not atomic across the plugin boundary; revocation uses one D1 batch.

--- a/docs/security-workspace-isolation.md
+++ b/docs/security-workspace-isolation.md
@@ -1,0 +1,65 @@
+# Interactive Workspace isolation
+
+[Issue #331](https://github.com/brandhaug/b2b-saas-starter/issues/331) verifies
+AC-2 of the [security baseline](https://github.com/brandhaug/b2b-saas-starter/issues/329).
+The tests use migrated local D1, real capability implementations, and successful
+operations before attempting unauthorized access.
+
+## Operation coverage
+
+| Transport and test                                                                     | Positive controls                                                                                                                                                 | Denials and retained state                                                                                                                                                                                                                                                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Browser server handlers](../apps/web/src/lib/server/workspace-isolation.live.test.ts) | Dashboard and webhook pages for distinct Workspace owners; one user who is owner in A and member in B; webhook creation and update                                | AC-2.1/AC-2.2/AC-2.3: foreign and missing slugs return the same not-found response; foreign webhook IDs cannot update, rotate secrets, or schedule test events; selecting another Workspace's audit event returns no record; notification records and unread counts stay scoped; unauthorized dashboard sections are absent; the same session observes demotion and removal; denied calls preserve endpoint and audit data. |
+| [REST](../apps/api/src/workspace-isolation-rest.live.test.ts)                          | Independent Workspace API Tokens; webhook creation; a queued test delivery; populated delivery and attempt reads; notification pagination and cursor continuation | AC-2.1/AC-2.2/AC-2.3: token/slug mismatch denies reads; foreign IDs cannot update, delete, rotate, schedule, or replay webhooks; secondary delivery and attempt reads return empty arrays; another Workspace's cursor never returns its records; foreign state, audit events, and queue-send count stay unchanged; foreign token revocation is an idempotent no-op; revoked tokens cannot read or write.                    |
+| [MCP OAuth tools and resources](../apps/api/src/workspace-isolation-mcp.live.test.ts)  | Distinct users and a multi-Workspace user; signed JWTs verified with a local JWKS; read-only consent; webhook creation; overview tools and resource reads         | AC-2.1/AC-2.2/AC-2.3: foreign webhook IDs and substituted Workspace arguments cannot retarget operations; consent cannot transfer between Workspaces; current roles override JWT role claims; removal and consent revocation affect existing sessions; reassigning a slug cannot retarget an old JWT, including when the new Workspace is suspended; denied calls preserve foreign endpoint and audit data.                 |
+| [Existing MCP Live coverage](../apps/api/src/mcp-live.test.ts)                         | Independent Workspace API Tokens and signed OAuth credentials                                                                                                     | Foreign endpoint/token/export IDs; API Token revocation; OAuth demotion, removal, consent version changes, and replacement; foreign audit data remains unchanged.                                                                                                                                                                                                                                                           |
+| [Suspension controls](../apps/api/src/workspace-suspension.live.test.ts)               | REST tokens and MCP sessions before suspension and after reactivation                                                                                             | Authorized suspension responses, outsider nondisclosure, catalog-wide suspension gates, and the existing token-recovery exceptions.                                                                                                                                                                                                                                                                                         |
+
+REST credentials belong to a Workspace, not a user. Distinct users and different
+roles across Workspaces are therefore exercised through browser handlers and OAuth.
+An error may echo the identifier supplied by the caller; it must not add protected
+record fields or reveal whether that foreign identifier exists.
+
+## Fixes retained by AC-2.4
+
+MCP reads previously resolved the slug in a JWT without comparing its immutable
+Workspace ID. Reassigning that slug could expose the new Workspace to a client
+whose user belonged to both Workspaces. Reads also continued after consent was
+revoked. The shared operation guard now checks Workspace ID, current consent
+binding and scope, and current Member permissions for tools, resources, and writes.
+
+Suspension used to run before the MCP authorization guard and could disclose the
+new Workspace's ID through an error. It now runs after authority is established.
+REST retains its suspension decision in its existing permission guard. Suspension
+recovery exceptions retain the same permission-to-operation mapping.
+
+## Running the checks
+
+From the repository root, after `vp install`:
+
+```bash
+pnpm -C packages/i18n generate
+vp test run apps/api/src/workspace-isolation-rest.live.test.ts apps/api/src/workspace-isolation-mcp.live.test.ts apps/api/src/mcp-live.test.ts apps/api/src/workspace-suspension.live.test.ts
+pnpm -C apps/web exec vp test run src/lib/server/workspace-isolation.live.test.ts
+pnpm run check
+E2E_PORT=13331 pnpm run validate
+```
+
+Choose a free `E2E_PORT` when validating multiple worktrees. See the
+[validation prerequisites](setup.md#validation).
+
+## Evidence limits
+
+These are representative regression tests, not an exhaustive operation or race
+matrix. The browser suite injects an authenticated session at the documented
+server-handler boundary. It does not test cookie issuance, browser session
+revocation, or TanStack's HTTP serialization. The MCP issuer fixture signs real
+JWTs but does not run browser consent, an external identity provider, or remote
+JWKS networking; those have separate [issuer](../packages/auth/src/live-mcp-oauth.test.ts) and [protocol](../apps/api/src/mcp-oauth.test.ts) tests. The issuer does not support revoking an individual self-contained JWT. Revoke the MCP Client connection to stop its existing JWTs through the current-consent check.
+
+Membership and consent changes are committed between calls. Concurrent revocation
+between authorization and persistence is not covered. Queue sends are recorded by
+a local test binding; external webhook receivers, deployed Cloudflare resources,
+and production access policies are not exercised. Queued work and exported
+artifacts belong to [AC-3](https://github.com/brandhaug/b2b-saas-starter/issues/332).
+A deployment needs its own verification and retained operator evidence.

--- a/packages/capabilities/src/developer-platform/mcp-client-connections.AGENTS.md
+++ b/packages/capabilities/src/developer-platform/mcp-client-connections.AGENTS.md
@@ -2,7 +2,7 @@
 
 User-keyed management of workspace-bound OAuth consent. Better Auth owns issuance and consent writes; this capability owns listing, audit, and revocation (ADR 0068).
 
-- `getGrant` returns the consent ID/version and scopes for the user, client, and workspace. The MCP write guard compares this binding with the signed claim. Preserve the database version trigger: revocation and scope restoration in the same second must invalidate the old claim.
+- `getGrant` returns the consent ID/version and scopes for the user, client, and workspace. The MCP operation guard compares this binding with the signed claim for reads, resources, and writes. Preserve the database version trigger: revocation and scope restoration in the same second must invalidate the old claim.
 - Lists retain consents whose workspace was deleted, projecting a null workspace. These reads take a user ID, never a workspace slug.
 - `recordGrant` audits separately because the plugin's HTTP write cannot join a D1 batch.
 - Revocation batches consent deletion, access/refresh token revocation, and audit. Deleting only consent leaves minted tokens usable. A foreign consent ID matches nothing and emits no event.


### PR DESCRIPTION
## Outcome

Implements #331, parent #329 AC-2. A valid MCP OAuth token could read another Workspace after its slug was reassigned, and could continue reading after consent revocation. Tools, resources, and writes now share a guard that checks the immutable Workspace ID, current consent and scope, and current membership permissions before exposing data or suspension details.

| Acceptance criterion | Evidence |
| --- | --- |
| AC-2.1 | Dedicated browser server-handler, REST, and MCP Live suites use two Workspaces, distinct users, a multi-Workspace user, and legitimate reads and writes. |
| AC-2.2 | Regression cases cover foreign slugs and record IDs, role demotion, membership removal, revoked API Tokens and MCP connections, cross-Workspace consent reuse, and reassigned slugs. |
| AC-2.3 | Tests check exact REST denial payloads, scoped pagination and unread counts, withheld browser segments, secondary delivery/attempt/audit reads, retained records/audits, and unchanged queue sends. Suspended slug reuse cannot disclose the other Workspace ID. |
| AC-2.4 | Fixes live in the shared API authorization guard; `docs/security-workspace-isolation.md` records operation coverage and limitations. |

## Decisions

REST already enforces suspension in `enforcePermission`. Removing the duplicate check from Workspace resolution lets MCP establish authority before returning suspension details. Existing suspension recovery exceptions retain the same permission mapping.

The browser suite injects session lookup and the Worker D1 binding. The remaining handler, permission, capability, and persistence paths are real. The MCP suite uses signed JWTs with a local JWKS and real stored consent; connection revocation uses the capability operation.

## Validation

Current revision: `2f76ff5b4fd6e14e0286dd51687db3ea95b0f4a0` on base `25258f8ccc4b8b0bffc8a7ca2ace96fd4a664b24`.

- `E2E_PORT=13331 pnpm run validate` passed at reviewed revision `4a99826860985449ca6e721ee381c3a80739a15d`, including full check, build/client boundary, Wrangler drift checks, migrated/seeded D1, and 35 E2E tests.
- Full web suite: 109 files and 653 tests passed, including all 3 new browser isolation tests. Focused API regression: 6 suites and 28 tests passed; integrated validation passed the final API suites.
- Independent Standards and Spec reviews found no actionable findings.
- The rebase adds only #346's README/checklist changes from `master`. `git range-diff` and stable patch IDs prove the reviewed task patch is unchanged. The coordinator retained review approval and required new-head CI instead of another heavy local validation run.
- Initial CI required title/E2E checks passed, but the package job failed on two unchanged billing tests at their existing 5-second timeout. No billing tests or CI settings were changed. All non-skipped CI checks passed on the current revision, including package tests, aggregate CI, and required E2E/title checks.
- The current head is mergeable and up to date with `master`. Coordinator approval applies to the unchanged reviewed patch, and all final gates now pass.

## Risks and remaining work

This is local regression evidence. Browser cookie/session lifecycle, external OAuth providers, deployed resources, and concurrent revocation races are outside the added coverage. The issuer does not support individual JWT revocation; revoking the MCP Client connection stops existing JWT operations through the current-consent check.

The authorization files and two documentation files overlap pending PR #307. Its SSO hunks were inspected and preserved; integration must retain both policies. No auth enrollment/session internals, shared harnesses, logger, CI, root manifest, or lockfile were changed.
