### PR TITLE
fix(security): remediate vulnerable Prisma transitive dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,7 @@ overrides:
   toml: 5.0.0
   undici: 7.29.0
   '@prisma/dev>valibot': 1.4.2
+  '@prisma/dev>@hono/node-server': 1.19.10
   ws: 8.21.0
   vite@*: npm:@voidzero-dev/vite-plus-core@0.3.0
   vitest@*: 4.1.11
@@ -2596,14 +2597,14 @@ packages:
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
 
-  '@hono/node-server@1.19.17':
-    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
+  '@hono/node-server@1.19.10':
+    resolution: {integrity: sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: 4.13.5
 
-  '@hono/node-server@1.19.9':
-    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: 4.13.5
@@ -10846,11 +10847,11 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.17(hono@4.13.5)':
+  '@hono/node-server@1.19.10(hono@4.13.5)':
     dependencies:
       hono: 4.13.5
 
-  '@hono/node-server@1.19.9(hono@4.13.5)':
+  '@hono/node-server@1.19.17(hono@4.13.5)':
     dependencies:
       hono: 4.13.5
 
@@ -11876,7 +11877,7 @@ snapshots:
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
       '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
-      '@hono/node-server': 1.19.9(hono@4.13.5)
+      '@hono/node-server': 1.19.10(hono@4.13.5)
       '@mrleebo/prisma-ast': 0.13.1
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,6 +124,9 @@ overrides:
   # GHSA-5qjj-4xww-7phc: Alchemy's Prisma dev tool pins vulnerable 1.2.0.
   # Remove when @prisma/dev updates its own dependency to >=1.4.2.
   '@prisma/dev>valibot': 1.4.2
+  # CVE-2026-29087: @prisma/dev pins a vulnerable node-server release.
+  # Remove when @prisma/dev updates its own dependency to >=1.19.10.
+  '@prisma/dev>@hono/node-server': 1.19.10
   ws: 8.21.0
   vite@*: 'catalog:'
   vitest@*: 'catalog:'


### PR DESCRIPTION
## Outcome

Remediates the audit failure for `CVE-2026-29087`, where `@prisma/dev@0.20.0` resolved `@hono/node-server@1.19.9`.

The workspace now scopes a pnpm override to `@prisma/dev` and resolves that edge to the fixed `1.19.10` release. The unrelated `1.19.17` dependency used by the MCP SDK remains unchanged.

## Decisions

Prisma is transitive through the repository's `alchemy` development dependency. No direct Prisma runtime dependency was added.

## Validation

- `pnpm install --lockfile-only --offline` — passed; lockfile regenerated.
- Lockfile scan — passed; no `@hono/node-server@1.19.9` entry remains.
- `git diff --check` — passed.
- `node .github/scripts/run-trivy.ts .` — could not complete locally because Trivy is unavailable.
- `pnpm run test:scripts` and frozen install — blocked after pnpm recreated `node_modules` and the sandbox could not reach the npm registry.

## Risks and remaining work

CI should rerun the pinned Trivy audit with its normal database and dependency setup.
