### PR TITLE
fix(web): hide unavailable demo links

### DIFF
--- a/apps/web/src/components/landing/closing-section.tsx
+++ b/apps/web/src/components/landing/closing-section.tsx
@@ -6,7 +6,7 @@ import { GITHUB_URL } from '@/components/landing/github-url'
 import { DEV_SERVERS, SETUP_STEPS } from '@/lib/toolchain'
 import { m } from '@b2b-saas-starter/i18n/messages'
 
-function ClosingSection() {
+function ClosingSection({ showDemo }: { readonly showDemo: boolean }) {
   // The whole command block, one click into the clipboard: the clone line
   // plus every quickstart step, `&&`-joined so it pastes as one paste. Same
   // copy pattern as secret-reveal: await, confirm visibly, clear after 2s.
@@ -35,10 +35,12 @@ function ClosingSection() {
             {m.landing_fork_description()}
           </p>
           <div className="mt-8 flex flex-wrap gap-3">
-            <Button nativeButton={false} render={<Link to="/demo" />} size="lg">
-              {m.action_open_demo()}
-              <ArrowRightIcon className="size-4" />
-            </Button>
+            {showDemo ? (
+              <Button nativeButton={false} render={<Link to="/demo" />} size="lg">
+                {m.action_open_demo()}
+                <ArrowRightIcon className="size-4" />
+              </Button>
+            ) : null}
             <Button
               nativeButton={false}
               render={<Link to="/docs" />}

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -17,7 +17,7 @@ const BILL_OF_MATERIALS: ReadonlyArray<string> = [
   'Alchemy v2'
 ]
 
-function HeroSection() {
+function HeroSection({ showDemo }: { readonly showDemo: boolean }) {
   return (
     <section className="border-b border-border">
       <div className="mx-auto max-w-7xl px-4 pt-16 pb-12 sm:px-6 lg:pt-28 lg:pb-16">
@@ -49,10 +49,12 @@ function HeroSection() {
                   the header carries one on every scroll position, and a
                   second at the fold read as a duplicate control, not a
                   choice. */}
-              <Button nativeButton={false} render={<Link to="/demo" />} size="lg">
-                {m.action_open_demo()}
-                <ArrowRightIcon className="size-4" />
-              </Button>
+              {showDemo ? (
+                <Button nativeButton={false} render={<Link to="/demo" />} size="lg">
+                  {m.action_open_demo()}
+                  <ArrowRightIcon className="size-4" />
+                </Button>
+              ) : null}
               <a
                 href={GITHUB_URL}
                 target="_blank"

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -66,14 +66,14 @@ function HomePage() {
   return (
     <PublicLayout>
       <main id="main-content">
-        <HeroSection />
+        <HeroSection showDemo={demo !== null} />
         {/* `null` means the showcase workspace is missing in this deployment:
             the page renders without the numbers instead of failing. */}
         {demo === null ? null : <DemoStrip demo={demo} />}
         <RequestTraceSection overview={demo === null ? null : demo.overview} />
         <ProvidersSection />
         <KnowledgeSection recentDocs={recentDocs} recentPosts={recentPosts} />
-        <ClosingSection />
+        <ClosingSection showDemo={demo !== null} />
       </main>
     </PublicLayout>
   )


### PR DESCRIPTION
## Outcome

Landing-page demo CTAs now render only when the showcase workspace is available. Unseeded deployments no longer expose links to `/demo` that resolve to the not-found page.

The `/demo` route remains the fixed, read-only showcase route when the workspace is seeded.

## Decisions

The landing page already hides the live-numbers strip when the showcase is unavailable. The hero and closing CTAs now use the same availability signal.

## Validation

Validated at commit `9a3ff46`:

- `pnpm -C apps/web typecheck`
- `pnpm exec vp lint apps/web/src/routes/index.tsx apps/web/src/components/landing/hero-section.tsx apps/web/src/components/landing/closing-section.tsx`
- `pnpm exec vp fmt --check apps/web/src/routes/index.tsx apps/web/src/components/landing/hero-section.tsx apps/web/src/components/landing/closing-section.tsx`
- `pnpm -C apps/web build`

All passed. The build reported only existing ineffective dynamic-import warnings. The live Worker was not smoke-tested from this environment.

## Risks and remaining work

Deploy the merged revision to update the public Worker. A deployment with the showcase workspace seeded will continue to show the demo CTAs and serve `/demo`.
