### PR TITLE
fix(email): correct content and align templates with app design

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -3,7 +3,11 @@
   "rules": {
     "circular-dependencies": "error"
   },
-  "entry": ["alchemy.run.ts", "packages/i18n/scripts/catalog-validation.test.mjs"],
+  "entry": [
+    "alchemy.run.ts",
+    "packages/i18n/scripts/catalog-validation.test.mjs",
+    "packages/email/src/previews/*.tsx"
+  ],
   "ignoreExportsUsedInFile": true,
   "ignoreDependencies": [
     "@b2b-saas-starter/db",

--- a/apps/background/src/notification-email-consumer.test.ts
+++ b/apps/background/src/notification-email-consumer.test.ts
@@ -154,9 +154,7 @@ describe('processNotificationEmailMessage', () => {
       expect(outcome).toBe('ack')
       expect(sent).toHaveLength(1)
       expect(sent[0]?.to).toBe('owner@example.com')
-      expect(sent[0]?.subject).toBe(
-        '[B2B SaaS Starter] API token created: API token created'
-      )
+      expect(sent[0]?.subject).toBe('[B2B SaaS Starter] API token created')
       const html = yield* Effect.promise(() => render(sent[0]!.element))
       expect(html).toContain('Ops Lead minted')
       expect(html).toContain('https://app.test/workspaces/starter-lab/api-tokens')

--- a/apps/background/src/notification-email-consumer.ts
+++ b/apps/background/src/notification-email-consumer.ts
@@ -148,7 +148,7 @@ export function processNotificationEmailMessage(
       {
         to: context.recipient.email,
         subject: m.backend_email_subject_notification(
-          { kindLabel, title: copy.title },
+          { title: copy.title },
           { locale }
         ),
         element: notificationEmailFor(kind, {

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -13,7 +13,7 @@
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "vp test run --passWithNoTests",
-    "dev": "email dev --dir src"
+    "dev": "email dev --dir src/previews"
   },
   "dependencies": {
     "@b2b-saas-starter/db": "workspace:*",

--- a/packages/email/src/notification-templates.test.tsx
+++ b/packages/email/src/notification-templates.test.tsx
@@ -1,4 +1,4 @@
-import { notificationKinds } from '@b2b-saas-starter/db/enums'
+import { notificationKinds, type NotificationKind } from '@b2b-saas-starter/db/enums'
 import { render } from 'react-email'
 import { Effect } from 'effect'
 import { type ReactElement } from 'react'
@@ -36,6 +36,39 @@ describe('notification email templates', () => {
     }
   })
 
+  it.effect(
+    'gives every kind a representative destination and rendered fixture copy',
+    () =>
+      Effect.gen(function* () {
+        const expected = {
+          'api_token.created': '/workspaces/starter-lab/api-tokens',
+          'api_token.revoked': '/workspaces/starter-lab/api-tokens',
+          'workspace_member.role_changed': '/workspaces/starter-lab/members',
+          'two_factor.changed': '/account',
+          'webhook.delivery_failed': '/workspaces/starter-lab/webhooks',
+          'workspace_member.joined': '/workspaces/starter-lab/members',
+          'billing.plan_changed': '/workspaces/starter-lab/billing',
+          'account.impersonated': '/account',
+          announcement: '/workspaces/starter-lab'
+        } satisfies Record<NotificationKind, string>
+
+        for (const kind of notificationKinds) {
+          const template = NOTIFICATION_EMAIL_TEMPLATES[kind]
+          const preview = template.PreviewProps
+          expect(new URL(preview.openUrl).pathname).toBe(expected[kind])
+          expect(preview.preferencesUrl).toContain(`kind=${kind}`)
+          if (kind !== 'api_token.created') {
+            expect(preview.kindLabel).not.toBe('API token created')
+            expect(preview.title).not.toBe('API token created')
+          }
+          const { html, text } = yield* rendered(notificationEmailFor(kind, preview))
+          expect(html).toContain(preview.kindLabel)
+          expect(html).toContain(preview.title)
+          expect(text).toContain(preview.message)
+        }
+      })
+  )
+
   describe.each(notificationKinds)('the %s notification', (kind) => {
     it.effect('renders with the notification copy and the unsubscribe link', () =>
       Effect.gen(function* () {
@@ -68,7 +101,7 @@ describe('notification email templates', () => {
       expect(html).toContain('Your daily notification digest')
       expect(html).toContain('2 unread notifications')
       expect(html).toContain('Webhook delivery gave up')
-      expect(html).toContain('Cloudflare Email needs configuration')
+      expect(html).toContain('Workspace export ready')
       expect(html).toContain(NotificationDigestEmail.PreviewProps.preferencesUrl)
     })
   )
@@ -89,3 +122,24 @@ describe('notification email templates', () => {
     })
   )
 })
+
+it.effect('uses Norwegian singular and plural digest subjects', () =>
+  Effect.gen(function* () {
+    const single = yield* rendered(
+      NotificationDigestEmail({
+        ...NotificationDigestEmail.PreviewProps,
+        items: NotificationDigestEmail.PreviewProps.items.slice(0, 1),
+        locale: 'nb'
+      })
+    )
+    const multiple = yield* rendered(
+      NotificationDigestEmail({
+        ...NotificationDigestEmail.PreviewProps,
+        locale: 'nb'
+      })
+    )
+    expect(single.html).toContain('1 ulest varsel')
+    expect(single.html).not.toContain('1 uleste')
+    expect(multiple.html).toContain('2 uleste varsler')
+  })
+)

--- a/packages/email/src/notification-templates.tsx
+++ b/packages/email/src/notification-templates.tsx
@@ -108,9 +108,9 @@ function NotificationFooter({
   readonly locale?: Locale | undefined
 }) {
   return (
-    <Text className="text-xs text-gray-500 mt-8">
+    <Text className="text-sm text-muted-foreground mt-8">
       {m.backend_email_notification_footer({}, { locale })}{' '}
-      <Link href={preferencesUrl} className="text-brand underline">
+      <Link href={preferencesUrl} className="text-primary underline">
         {m.backend_email_notification_footer_link({}, { locale })}
       </Link>
       .
@@ -129,7 +129,7 @@ function WorkspaceLine({
     return null
   }
   return (
-    <Text className="text-sm text-gray-500 mt-2 mb-0">
+    <Text className="text-sm text-muted-foreground mt-2 mb-0">
       {m.backend_email_notification_workspace({ workspaceName }, { locale })}
     </Text>
   )
@@ -148,11 +148,11 @@ function NotificationBody({
 }: NotificationBodyProps) {
   const locale = requestedLocale ?? DEFAULT_LOCALE
   return (
-    <EmailLayout preview={kindLabel} heading={kindLabel} locale={locale}>
-      <Text className="text-base text-gray-700 mt-4">{lead}</Text>
-      <Section className="bg-gray-50 rounded-md px-4 py-3 mt-4">
-        <Text className="text-base font-medium text-gray-900 m-0">{title}</Text>
-        <Text className="text-sm text-gray-700 mt-1 mb-0">{message}</Text>
+    <EmailLayout preview={title} heading={kindLabel} locale={locale}>
+      <Text className="text-base text-foreground mt-4">{lead}</Text>
+      <Section className="bg-muted px-4 py-3 mt-4">
+        <Text className="text-base font-medium text-foreground m-0">{title}</Text>
+        <Text className="text-sm text-foreground mt-1 mb-0">{message}</Text>
         <WorkspaceLine workspaceName={workspaceName} locale={locale} />
       </Section>
       <ActionLink href={openUrl} label={action} locale={locale} />
@@ -213,24 +213,73 @@ export function AnnouncementEmail(props: NotificationEmailProps) {
   return <NotificationBody {...props} lead={copy.lead} action={copy.action} />
 }
 
-const previewNotification = {
+const previewBase = {
   kindLabel: 'API token created',
   title: 'API token created',
-  message: 'Ops Lead minted "MCP local client" with read and write scopes.',
+  message: 'Ops Lead created "MCP local client" with read and write scopes.',
   workspaceName: 'Starter Lab',
   openUrl: 'http://localhost:3071/workspaces/starter-lab/api-tokens',
   preferencesUrl: 'http://localhost:3071/account/notifications?kind=api_token.created'
 } satisfies NotificationEmailProps
 
-ApiTokenCreatedEmail.PreviewProps = previewNotification
-ApiTokenRevokedEmail.PreviewProps = previewNotification
-MemberRoleChangedEmail.PreviewProps = previewNotification
-TwoFactorChangedNotificationEmail.PreviewProps = previewNotification
-WebhookDeliveryFailedEmail.PreviewProps = previewNotification
-MemberJoinedEmail.PreviewProps = previewNotification
-PlanChangedEmail.PreviewProps = previewNotification
+ApiTokenCreatedEmail.PreviewProps = previewBase
+ApiTokenRevokedEmail.PreviewProps = {
+  ...previewBase,
+  kindLabel: 'API token revoked',
+  title: 'API token revoked',
+  message:
+    'Ops Lead revoked "MCP local client". Integrations using this token will stop working.',
+  preferencesUrl: 'http://localhost:3071/account/notifications?kind=api_token.revoked'
+}
+MemberRoleChangedEmail.PreviewProps = {
+  ...previewBase,
+  kindLabel: 'Workspace role changed',
+  title: 'Workspace role changed',
+  message: 'Jordan Lee changed your role from member to administrator.',
+  openUrl: 'http://localhost:3071/workspaces/starter-lab/members',
+  preferencesUrl:
+    'http://localhost:3071/account/notifications?kind=workspace_member.role_changed'
+}
+TwoFactorChangedNotificationEmail.PreviewProps = {
+  ...previewBase,
+  kindLabel: 'Two-factor authentication changed',
+  title: 'Two-factor authentication changed',
+  message:
+    'Two-factor authentication was enabled for your account. If that was not you, reset your password now.',
+  workspaceName: null,
+  openUrl: 'http://localhost:3071/account',
+  preferencesUrl: 'http://localhost:3071/account/notifications?kind=two_factor.changed'
+}
+WebhookDeliveryFailedEmail.PreviewProps = {
+  ...previewBase,
+  kindLabel: 'Webhook delivery failed',
+  title: 'Webhook delivery failed',
+  message:
+    'https://example.com/webhooks/starter rejected billing.plan_changed and will not be retried.',
+  openUrl: 'http://localhost:3071/workspaces/starter-lab/webhooks',
+  preferencesUrl:
+    'http://localhost:3071/account/notifications?kind=webhook.delivery_failed'
+}
+MemberJoinedEmail.PreviewProps = {
+  ...previewBase,
+  kindLabel: 'Member joined',
+  title: 'Invitation accepted',
+  message: 'Taylor Morgan joined Starter Lab as a member.',
+  openUrl: 'http://localhost:3071/workspaces/starter-lab/members',
+  preferencesUrl:
+    'http://localhost:3071/account/notifications?kind=workspace_member.joined'
+}
+PlanChangedEmail.PreviewProps = {
+  ...previewBase,
+  kindLabel: 'Plan changed',
+  title: 'Plan changed to Team',
+  message: 'The workspace now serves the Team plan limits.',
+  openUrl: 'http://localhost:3071/workspaces/starter-lab/billing',
+  preferencesUrl:
+    'http://localhost:3071/account/notifications?kind=billing.plan_changed'
+}
 AccountImpersonatedEmail.PreviewProps = {
-  ...previewNotification,
+  ...previewBase,
   kindLabel: 'Account impersonated',
   title: 'A System Admin accessed your account',
   message:
@@ -240,7 +289,14 @@ AccountImpersonatedEmail.PreviewProps = {
   preferencesUrl:
     'http://localhost:3071/account/notifications?kind=account.impersonated'
 }
-AnnouncementEmail.PreviewProps = previewNotification
+AnnouncementEmail.PreviewProps = {
+  ...previewBase,
+  kindLabel: 'Announcements',
+  title: 'Workspace export ready',
+  message: 'Your export of Starter Lab is ready to download from workspace settings.',
+  openUrl: 'http://localhost:3071/workspaces/starter-lab',
+  preferencesUrl: 'http://localhost:3071/account/notifications?kind=announcement'
+}
 
 /** One line of the digest: what happened, where, and the app link for it. */
 export type DigestItem = {
@@ -274,15 +330,15 @@ function digestRowHeading(item: DigestItem): string {
 
 function DigestRow({ item }: { readonly item: DigestItem }) {
   return (
-    <Section className="border-solid border-0 border-b border-gray-200 py-3">
-      <Text className="text-xs uppercase tracking-wide text-gray-500 m-0">
+    <Section className="border-solid border-0 border-b border-border py-3">
+      <Text className="text-sm text-muted-foreground m-0">
         {digestRowHeading(item)}
       </Text>
-      <Text className="text-base font-medium text-gray-900 mt-1 mb-0">
+      <Text className="text-base font-medium text-foreground mt-1 mb-0">
         {item.title}
       </Text>
-      <Text className="text-sm text-gray-700 mt-1 mb-0">{item.message}</Text>
-      <Text className="text-xs text-gray-400 mt-1 mb-0">{item.createdAt}</Text>
+      <Text className="text-sm text-foreground mt-1 mb-0">{item.message}</Text>
+      <Text className="text-sm text-muted-foreground mt-1 mb-0">{item.createdAt}</Text>
     </Section>
   )
 }
@@ -312,7 +368,7 @@ export function NotificationDigestEmail({
       heading={m.backend_email_notification_digest_heading({}, { locale })}
       locale={locale}
     >
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_notification_digest_greeting(
           { recipientName, countLine },
           { locale }
@@ -348,10 +404,11 @@ NotificationDigestEmail.PreviewProps = {
     {
       id: 'not_preview_2',
       kindLabel: 'Announcements',
-      title: 'Cloudflare Email needs configuration',
-      message: 'Set CLOUDFLARE_EMAIL_FROM before enabling real email delivery.',
+      title: 'Workspace export ready',
+      message:
+        'Your export of Starter Lab is ready to download from workspace settings.',
       workspaceName: 'Starter Lab',
-      createdAt: '2026-05-16 08:10 UTC'
+      createdAt: '2026-05-16 07:45 UTC'
     }
   ],
   openUrl: 'http://localhost:3071/workspaces',

--- a/packages/email/src/previews/account-deleted.tsx
+++ b/packages/email/src/previews/account-deleted.tsx
@@ -1,0 +1,5 @@
+import { AccountDeletedEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <AccountDeletedEmail {...AccountDeletedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/account-impersonated.tsx
+++ b/packages/email/src/previews/account-impersonated.tsx
@@ -1,0 +1,5 @@
+import { AccountImpersonatedEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <AccountImpersonatedEmail {...AccountImpersonatedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/announcement.tsx
+++ b/packages/email/src/previews/announcement.tsx
@@ -1,0 +1,5 @@
+import { AnnouncementEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <AnnouncementEmail {...AnnouncementEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/api-token-created.tsx
+++ b/packages/email/src/previews/api-token-created.tsx
@@ -1,0 +1,5 @@
+import { ApiTokenCreatedEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <ApiTokenCreatedEmail {...ApiTokenCreatedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/api-token-revoked.tsx
+++ b/packages/email/src/previews/api-token-revoked.tsx
@@ -1,0 +1,5 @@
+import { ApiTokenRevokedEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <ApiTokenRevokedEmail {...ApiTokenRevokedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/backup-codes-rotated.tsx
+++ b/packages/email/src/previews/backup-codes-rotated.tsx
@@ -1,0 +1,5 @@
+import { BackupCodesRotatedEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <BackupCodesRotatedEmail {...BackupCodesRotatedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/billing-plan-changed.tsx
+++ b/packages/email/src/previews/billing-plan-changed.tsx
@@ -1,0 +1,5 @@
+import { PlanChangedEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <PlanChangedEmail {...PlanChangedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/email-verification.tsx
+++ b/packages/email/src/previews/email-verification.tsx
@@ -1,0 +1,5 @@
+import { EmailVerificationEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <EmailVerificationEmail {...EmailVerificationEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/magic-link.tsx
+++ b/packages/email/src/previews/magic-link.tsx
@@ -1,0 +1,5 @@
+import { MagicLinkEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <MagicLinkEmail {...MagicLinkEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/notification-digest.tsx
+++ b/packages/email/src/previews/notification-digest.tsx
@@ -1,0 +1,5 @@
+import { NotificationDigestEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <NotificationDigestEmail {...NotificationDigestEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/one-time-code-change-email.tsx
+++ b/packages/email/src/previews/one-time-code-change-email.tsx
@@ -1,0 +1,5 @@
+import { OneTimeCodeEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <OneTimeCodeEmail code="123456" purpose="change-email" />
+}

--- a/packages/email/src/previews/one-time-code-email-verification.tsx
+++ b/packages/email/src/previews/one-time-code-email-verification.tsx
@@ -1,0 +1,5 @@
+import { OneTimeCodeEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <OneTimeCodeEmail code="123456" purpose="email-verification" />
+}

--- a/packages/email/src/previews/one-time-code-forget-password.tsx
+++ b/packages/email/src/previews/one-time-code-forget-password.tsx
@@ -1,0 +1,5 @@
+import { OneTimeCodeEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <OneTimeCodeEmail code="123456" purpose="forget-password" />
+}

--- a/packages/email/src/previews/one-time-code.tsx
+++ b/packages/email/src/previews/one-time-code.tsx
@@ -1,0 +1,5 @@
+import { OneTimeCodeEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <OneTimeCodeEmail {...OneTimeCodeEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/passkey-changed.tsx
+++ b/packages/email/src/previews/passkey-changed.tsx
@@ -1,0 +1,5 @@
+import { PasskeyChangedEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <PasskeyChangedEmail {...PasskeyChangedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/passkey-removed.tsx
+++ b/packages/email/src/previews/passkey-removed.tsx
@@ -1,0 +1,5 @@
+import { PasskeyChangedEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <PasskeyChangedEmail added={false} />
+}

--- a/packages/email/src/previews/password-changed.tsx
+++ b/packages/email/src/previews/password-changed.tsx
@@ -1,0 +1,5 @@
+import { PasswordChangedEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <PasswordChangedEmail {...PasswordChangedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/password-reset-confirmation.tsx
+++ b/packages/email/src/previews/password-reset-confirmation.tsx
@@ -1,0 +1,5 @@
+import { PasswordChangedEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <PasswordChangedEmail via="reset" />
+}

--- a/packages/email/src/previews/password-reset.tsx
+++ b/packages/email/src/previews/password-reset.tsx
@@ -1,0 +1,5 @@
+import { PasswordResetEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <PasswordResetEmail {...PasswordResetEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/two-factor-changed-account.tsx
+++ b/packages/email/src/previews/two-factor-changed-account.tsx
@@ -1,0 +1,5 @@
+import { TwoFactorChangedEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <TwoFactorChangedEmail {...TwoFactorChangedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/two-factor-changed.tsx
+++ b/packages/email/src/previews/two-factor-changed.tsx
@@ -1,0 +1,9 @@
+import { TwoFactorChangedNotificationEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return (
+    <TwoFactorChangedNotificationEmail
+      {...TwoFactorChangedNotificationEmail.PreviewProps}
+    />
+  )
+}

--- a/packages/email/src/previews/two-factor-disabled.tsx
+++ b/packages/email/src/previews/two-factor-disabled.tsx
@@ -1,0 +1,5 @@
+import { TwoFactorChangedEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <TwoFactorChangedEmail enabled={false} />
+}

--- a/packages/email/src/previews/webhook-delivery-failed.tsx
+++ b/packages/email/src/previews/webhook-delivery-failed.tsx
@@ -1,0 +1,5 @@
+import { WebhookDeliveryFailedEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <WebhookDeliveryFailedEmail {...WebhookDeliveryFailedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/workspace-invitation.tsx
+++ b/packages/email/src/previews/workspace-invitation.tsx
@@ -1,0 +1,5 @@
+import { WorkspaceInvitationEmail } from '../templates.tsx'
+
+export default function Preview() {
+  return <WorkspaceInvitationEmail {...WorkspaceInvitationEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/workspace-member-joined.tsx
+++ b/packages/email/src/previews/workspace-member-joined.tsx
@@ -1,0 +1,5 @@
+import { MemberJoinedEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <MemberJoinedEmail {...MemberJoinedEmail.PreviewProps} />
+}

--- a/packages/email/src/previews/workspace-member-role-changed.tsx
+++ b/packages/email/src/previews/workspace-member-role-changed.tsx
@@ -1,0 +1,5 @@
+import { MemberRoleChangedEmail } from '../notification-templates.tsx'
+
+export default function Preview() {
+  return <MemberRoleChangedEmail {...MemberRoleChangedEmail.PreviewProps} />
+}

--- a/packages/email/src/templates.test.tsx
+++ b/packages/email/src/templates.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it } from '@effect/vitest'
+import { Effect } from 'effect'
+import { render } from 'react-email'
+import { type Locale } from '@b2b-saas-starter/i18n/locale'
+import {
+  AccountDeletedEmail,
+  OneTimeCodeEmail,
+  PasskeyChangedEmail,
+  TwoFactorChangedEmail
+} from './templates.tsx'
+
+// Both counts can be singular independently in an account deletion receipt.
+describe.each([
+  {
+    locale: 'en',
+    singular: '1 workspace',
+    plural: '2 workspaces',
+    incorrect: '1 workspaces'
+  },
+  {
+    locale: 'nb',
+    singular: '1 arbeidsområde',
+    plural: '2 arbeidsområder',
+    incorrect: '1 arbeidsområder'
+  }
+] satisfies ReadonlyArray<{
+  locale: Locale
+  singular: string
+  plural: string
+  incorrect: string
+}>)('account receipts in $locale', ({ locale, singular, plural, incorrect }) => {
+  it.effect('handles deleted and left counts independently', () =>
+    Effect.gen(function* () {
+      for (const counts of [
+        { workspacesDeleted: 1, workspacesLeft: 2 },
+        { workspacesDeleted: 2, workspacesLeft: 1 }
+      ]) {
+        const text = yield* Effect.promise(() =>
+          render(AccountDeletedEmail({ ...counts, locale }), { plainText: true })
+        )
+        expect(text).toContain(singular)
+        expect(text).toContain(plural)
+        expect(text).not.toContain(incorrect)
+      }
+    })
+  )
+})
+
+describe.each([
+  { enabled: true, en: 'turned on', nb: 'slått på' },
+  { enabled: false, en: 'turned off', nb: 'slått av' }
+])('two-factor enabled=$enabled', ({ enabled, en, nb }) => {
+  it.effect('reports the change in both languages', () =>
+    Effect.gen(function* () {
+      const english = yield* Effect.promise(() =>
+        render(TwoFactorChangedEmail({ enabled, locale: 'en' }), { plainText: true })
+      )
+      const norwegian = yield* Effect.promise(() =>
+        render(TwoFactorChangedEmail({ enabled, locale: 'nb' }), { plainText: true })
+      )
+      expect(english).toContain(en)
+      expect(norwegian).toContain(nb)
+    })
+  )
+})
+
+describe.each([
+  { added: true, en: 'was added', nb: 'ble lagt til' },
+  { added: false, en: 'was removed', nb: 'ble fjernet' }
+])('passkey added=$added', ({ added, en, nb }) => {
+  it.effect('reports the change in both languages', () =>
+    Effect.gen(function* () {
+      const english = yield* Effect.promise(() =>
+        render(PasskeyChangedEmail({ added, locale: 'en' }), { plainText: true })
+      )
+      const norwegian = yield* Effect.promise(() =>
+        render(PasskeyChangedEmail({ added, locale: 'nb' }), { plainText: true })
+      )
+      expect(english).toContain(en)
+      expect(norwegian).toContain(nb)
+    })
+  )
+})
+
+it.effect('keeps codes copyable and out of inbox previews for every purpose', () =>
+  Effect.gen(function* () {
+    const purposes: ReadonlyArray<Parameters<typeof OneTimeCodeEmail>[0]['purpose']> = [
+      'sign-in',
+      'email-verification',
+      'forget-password',
+      'change-email'
+    ]
+    for (const purpose of purposes) {
+      const html = yield* Effect.promise(() =>
+        render(OneTimeCodeEmail({ code: '048291', purpose }))
+      )
+      const text = yield* Effect.promise(() =>
+        render(OneTimeCodeEmail({ code: '048291', purpose }), { plainText: true })
+      )
+      expect(text).toContain('048291')
+      expect(html).not.toContain('href=')
+      const preview = html.slice(html.indexOf('<body'), html.indexOf('</div>'))
+      expect(preview).not.toContain('048291')
+    }
+  })
+)
+
+it.effect('keeps Norwegian language metadata on the body as well as the document', () =>
+  Effect.gen(function* () {
+    const html = yield* Effect.promise(() =>
+      render(TwoFactorChangedEmail({ enabled: false, locale: 'nb' }))
+    )
+    expect(html).toContain('lang="nb-NO"')
+    expect(html).not.toMatch(/\blang="en(?:-US)?"/)
+  })
+)

--- a/packages/email/src/templates.tsx
+++ b/packages/email/src/templates.tsx
@@ -53,22 +53,54 @@ export function EmailLayout({
           theme: {
             extend: {
               colors: {
-                brand: '#2563eb'
+                // Email clients need literal sRGB values, not the app's CSS variables.
+                // Keep these aligned with apps/web/src/index.css (Catppuccin Mocha).
+                background: '#1e1e2e',
+                card: '#181825',
+                foreground: '#cdd6f4',
+                primary: '#cba6f7',
+                'primary-foreground': '#11111b',
+                muted: '#313244',
+                'muted-foreground': '#a6adc8',
+                border: '#313244'
+              },
+              fontFamily: {
+                sans: ['Geist Variable', 'Arial', 'Helvetica', 'sans-serif'],
+                mono: ['Geist Mono Variable', 'Consolas', 'Courier New', 'monospace']
               }
             }
           }
         }}
       >
-        <Head />
+        <Head>
+          <meta name="color-scheme" content="dark" />
+          <meta name="supported-color-schemes" content="dark" />
+        </Head>
         <Preview>{preview}</Preview>
-        <Body className="bg-gray-100 font-sans py-10">
-          <Container className="bg-white max-w-xl mx-auto rounded-lg px-8 py-10">
-            <Heading className="text-2xl font-bold text-gray-900 m-0">
+        <Body
+          lang={intlLocale(locale)}
+          className="bg-background text-foreground font-sans m-0 p-4"
+        >
+          <Container
+            className="bg-card border border-solid border-border w-full mx-auto px-6 py-8"
+            style={{
+              maxWidth: '576px',
+              tableLayout: 'fixed',
+              overflowWrap: 'anywhere'
+            }}
+          >
+            <Heading
+              as="h1"
+              className="text-2xl leading-8 font-semibold text-foreground m-0"
+            >
               {heading}
             </Heading>
             {children}
-            <Hr className="border-solid border-gray-200 my-8" />
-            <Text className="text-xs text-gray-500 m-0">
+            <Hr
+              className="border-t border-border my-8"
+              style={{ borderTop: undefined }}
+            />
+            <Text className="text-sm text-muted-foreground m-0">
               © {footerYear()} B2B SaaS Starter
             </Text>
           </Container>
@@ -94,14 +126,14 @@ export function ActionLink({ href, label, locale = DEFAULT_LOCALE }: ActionLinkP
       <Section className="mt-6">
         <Button
           href={href}
-          className="bg-brand text-white px-6 py-3 rounded-md font-medium box-border"
+          className="bg-primary text-primary-foreground px-6 py-3 rounded-[6px] text-base leading-6 font-medium box-border"
         >
           {label}
         </Button>
       </Section>
-      <Text className="text-sm text-gray-500 mt-6">
+      <Text className="text-sm text-muted-foreground mt-6">
         {m.backend_email_auth_action_fallback({}, { locale })}{' '}
-        <Link href={href} className="text-brand underline">
+        <Link href={href} className="text-primary underline break-all">
           {href}
         </Link>
       </Text>
@@ -126,7 +158,7 @@ export function WorkspaceInvitationEmail({
       heading={m.backend_email_auth_invitation_heading({ workspaceName }, { locale })}
       locale={locale}
     >
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_auth_invitation_body({}, { locale })}
       </Text>
       <ActionLink
@@ -140,7 +172,7 @@ export function WorkspaceInvitationEmail({
 
 WorkspaceInvitationEmail.PreviewProps = {
   workspaceName: 'Starter Lab',
-  inviteUrl: 'http://localhost:3071/invitations/accept'
+  inviteUrl: 'http://localhost:3071/invitations/accept?invitation=preview-invitation'
 } satisfies WorkspaceInvitationEmailProps
 
 export default WorkspaceInvitationEmail
@@ -165,7 +197,7 @@ export function PasswordResetEmail({
       heading={m.backend_email_subject_reset_password({}, { locale })}
       locale={locale}
     >
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_auth_reset_description({}, { locale })}
       </Text>
       <ActionLink
@@ -173,7 +205,7 @@ export function PasswordResetEmail({
         label={m.backend_email_auth_reset_action({}, { locale })}
         locale={locale}
       />
-      <Text className="text-sm text-gray-500 mt-4">
+      <Text className="text-sm text-muted-foreground mt-4">
         {m.backend_email_auth_reset_ignore({}, { locale })}
       </Text>
     </EmailLayout>
@@ -204,7 +236,7 @@ export function EmailVerificationEmail({
       heading={m.backend_email_subject_verify_email({}, { locale })}
       locale={locale}
     >
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_auth_verify_description({}, { locale })}
       </Text>
       <ActionLink
@@ -257,18 +289,18 @@ export function OneTimeCodeEmail({
   }
   return (
     <EmailLayout preview={subject} heading={heading} locale={locale}>
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_auth_otp_description({}, { locale })}
       </Text>
       <Section className="mt-6">
-        <Text className="text-4xl font-bold tracking-[0.3em] text-gray-900 m-0 font-mono">
+        <Text className="text-3xl leading-10 font-semibold tracking-[0.2em] text-foreground m-0 font-mono">
           {code}
         </Text>
       </Section>
-      <Text className="text-sm text-gray-500 mt-6">
+      <Text className="text-sm text-muted-foreground mt-6">
         {m.backend_email_auth_otp_expiry({}, { locale })}
       </Text>
-      <Text className="text-sm text-gray-500 mt-4">
+      <Text className="text-sm text-muted-foreground mt-4">
         {m.backend_email_auth_otp_ignore({}, { locale })}
       </Text>
     </EmailLayout>
@@ -296,7 +328,7 @@ export function MagicLinkEmail({ url, locale = DEFAULT_LOCALE }: MagicLinkEmailP
       heading={m.backend_email_auth_magic_link_heading({}, { locale })}
       locale={locale}
     >
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_auth_magic_description({}, { locale })}
       </Text>
       <ActionLink
@@ -304,7 +336,7 @@ export function MagicLinkEmail({ url, locale = DEFAULT_LOCALE }: MagicLinkEmailP
         label={m.backend_email_auth_magic_action({}, { locale })}
         locale={locale}
       />
-      <Text className="text-sm text-gray-500 mt-4">
+      <Text className="text-sm text-muted-foreground mt-4">
         {m.backend_email_auth_magic_ignore({}, { locale })}
       </Text>
     </EmailLayout>
@@ -358,8 +390,8 @@ export function TwoFactorChangedEmail({ enabled, locale }: TwoFactorChangedEmail
   }
   return (
     <EmailLayout preview={preview} heading={heading} locale={activeLocale}>
-      <Text className="text-base text-gray-700 mt-4">{stateCopy}</Text>
-      <Text className="text-sm text-gray-500 mt-4">
+      <Text className="text-base text-foreground mt-4">{stateCopy}</Text>
+      <Text className="text-sm text-muted-foreground mt-4">
         {m.backend_email_auth_security_warning({}, { locale: activeLocale })}
       </Text>
     </EmailLayout>
@@ -397,8 +429,8 @@ export function PasskeyChangedEmail({ added, locale }: PasskeyChangedEmailProps)
   }
   return (
     <EmailLayout preview={preview} heading={heading} locale={activeLocale}>
-      <Text className="text-base text-gray-700 mt-4">{stateCopy}</Text>
-      <Text className="text-sm text-gray-500 mt-4">
+      <Text className="text-base text-foreground mt-4">{stateCopy}</Text>
+      <Text className="text-sm text-muted-foreground mt-4">
         {m.backend_email_auth_security_warning({}, { locale: activeLocale })}
       </Text>
     </EmailLayout>
@@ -454,13 +486,13 @@ export function PasswordChangedEmail({ via, locale }: PasswordChangedEmailProps)
   }
   return (
     <EmailLayout preview={preview} heading={heading} locale={locale}>
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_auth_password_changed_body(
           { via: flow },
           { locale: activeLocale }
         )}
       </Text>
-      <Text className="text-sm text-gray-500 mt-4">
+      <Text className="text-sm text-muted-foreground mt-4">
         {m.backend_email_auth_security_warning({}, { locale: activeLocale })}
       </Text>
     </EmailLayout>
@@ -490,10 +522,10 @@ export function BackupCodesRotatedEmail({
       heading={m.backend_email_auth_backup_codes_heading({}, { locale: activeLocale })}
       locale={locale}
     >
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_auth_backup_codes({}, { locale: activeLocale })}
       </Text>
-      <Text className="text-sm text-gray-500 mt-4">
+      <Text className="text-sm text-muted-foreground mt-4">
         {m.backend_email_auth_backup_codes_warning({}, { locale: activeLocale })}
       </Text>
     </EmailLayout>
@@ -535,16 +567,20 @@ export function AccountDeletedEmail({
       )}
       locale={locale}
     >
-      <Text className="text-base text-gray-700 mt-4">
+      <Text className="text-base text-foreground mt-4">
         {m.backend_email_auth_account_deleted_body({}, { locale: activeLocale })}
       </Text>
-      <Text className="text-base text-gray-700 mt-4">
-        {m.backend_email_auth_account_deleted(
-          { workspacesDeleted, workspacesLeft },
+      <Text className="text-base text-foreground mt-4">
+        {m.backend_email_auth_workspaces_deleted(
+          { count: workspacesDeleted },
+          { locale: activeLocale }
+        )}{' '}
+        {m.backend_email_auth_workspaces_left(
+          { count: workspacesLeft },
           { locale: activeLocale }
         )}
       </Text>
-      <Text className="text-sm text-gray-500 mt-4">
+      <Text className="text-sm text-muted-foreground mt-4">
         {m.backend_email_auth_account_deleted_warning({}, { locale: activeLocale })}
       </Text>
     </EmailLayout>

--- a/packages/i18n/messages/backend/en.json
+++ b/packages/i18n/messages/backend/en.json
@@ -17,18 +17,27 @@
         "password_changed": "Your password was changed",
         "backup_codes_rotated": "Your two-factor recovery codes were replaced",
         "account_deleted": "Your account was deleted",
-        "notification": "[B2B SaaS Starter] {kindLabel}: {title}",
-        "digest": "[B2B SaaS Starter] Your daily digest: {count} unread"
+        "notification": "[B2B SaaS Starter] {title}",
+        "digest": [
+          {
+            "declarations": ["input count", "local category = count: plural"],
+            "selectors": ["category"],
+            "match": {
+              "category=one": "[B2B SaaS Starter] Your daily digest: {count} unread notification",
+              "category=other": "[B2B SaaS Starter] Your daily digest: {count} unread notifications"
+            }
+          }
+        ]
       },
       "auth": {
         "reset_description": "Somebody asked to reset the password for your B2B SaaS Starter account. If that was you, choose a new password within thirty minutes; the link works once and then expires.",
         "reset_action": "Choose a new password",
         "reset_ignore": "If you did not ask for a reset, you can ignore this email; your password stays unchanged.",
-        "verify_description": "Confirm your email address to finish setting up your B2B SaaS Starter account. The link works once and expires in an hour.",
+        "verify_description": "Confirm your email address to finish setting up your B2B SaaS Starter account. The link expires in one hour.",
         "verify_action": "Verify my email",
         "magic_description": "Somebody asked for a sign-in link for this email address. If that was you, open the link to sign in without a password. It works once and expires in ten minutes.",
         "magic_action": "Sign in",
-        "magic_ignore": "If you did not ask for the link, you can ignore this email; opening it is the only thing the link can do.",
+        "magic_ignore": "If you did not request this link, do not open it. You can ignore this email.",
         "otp_description": "Use the code below to continue.",
         "otp_expiry": "The code works once, expires in ten minutes, and stops working after three failed attempts.",
         "otp_ignore": "If you did not request this code, you can ignore this email; your account is unchanged.",
@@ -38,21 +47,20 @@
         "reset_body": "Use the link below to choose a new password.",
         "magic_link_heading": "Sign in to B2B SaaS Starter",
         "magic_link_body": "Use the link below to sign in.",
-        "one_time_code_heading": "Your verification code",
+        "one_time_code_heading": "Confirm your new email address",
         "sign_in_code_heading": "Sign in to B2B SaaS Starter",
         "one_time_code_body": "Enter this code to continue: {code}",
         "password_changed_heading": "Your password was changed",
-        "password_changed_body": "Your password was changed through {via}. If you did not do this, reset your password immediately.",
+        "password_changed_body": "The password for your B2B SaaS Starter account was just {via}. If that was you, sign in with the new password the next time you need it.",
         "two_factor_enabled": "Two-factor authentication was turned on.",
         "two_factor_disabled": "Two-factor authentication was turned off.",
         "passkey_added": "A passkey was added to your account.",
         "passkey_removed": "A passkey was removed from your account.",
-        "backup_codes": "Your previously saved two-factor recovery codes stopped working. Store the new codes somewhere safe.",
-        "account_deleted": "Your account was deleted. {workspacesDeleted} workspaces were deleted and you left {workspacesLeft} workspaces.",
+        "backup_codes": "Your previously saved two-factor recovery codes stopped working.",
         "action_fallback": "If the button does not work, copy this URL into your browser:",
         "invitation_preview": "You have been invited to {workspaceName}",
         "invitation_heading": "Join {workspaceName}",
-        "invitation_body": "You have been invited to a B2B SaaS Starter workspace. Accept the invitation to review reports, tokens, and settings.",
+        "invitation_body": "You have been invited to a workspace in B2B SaaS Starter. Accept the invitation to join your team.",
         "invitation_action": "Accept invitation",
         "security_warning": "If you did not make this change, reset your password immediately and review your account security settings.",
         "two_factor_enabled_preview": "Two-factor authentication enabled",
@@ -66,8 +74,6 @@
         "password_reset_preview": "Your password was reset",
         "password_changed_preview": "Your password was changed",
         "password_reset_heading": "Your password was reset",
-        "password_changed_heading": "Your password was changed",
-        "password_changed_body": "The password for your B2B SaaS Starter account was just {via}. If that was you, sign in with the new password the next time you need it.",
         "password_reset_via": "reset through the link we emailed you",
         "password_changed_via": "changed from your account settings",
         "backup_codes_preview": "Your two-factor recovery codes were replaced",
@@ -76,7 +82,27 @@
         "account_deleted_preview": "Your B2B SaaS Starter account was deleted",
         "account_deleted_heading": "Your account was deleted",
         "account_deleted_body": "Your B2B SaaS Starter account has been permanently deleted, along with every session signed in as you.",
-        "account_deleted_warning": "If you did not delete this account, reset the password of any account that shares this password and contact support immediately."
+        "account_deleted_warning": "If you did not delete this account, reset the password of any account that shares this password and contact support immediately.",
+        "workspaces_deleted": [
+          {
+            "declarations": ["input count", "local category = count: plural"],
+            "selectors": ["category"],
+            "match": {
+              "category=one": "1 workspace was deleted.",
+              "category=other": "{count} workspaces were deleted."
+            }
+          }
+        ],
+        "workspaces_left": [
+          {
+            "declarations": ["input count", "local category = count: plural"],
+            "selectors": ["category"],
+            "match": {
+              "category=one": "You left 1 workspace.",
+              "category=other": "You left {count} workspaces."
+            }
+          }
+        ]
       },
       "notification": {
         "kind_api_token_created": "API token created",
@@ -91,29 +117,29 @@
         "footer": "You receive this email because of your notification preferences.",
         "footer_link": "Change how you get these emails or unsubscribe",
         "workspace": "Workspace: {workspaceName}",
-        "api_token_created_lead": "Somebody minted a new API token in a workspace you belong to. If nobody on your team did this, revoke it now.",
+        "api_token_created_lead": "A new API token was created in a workspace you belong to. If you do not recognize it, ask a workspace owner or admin to review it.",
         "api_token_created_action": "Review API tokens",
         "api_token_revoked_lead": "An API token in a workspace you belong to no longer works. Integrations that used it will start failing.",
         "api_token_revoked_action": "Review API tokens",
-        "role_changed_lead": "An owner or admin changed what you can do in this workspace.",
+        "role_changed_lead": "A member's role in this workspace changed.",
         "role_changed_action": "Open the workspace",
         "two_factor_changed_lead": "Two-factor authentication was turned on or off for your account. If that was not you, reset your password now.",
         "two_factor_changed_action": "Review account security",
-        "webhook_failed_lead": "A webhook endpoint rejected a delivery or gave up after retries. The delivery history has the response codes.",
+        "webhook_failed_lead": "A webhook delivery failed. Review the delivery history for the error and retry status.",
         "webhook_failed_action": "Open webhook endpoints",
         "member_joined_lead": "Somebody accepted an invitation to a workspace you belong to.",
         "member_joined_action": "See members",
         "plan_changed_lead": "A workspace you belong to is on a different plan. Limits and entitlements follow the new plan from now on.",
         "plan_changed_action": "Open billing",
-        "impersonated_lead": "A System Admin opened an impersonation session on your account for support. It is recorded in the audit trail and cannot change your password, two-factor settings, or email.",
+        "impersonated_lead": "A System Admin opened an impersonation session on your account. It is recorded in the audit trail and cannot change your password, two-factor settings, or email.",
         "impersonated_action": "Review account security",
-        "announcement_lead": "A notice for everyone in the workspace.",
+        "announcement_lead": "You have a new notification.",
         "announcement_action": "Open the workspace",
         "digest_one": "One unread notification from the last 24 hours.",
         "digest_many": "{count} unread notifications from the last 24 hours.",
         "digest_heading": "Your daily notification digest",
         "digest_open": "Open your workspaces",
-        "digest_greeting": "Hi {recipientName}, {countLine}",
+        "digest_greeting": "{recipientName}, here is your daily summary. {countLine}",
         "event_webhook_permanent_title": "Webhook delivery failed",
         "event_webhook_permanent_message": "{endpointUrl}: {eventType} was rejected and will not be retried.",
         "event_webhook_dead_letter_title": "Webhook delivery dead-lettered",
@@ -134,7 +160,7 @@
         "event_member_role_admin": "administrator",
         "event_member_role_member": "member",
         "event_token_created_title": "API token created",
-        "event_token_created_message": "{actorName} minted \"{tokenName}\" with {scopes} scopes.",
+        "event_token_created_message": "{actorName} created \"{tokenName}\" with {scopes} scopes.",
         "event_sso_failed_title": "SSO connection failed its test",
         "event_sso_failed_message": "The {protocol} connection for {domain} failed: {reason}",
         "event_sso_reason_discovery_unreachable": "The identity provider could not be reached.",

--- a/packages/i18n/messages/backend/nb.json
+++ b/packages/i18n/messages/backend/nb.json
@@ -17,18 +17,27 @@
         "password_changed": "Passordet ditt ble endret",
         "backup_codes_rotated": "Gjenopprettingskodene for tofaktorautentisering er erstattet",
         "account_deleted": "Kontoen din ble slettet",
-        "notification": "[B2B SaaS Starter] {kindLabel}: {title}",
-        "digest": "[B2B SaaS Starter] Din daglige oppsummering: {count} uleste"
+        "notification": "[B2B SaaS Starter] {title}",
+        "digest": [
+          {
+            "declarations": ["input count", "local category = count: plural"],
+            "selectors": ["category"],
+            "match": {
+              "category=one": "[B2B SaaS Starter] Din daglige oppsummering: {count} ulest varsel",
+              "category=other": "[B2B SaaS Starter] Din daglige oppsummering: {count} uleste varsler"
+            }
+          }
+        ]
       },
       "auth": {
         "reset_description": "Noen ba om å tilbakestille passordet for B2B SaaS Starter-kontoen din. Hvis det var deg, velg et nytt passord innen tretti minutter; lenken kan brukes én gang og utløper deretter.",
         "reset_action": "Velg et nytt passord",
         "reset_ignore": "Hvis du ikke ba om en tilbakestilling, kan du se bort fra denne e-posten; passordet ditt forblir uendret.",
-        "verify_description": "Bekreft e-postadressen din for å fullføre oppsettet av B2B SaaS Starter-kontoen din. Lenken kan brukes én gang og utløper om en time.",
+        "verify_description": "Bekreft e-postadressen din for å fullføre oppsettet av B2B SaaS Starter-kontoen din. Lenken utløper om én time.",
         "verify_action": "Bekreft e-posten min",
         "magic_description": "Noen ba om en innloggingslenke for denne e-postadressen. Hvis det var deg, åpne lenken for å logge inn uten passord. Den kan brukes én gang og utløper om ti minutter.",
         "magic_action": "Logg inn",
-        "magic_ignore": "Hvis du ikke ba om lenken, kan du se bort fra denne e-posten; lenken kan bare brukes til innlogging.",
+        "magic_ignore": "Hvis du ikke ba om denne lenken, må du ikke åpne den. Du kan se bort fra e-posten.",
         "otp_description": "Bruk koden nedenfor for å fortsette.",
         "otp_expiry": "Koden kan brukes én gang, utløper om ti minutter og slutter å virke etter tre mislykkede forsøk.",
         "otp_ignore": "Hvis du ikke ba om denne koden, kan du se bort fra e-posten; kontoen din er uendret.",
@@ -38,21 +47,20 @@
         "reset_body": "Bruk lenken nedenfor for å velge et nytt passord.",
         "magic_link_heading": "Logg inn på B2B SaaS Starter",
         "magic_link_body": "Bruk lenken nedenfor for å logge inn.",
-        "one_time_code_heading": "Bekreftelseskoden din",
+        "one_time_code_heading": "Bekreft den nye e-postadressen din",
         "sign_in_code_heading": "Logg inn på B2B SaaS Starter",
         "one_time_code_body": "Skriv inn denne koden for å fortsette: {code}",
         "password_changed_heading": "Passordet ditt ble endret",
-        "password_changed_body": "Passordet ditt ble endret via {via}. Hvis det ikke var deg, må du tilbakestille passordet umiddelbart.",
+        "password_changed_body": "Passordet for B2B SaaS Starter-kontoen din ble {via}. Hvis det var deg, logger du inn med det nye passordet neste gang.",
         "two_factor_enabled": "Tofaktorautentisering ble slått på.",
         "two_factor_disabled": "Tofaktorautentisering ble slått av.",
         "passkey_added": "En passnøkkel ble lagt til på kontoen din.",
         "passkey_removed": "En passnøkkel ble fjernet fra kontoen din.",
-        "backup_codes": "De tidligere lagrede gjenopprettingskodene for tofaktorautentisering sluttet å virke. Lagre de nye kodene på et trygt sted.",
-        "account_deleted": "Kontoen din ble slettet. {workspacesDeleted} arbeidsområder ble slettet, og du forlot {workspacesLeft} arbeidsområder.",
+        "backup_codes": "De tidligere lagrede gjenopprettingskodene for tofaktorautentisering virker ikke lenger.",
         "action_fallback": "Hvis knappen ikke virker, kopier denne URL-en til nettleseren din:",
         "invitation_preview": "Du er invitert til {workspaceName}",
         "invitation_heading": "Bli med i {workspaceName}",
-        "invitation_body": "Du er invitert til et arbeidsområde i B2B SaaS Starter. Godta invitasjonen for å se rapporter, tokener og innstillinger.",
+        "invitation_body": "Du er invitert til et arbeidsområde i B2B SaaS Starter. Godta invitasjonen for å bli med i teamet.",
         "invitation_action": "Godta invitasjonen",
         "security_warning": "Hvis det ikke var deg, må du tilbakestille passordet umiddelbart og se gjennom sikkerhetsinnstillingene for kontoen.",
         "two_factor_enabled_preview": "Tofaktorautentisering slått på",
@@ -66,8 +74,6 @@
         "password_reset_preview": "Passordet ditt ble tilbakestilt",
         "password_changed_preview": "Passordet ditt ble endret",
         "password_reset_heading": "Passordet ditt ble tilbakestilt",
-        "password_changed_heading": "Passordet ditt ble endret",
-        "password_changed_body": "Passordet for B2B SaaS Starter-kontoen din ble {via}. Hvis det var deg, logger du inn med det nye passordet neste gang.",
         "password_reset_via": "tilbakestilt via lenken vi sendte deg",
         "password_changed_via": "endret fra kontoinnstillingene dine",
         "backup_codes_preview": "Gjenopprettingskodene for tofaktorautentisering er erstattet",
@@ -76,7 +82,27 @@
         "account_deleted_preview": "B2B SaaS Starter-kontoen din ble slettet",
         "account_deleted_heading": "Kontoen din ble slettet",
         "account_deleted_body": "B2B SaaS Starter-kontoen din er permanent slettet, sammen med alle innloggede økter.",
-        "account_deleted_warning": "Hvis du ikke slettet kontoen, må du tilbakestille passordet for alle kontoer som deler dette passordet og kontakte brukerstøtte umiddelbart."
+        "account_deleted_warning": "Hvis du ikke slettet kontoen, må du tilbakestille passordet for alle kontoer som deler dette passordet og kontakte brukerstøtte umiddelbart.",
+        "workspaces_deleted": [
+          {
+            "declarations": ["input count", "local category = count: plural"],
+            "selectors": ["category"],
+            "match": {
+              "category=one": "1 arbeidsområde ble slettet.",
+              "category=other": "{count} arbeidsområder ble slettet."
+            }
+          }
+        ],
+        "workspaces_left": [
+          {
+            "declarations": ["input count", "local category = count: plural"],
+            "selectors": ["category"],
+            "match": {
+              "category=one": "Du forlot 1 arbeidsområde.",
+              "category=other": "Du forlot {count} arbeidsområder."
+            }
+          }
+        ]
       },
       "notification": {
         "kind_api_token_created": "API-token opprettet",
@@ -91,29 +117,29 @@
         "footer": "Du mottar denne e-posten på grunn av varslingsinnstillingene dine.",
         "footer_link": "Endre hvordan du mottar disse e-postene eller meld deg av",
         "workspace": "Arbeidsområde: {workspaceName}",
-        "api_token_created_lead": "Noen opprettet et nytt API-token i et arbeidsområde du tilhører. Hvis ingen på teamet ditt gjorde dette, bør du tilbakekalle det nå.",
+        "api_token_created_lead": "Et nytt API-token ble opprettet i et arbeidsområde du tilhører. Hvis du ikke kjenner det igjen, be en eier eller administrator i arbeidsområdet om å undersøke det.",
         "api_token_created_action": "Se API-tokener",
         "api_token_revoked_lead": "Et API-token i et arbeidsområde du tilhører virker ikke lenger. Integrasjoner som brukte det vil begynne å feile.",
         "api_token_revoked_action": "Se API-tokener",
-        "role_changed_lead": "En eier eller administrator endret hva du kan gjøre i dette arbeidsområdet.",
+        "role_changed_lead": "Rollen til et medlem i dette arbeidsområdet ble endret.",
         "role_changed_action": "Åpne arbeidsområdet",
         "two_factor_changed_lead": "Tofaktorautentisering ble slått på eller av for kontoen din. Hvis det ikke var deg, bør du tilbakestille passordet nå.",
         "two_factor_changed_action": "Se kontosikkerhet",
-        "webhook_failed_lead": "Et webhook-endepunkt avviste en levering eller ga opp etter flere forsøk. Leveringshistorikken viser svarkodene.",
+        "webhook_failed_lead": "En webhook-levering mislyktes. Se leveringshistorikken for feilen og status for nye forsøk.",
         "webhook_failed_action": "Åpne webhook-endepunkter",
         "member_joined_lead": "Noen godtok en invitasjon til et arbeidsområde du tilhører.",
         "member_joined_action": "Se medlemmer",
         "plan_changed_lead": "Et arbeidsområde du tilhører har en annen plan. Grenser og rettigheter følger den nye planen fra nå av.",
         "plan_changed_action": "Åpne fakturering",
-        "impersonated_lead": "En systemadministrator åpnet en representasjonsøkt på kontoen din for å hjelpe deg. Dette er registrert i revisjonssporet, og kan ikke endre passordet, tofaktorinnstillingene eller e-postadressen din.",
+        "impersonated_lead": "En systemadministrator åpnet en representasjonsøkt på kontoen din. Dette er registrert i revisjonssporet. Økten kan ikke endre passordet, tofaktorinnstillingene eller e-postadressen din.",
         "impersonated_action": "Se kontosikkerhet",
-        "announcement_lead": "En beskjed til alle i arbeidsområdet.",
+        "announcement_lead": "Du har et nytt varsel.",
         "announcement_action": "Åpne arbeidsområdet",
         "digest_one": "Ett ulest varsel fra de siste 24 timene.",
         "digest_many": "{count} uleste varsler fra de siste 24 timene.",
         "digest_heading": "Din daglige varslingsoppsummering",
         "digest_open": "Åpne arbeidsområdene dine",
-        "digest_greeting": "Hei {recipientName}, {countLine}",
+        "digest_greeting": "{recipientName}, her er den daglige oppsummeringen din. {countLine}",
         "event_webhook_permanent_title": "Webhook-levering mislyktes",
         "event_webhook_permanent_message": "{endpointUrl}: {eventType} ble avvist og blir ikke forsøkt på nytt.",
         "event_webhook_dead_letter_title": "Webhook-levering havnet i dead-letter-køen",
@@ -123,7 +149,7 @@
         "event_webhook_ladder_warning_title": "Webhook-endepunktet feiler",
         "event_webhook_ladder_warning_message": "{target} har hatt {consecutiveFailures} mislykkede leveringer på rad og blir deaktivert automatisk etter {disableAt} feil.",
         "event_impersonation_title": "En systemadministrator åpnet kontoen din",
-        "event_impersonation_message": "{adminName} startet en imitasjonsøkt på kontoen din. Den avsluttes når administratoren stopper den eller etter {minutes} minutter, og kan ikke endre passordet, tofaktorinnstillingene eller e-postadressen din.",
+        "event_impersonation_message": "{adminName} startet en representasjonsøkt på kontoen din. Den avsluttes når administratoren stopper den eller etter {minutes} minutter, og kan ikke endre passordet, tofaktorinnstillingene eller e-postadressen din.",
         "event_export_ready_title": "Eksport av arbeidsområdet er klar",
         "event_export_ready_message": "Eksporten av {workspaceName} er klar for nedlasting fra innstillingene for arbeidsområdet frem til {expiresAt}.",
         "event_plan_changed_title": "Abonnementet ble endret til {planName}",


### PR DESCRIPTION
## Outcome

Fixes the email content and design audit requested after several preview emails showed “API token created.” Each notification preview now has the correct event, label, destination, and preferences link. Production subjects no longer repeat the event title.

All emails use the web app's Catppuccin Mocha colors, square bordered panels, mauve actions, Geist font stacks with email-safe fallbacks, and readable spacing. The shared layout keeps copyable fallback URLs, explicit document/body locale, and pixel-based inline styles.

The English and Norwegian audit corrects invitation claims, magic-link guidance, verification expiry wording, repeated recovery-code advice, account-deletion and digest plural forms, and notification wording that assumed a particular recipient, failure state, or support purpose. Paraglide still selects the recipient's language within the same templates.

## Decisions

- Preview-only default components expose all 20 templates and six auth state/purpose variants. They pass the existing `PreviewProps` explicitly so both development discovery and HTML exports contain real example data.
- Colors are email-safe sRGB equivalents of `apps/web/src/index.css`; emails do not import web CSS or depend on the app package.
- Auth expiry copy was checked against the configured 30-minute reset, one-hour verification, and ten-minute OTP/magic-link windows. Verification does not claim one-time token consumption.

## Validation

Tested revision: `3ba9a668df0f39a26df50cf2355addb70c5fddd9`.

- GitHub CI passed: quality, package tests, web tests, build, E2E, aggregate CI, dependency audit, title gate, and preview deployment.

- `pnpm run check` passed, including typecheck, lint, formatting, dead-code analysis, repository tests, script tests, and operations tests. Local workerd required execution outside the filesystem sandbox.
- `pnpm run build` passed, including the client/server import boundary check.
- Email package: 39 passing tests. Notification-consumer and digest focused tests: 19 passing tests.
- React Email CLI exported all 26 previews. Output inspection found no undefined fields, empty headings, CSS variables, rem units, flex, or grid. Largest formatted HTML: 13,395 bytes.
- Sampled foreground/background, muted text, and primary action contrast ratios range from 5.65:1 to 12.14:1.
- Independent standards and spec reviews passed after fixes.

To inspect: `pnpm -C packages/email dev`. Select the account, notification, digest, and auth variant entries in the preview list.

## Risks and remaining work

Browser verification is reserved for the requester. No local browser automation was run and no test emails were sent. The repository’s automatic CI E2E check passed. Real Gmail, Outlook, and Apple Mail rendering, including forced dark-mode behavior, remains unverified. `pnpm run validate` was not run because it includes browser E2E; check and build were run separately.

This work uses the default-base templates. It does not include the unrelated recovery/auth changes in the separate `oscar` worktree.
