### PR TITLE
ci(security): protect workflow credentials and dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,11 @@ runs:
   steps:
     - name: Install Vite+ (pinned)
       run: |
-        curl -fsSL https://vite.plus | VP_VERSION=0.3.0 VP_NODE_MANAGER=yes bash
+        installer="$(mktemp)"
+        trap 'rm -f "$installer"' EXIT
+        curl -fsSL https://vite.plus -o "$installer"
+        echo 'd4a1ffa8245bdfcf39a786d545be6a43e231b771c32d7c02414bb96d4f5d9cdc  '"$installer" | shasum -a 256 -c -
+        VP_VERSION=0.3.0 VP_NODE_MANAGER=yes bash "$installer"
         # The installer does not touch PATH, so expose its bin dir (vp + managed
         # node/npm/corepack) to later steps.
         echo "$HOME/.local/share/vite-plus/bin" >> "$GITHUB_PATH"
@@ -33,7 +37,7 @@ runs:
       env:
         COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
       shell: bash
-    - uses: actions/cache@v4
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ~/.local/share/pnpm/store
         key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
@@ -44,7 +48,7 @@ runs:
     - name: Restore Vite Task cache
       id: vite-task-cache-restore
       if: ${{ inputs.cache-task == 'true' }}
-      uses: actions/cache/restore@v6
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: node_modules/.vite/task-cache
         key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.workflow }}-${{ github.job }}-${{ strategy.job-index }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/scripts/secret-scan.test.ts
+++ b/.github/scripts/secret-scan.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+const binary = process.env.GITLEAKS_BINARY ?? 'gitleaks'
+
+await test('secret detection catches and permits synthetic fixtures', (t) => {
+  let versionOutput = ''
+  try {
+    versionOutput = execFileSync(binary, ['version'], { encoding: 'utf8' })
+  } catch (error) {
+    if (process.env.GITLEAKS_BINARY) {
+      throw error
+    }
+    t.skip('gitleaks is unavailable')
+    return
+  }
+  assert.match(versionOutput, /\d+\.\d+/)
+
+  const directory = mkdtempSync(join(tmpdir(), 'secret-scan-'))
+  t.after(() => rmSync(directory, { recursive: true, force: true }))
+  execFileSync('git', ['-C', directory, 'init', '--quiet'])
+  execFileSync('git', ['-C', directory, 'config', 'user.email', 'test@example.invalid'])
+  execFileSync('git', ['-C', directory, 'config', 'user.name', 'Synthetic Test'])
+
+  writeFileSync(join(directory, 'clean.txt'), 'ordinary configuration\n')
+  execFileSync('git', ['-C', directory, 'add', 'clean.txt'])
+  execFileSync('git', ['-C', directory, 'commit', '--quiet', '-m', 'clean fixture'])
+  execFileSync(binary, ['detect', '--source', directory, '--redact', '25'], {
+    stdio: 'pipe'
+  })
+
+  writeFileSync(
+    join(directory, 'fixture.env'),
+    [
+      'AWS_ACCESS_KEY_ID=',
+      ['AKIA', 'IOSFODNN7', 'NOTREAL'].join(''),
+      '\nAWS_SECRET_ACCESS_KEY=',
+      ['wJalrXUtnFEMI', '/K7MDENG/bPxRfi', 'CYNOTREALKEY'].join(''),
+      '\n'
+    ].join('')
+  )
+  execFileSync('git', ['-C', directory, 'add', 'fixture.env'])
+  execFileSync('git', ['-C', directory, 'commit', '--quiet', '-m', 'secret fixture'])
+  const scan = spawnSync(binary, ['detect', '--source', directory, '--redact', '25'], {
+    encoding: 'utf8'
+  })
+  assert.ifError(scan.error)
+  assert.equal(scan.status, 1)
+})

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,14 +25,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Install pinned Vite+ Node runtime
         run: |
-          curl -fsSL https://vite.plus | VP_VERSION=0.3.0 VP_NODE_MANAGER=yes bash
+          installer="$(mktemp)"
+          trap 'rm -f "$installer"' EXIT
+          curl -fsSL https://vite.plus -o "$installer"
+          echo 'd4a1ffa8245bdfcf39a786d545be6a43e231b771c32d7c02414bb96d4f5d9cdc  '"$installer" | shasum -a 256 -c -
+          VP_VERSION=0.3.0 VP_NODE_MANAGER=yes bash "$installer"
           echo "$HOME/.local/share/vite-plus/bin" >> "$GITHUB_PATH"
-      - uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567
+      - name: Detect committed secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: 'false'
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: 'false'
+          GITLEAKS_ENABLE_SUMMARY: 'true'
+          GITLEAKS_VERSION: 8.24.3
+      - name: Verify secret detection with synthetic fixtures
+        run: node --test .github/scripts/secret-scan.test.ts
+        env:
+          GITLEAKS_BINARY: gitleaks
+      - uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.74.0
         with:
           version: v0.74.0
           cache: false
@@ -42,7 +59,7 @@ jobs:
           TRIVY_BINARY: trivy
       # Exceptions take effect only after review and merge into the trusted base.
       # Workflow edit protection requires the settings in docs/dependency-security.md.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ (github.event.pull_request.base.ref == github.event.repository.default_branch && github.event.pull_request.base.sha) || github.event.repository.default_branch }}
           path: .audit-policy-base

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -20,6 +20,7 @@ jobs:
     name: Export encrypted production D1 backup
     if: >-
       vars.BACKUP_ENABLED == 'true' &&
+      (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) &&
       (github.event_name == 'workflow_dispatch' || github.event.schedule == '17 2 * * *')
     runs-on: ubuntu-latest
     # Keep these credentials in a dedicated environment with no deployment
@@ -27,7 +28,9 @@ jobs:
     environment: backup
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Create, encrypt, upload, and prune backup
         env:
@@ -49,7 +52,7 @@ jobs:
           node scripts/d1-backup.ts backup | tee backup-evidence.json
       - name: Publish backup evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: d1-backup-evidence-${{ github.run_id }}
           path: backup-evidence.json
@@ -60,12 +63,15 @@ jobs:
     name: Verify backup freshness and integrity
     if: >-
       vars.BACKUP_ENABLED == 'true' &&
+      (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) &&
       (github.event_name == 'workflow_dispatch' || github.event.schedule == '47 4 * * *')
     runs-on: ubuntu-latest
     environment: backup
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Verify latest completed backup
         env:

--- a/.github/workflows/catalog-update.yml
+++ b/.github/workflows/catalog-update.yml
@@ -29,18 +29,19 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # The action compares branches against the full history to close
           # stale PRs and rebuild conflicting ones.
           fetch-depth: 0
           token: ${{ secrets.CI_PAT }}
+          persist-credentials: false
 
       # The catalogs are pnpm-defined, so the action installs and audits
       # through pnpm (auto-detected from pnpm-workspace.yaml).
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: brandhaug/catalog-update-action@v1
+      - uses: brandhaug/catalog-update-action@a0e9ad94e9cb6c053cbbcc32e4db76e030732468 # v1
         with:
           config: '.catalog-updaterc.json'
           dry-run: 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         id: setup
         with:
@@ -42,7 +44,7 @@ jobs:
           git diff --exit-code -- apps/*/wrangler.jsonc
       - name: Save Vite Task cache
         if: success()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.setup.outputs.vite-task-cache-primary-key }}
@@ -61,7 +63,9 @@ jobs:
             filter: '!web'
     name: Tests (${{ matrix.name }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         id: setup
         with:
@@ -84,7 +88,7 @@ jobs:
         run: pnpm run test:operations
       - name: Save Vite Task cache
         if: success()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.setup.outputs.vite-task-cache-primary-key }}
@@ -92,7 +96,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         id: setup
         with:
@@ -100,7 +106,7 @@ jobs:
       - run: vp run build
       - name: Save Vite Task cache
         if: success()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.setup.outputs.vite-task-cache-primary-key }}
@@ -130,7 +136,9 @@ jobs:
       matrix:
         shard: [1, 2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - run: pnpm exec playwright install --with-deps --only-shell chromium
       # The compiled preview attaches this local D1 for real authentication.
@@ -142,7 +150,7 @@ jobs:
         run: node .github/scripts/run-check.ts e2e --shard=${{ matrix.shard }}/2
       - name: Upload Playwright results and traces
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-results-${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
@@ -166,7 +174,7 @@ jobs:
 
   deploy:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/master')
     needs: [ci, e2e]
     runs-on: ubuntu-latest
@@ -175,7 +183,9 @@ jobs:
       group: deploy-production
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       # Migrations are squashed routinely, and a squash renames the surviving
       # folder. Alchemy tracks applied migrations by that folder name, so the

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enforce Conventional Commits
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,8 +12,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
-# Repository secrets are exposed to this workflow, so it must never run PR
-# code from a fork: every job checks `head.repo.full_name == github.repository`.
+# Preview-environment secrets are exposed to this workflow, so it must never run
+# PR code from a fork: every job checks `head.repo.full_name == github.repository`.
 # Dependabot runs see a separate (empty) secret set and are skipped too.
 permissions:
   contents: read
@@ -27,10 +27,6 @@ concurrency:
 
 env:
   ALCHEMY_STAGE: pr-${{ github.event.pull_request.number }}
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  # A preview-only secret, distinct from the `production` environment's.
-  BETTER_AUTH_SECRET: ${{ secrets.PREVIEW_BETTER_AUTH_SECRET }}
   GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
   SERVICE_VERSION: pr-${{ github.event.pull_request.number }}
 
@@ -38,12 +34,21 @@ jobs:
   deploy:
     name: Deploy preview stage
     if: >-
+      vars.PREVIEW_ENABLED == 'true' &&
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    environment: preview
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.PREVIEW_CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PREVIEW_CLOUDFLARE_ACCOUNT_ID }}
+      # A preview-only secret, distinct from the `production` environment's.
+      BETTER_AUTH_SECRET: ${{ secrets.PREVIEW_BETTER_AUTH_SECRET }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Resolve preview URLs
         id: urls
@@ -75,15 +80,26 @@ jobs:
   destroy:
     name: Destroy preview stage
     if: >-
+      vars.PREVIEW_ENABLED == 'true' &&
       github.event.action == 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    # Cleanup must not wait for approval after a pull request closes.
+    # Configure this environment with the same preview-only secrets and no
+    # production permissions, but without required reviewers.
+    environment: preview-cleanup
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.PREVIEW_CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PREVIEW_CLOUDFLARE_ACCOUNT_ID }}
+      # A preview-only secret, distinct from the `production` environment's.
+      BETTER_AUTH_SECRET: ${{ secrets.PREVIEW_BETTER_AUTH_SECRET }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # The merge ref is gone once a PR merges; the head commit is not.
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup
       # alchemy.run.ts resolves the stage's URLs at module scope even on
       # destroy, so the same inputs are needed here.

--- a/.github/workflows/queue-monitor.yml
+++ b/.github/workflows/queue-monitor.yml
@@ -14,12 +14,16 @@ concurrency:
 
 jobs:
   inspect:
-    if: vars.OPS_MONITORING_ENABLED == 'true'
+    if: >-
+      vars.OPS_MONITORING_ENABLED == 'true' &&
+      (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: ubuntu-latest
     environment: operations-monitoring
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Check queue backlog without consuming messages
         env:

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -1,0 +1,74 @@
+# CI security controls
+
+The workflows use least-privilege default permissions, immutable action revisions,
+and separate environments for jobs that can change production or operational data.
+Pull-request jobs run with read-only repository access. Production deployment is
+reachable only from the default branch after the required build and test jobs;
+manual runs on other branches cannot use those credentials. Backup and queue
+monitoring dispatches have the same default-branch restriction.
+
+## Workflow dependencies
+
+Every third-party action is pinned to a full commit SHA with a version comment.
+When updating an action, an operator should review the upstream release and
+changelog, resolve the release tag to its full commit, update the SHA and comment
+in one pull request, and let the normal CI, audit, and review protections run.
+Do not replace an immutable revision with a tag. Local composite actions are part
+of this repository and are reviewed with the workflow that calls them.
+The Vite+ installer is downloaded over HTTPS and checked against a recorded
+SHA-256 before execution; update that digest only after reviewing the installer
+release and recording the new value in the same change.
+
+The catalog updater has a narrowly scoped write token because it opens dependency
+update pull requests. Checkout does not persist credentials. The preview workflow
+uses dedicated, non-production `preview` and `preview-cleanup` environments and
+has deployment credentials only for same-repository pull requests; it skips forks
+and Dependabot.
+The environment secrets are named `PREVIEW_CLOUDFLARE_API_TOKEN`,
+`PREVIEW_CLOUDFLARE_ACCOUNT_ID`, and `PREVIEW_BETTER_AUTH_SECRET`; the token must
+be scoped to preview resources and have no production permissions. Keep required
+reviewers and environment audit logging enabled for `preview`; `preview-cleanup`
+must not require approval so teardown cannot be stranded. A same-repository pull
+request is still untrusted code and must never receive
+production credentials.
+The repository variable `PREVIEW_ENABLED` is an operator-controlled gate; leave it
+unset until both preview environments are configured and verified.
+
+## Secret detection
+
+The audit workflow runs the pinned Gitleaks Action v3 and a synthetic regression test.
+The test checks a clean repository, catches a committed AWS-shaped fixture, and
+fails if the configured binary is unavailable in CI. The fixture is never a real
+credential and is created only in a temporary repository. Gitleaks detects the
+patterns covered by its current rules; it cannot prove that every provider token,
+encoded value, runtime secret, or value stored outside Git is safe. Operators must
+still review secret changes and provider exposure.
+
+The audit job is a required check only after an operator adds its exact check name
+to the active default-branch ruleset. A green workflow before that change is
+informational and does not protect merges. Required review, stale-approval
+dismissal, approval of the latest push, and the absence of bypass actors are also
+operator-owned GitHub settings. Record the ruleset response, check-run URL, commit,
+and observation time in the private security record; do not commit credentials or
+private evidence links.
+
+## Credential incident path
+
+When a secret is detected, stop using the affected credential, preserve the alert
+and commit metadata without copying the secret value, and restrict access to the
+incident record. Revoke or rotate it at the issuing provider, replace the GitHub
+secret or environment value, and invalidate dependent sessions, signing keys, or
+deployment tokens as applicable. Remove the value from the repository and history
+only after preserving the minimum evidence and confirming that rotation makes old
+copies unusable; history rewriting is not a substitute for revocation.
+
+Check workflow logs, artifacts, caches, pull-request comments, forks, and provider
+audit records for exposure. Clean up exposed artifacts and notify affected owners
+or providers according to the operator's incident procedure. Record detection,
+scope, revocation time, replacement, evidence locations, cleanup, and follow-up
+prevention. Never paste the credential into an issue, log, test, or evidence file.
+
+GitHub secret storage, environment approval rules, default-branch rulesets,
+repository Actions policy, and provider-side audit logs cannot be verified from
+the repository. Treat them as incomplete until an authorized operator records
+fresh observations.

--- a/docs/dependency-security.md
+++ b/docs/dependency-security.md
@@ -1,5 +1,8 @@
 # Dependency security check
 
+Workflow action pinning, committed-secret detection, and the credential incident
+path are documented in the [CI security controls](ci-security.md).
+
 ## Scope and failure policy
 
 The `audit` job in [Audit](../.github/workflows/audit.yml) uses pinned Trivy v0.74.0

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -139,20 +139,29 @@ and sets `ENVIRONMENT=preview`. A preview is publicly reachable and
 signs in with the documented demo credentials, so never point one at
 real data.
 
-### Repository secrets for previews
+### Preview environment secrets
 
-The workflow reads **repository** secrets (Settings → Secrets and
-variables → Actions), not the `production` environment:
+The workflow reads secrets from the dedicated `preview` environment (Settings →
+Environments → preview), not repository secrets or the `production` environment:
 
-| Secret                       | Required | Value                                                                                           |
-| ---------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`       | yes      | A token with the permissions from step 2 above; a separate token from production is a good idea |
-| `CLOUDFLARE_ACCOUNT_ID`      | yes      | From step 1 above                                                                               |
-| `PREVIEW_BETTER_AUTH_SECRET` | yes      | `openssl rand -base64 32`; shared by all preview stages, never the production value             |
+| Secret                          | Required | Value                                                                                          |
+| ------------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `PREVIEW_CLOUDFLARE_API_TOKEN`  | yes      | A token with only preview-stage permissions; it must not deploy or change production resources |
+| `PREVIEW_CLOUDFLARE_ACCOUNT_ID` | yes      | From step 1 above                                                                              |
+| `PREVIEW_BETTER_AUTH_SECRET`    | yes      | `openssl rand -base64 32`; shared by all preview stages, never the production value            |
 
 `BETTER_AUTH_URL` is not a secret here: the workflow resolves the
 account's `workers.dev` subdomain through the API and `alchemy.run.ts`
 derives the URL from the stage's web Worker name.
+
+Create a matching `preview-cleanup` environment with these exact three secrets:
+`PREVIEW_CLOUDFLARE_API_TOKEN`, `PREVIEW_CLOUDFLARE_ACCOUNT_ID`, and
+`PREVIEW_BETTER_AUTH_SECRET`. Give it no required reviewers. Closed pull requests
+must be able to destroy their stage without waiting for approval; both environments
+must stay limited to preview resources and separate from production.
+Set the repository Actions variable `PREVIEW_ENABLED=true` only after both
+environments and their credentials are verified. With the variable unset, preview
+jobs are intentionally skipped instead of running with empty credentials.
 
 ### Running a preview stage from a laptop
 


### PR DESCRIPTION
## Outcome

Implements the next unblocked security-baseline slice: CI workflow credential and dependency protection.

- Immutable SHA pins now cover every third-party GitHub Action, with an update process documented in [CI security controls](../blob/e9c4c1b/docs/ci-security.md).
- Workflow permissions, checkout credentials, default-branch dispatch restrictions, and preview-only environments reduce credential exposure; preview and cleanup secrets are explicitly separated from production.
- Audit now runs pinned Gitleaks secret detection and a synthetic positive/negative regression test.
- Added a credential incident path and documented operator-owned GitHub settings and evidence gaps.

Acceptance evidence: AC-13.1–AC-13.5 are covered by the workflow changes, `.github/scripts/secret-scan.test.ts`, `docs/ci-security.md`, and the existing validation workflows. GitHub ruleset enforcement and environment settings remain operator-owned and are explicitly not claimed as verified by repository code.

## Decisions

- The Vite+ installer is downloaded over HTTPS and verified against a recorded SHA-256 before execution.
- Preview deployment uses non-production `preview` and approval-free `preview-cleanup` environments with dedicated `PREVIEW_*` secret names. Operators must scope those credentials to preview resources.
- Existing provider and deployment behavior remains unchanged outside workflow gating and secret boundaries.

## Validation

Tested revision: `074a8b37e0e005d1b32a143a50030a8994208e5d` (rebased onto current `master`).

- Passed: `pnpm run lint`
- Passed: `pnpm run format:check`
- Passed: `pnpm run test:scripts` (39 passed, 2 skipped because local Gitleaks/Trivy binaries are unavailable; CI audit supplies them)
- Passed on GitHub: CI quality/build/package/web/E2E aggregate, Audit, and PR Gate for the final head. Preview deploy is intentionally skipped until `PREVIEW_ENABLED=true` and the preview environments are configured.
- `pnpm run check` / `pnpm run validate`: blocked by the unrelated existing `packages/ai/src/openai.test.ts` redirect test failing to bind a local listener in this environment. Typecheck, lint, format, dead-code, and all preceding tests passed.
- Local Gitleaks execution could not be completed because the release download endpoint returned HTTP 500; the CI workflow installs the pinned scanner and makes the synthetic test mandatory.

## Risks and remaining work

- An operator must configure the `preview`, `preview-cleanup`, and production environments, their secret scopes, required reviewers, and default-branch required checks. Repository code cannot verify those settings.
- Preview jobs remain intentionally skipped until the operator sets `PREVIEW_ENABLED=true` after configuring both non-production environments.
- The `audit` check must be added to the active default-branch ruleset after merge; the current observed ruleset requires only `ci` and `e2e`.
- No known implementation blockers remain.
