### PR TITLE
feat(web): rebuild animated request trace diagram

### DIFF
--- a/apps/web/src/components/landing/architecture-schematic.tsx
+++ b/apps/web/src/components/landing/architecture-schematic.tsx
@@ -1,11 +1,6 @@
-/* oxlint-disable jsx-a11y/prefer-tag-over-role -- inline SVG can't be an <img>; role="img" + aria-label is the canonical pattern */
+/* oxlint-disable jsx-a11y/prefer-tag-over-role -- inline SVG uses role="img" for its accessible description */
 import { m } from '@b2b-saas-starter/i18n/messages'
 
-/**
- * The schematic's addressable nodes: the stage a narrative scroll is on can
- * light the node it is discussing (peach fill + stroke), so the diagram works
- * as a "you are here" map, not just an artifact.
- */
 export type SchematicNode =
   | 'browser'
   | 'curl'
@@ -19,604 +14,223 @@ export type SchematicNode =
   | 'queues'
   | 'email'
 
-const ACTIVE_NODE_CLASSES = 'fill-signal/15 stroke-signal'
-const ACTIVE_TEXT_CLASSES = 'fill-signal'
+// The moving signals and resting wires share geometry so pulses never jump.
+const CONNECTIONS = [
+  { path: 'M52 66 V108', step: 0 },
+  { path: 'M150 66 V84 Q150 92 158 92 H192 Q200 92 200 100 V108', step: 0 },
+  { path: 'M248 66 V84 Q248 92 240 92 H208 Q200 92 200 100 V108', step: 0 },
+  { path: 'M348 66 V108', step: 0 },
+  { path: 'M52 170 V202 Q52 218 68 218 H184 Q200 218 200 234 V250', step: 1 },
+  { path: 'M200 170 V250', step: 1 },
+  { path: 'M348 170 V202 Q348 218 332 218 H216 Q200 218 200 234 V250', step: 1 },
+  { path: 'M200 322 V342 Q200 358 184 358 H68 Q52 358 52 374 V402', step: 2 },
+  { path: 'M200 322 V402', step: 2 },
+  { path: 'M200 322 V342 Q200 358 216 358 H332 Q348 358 348 374 V402', step: 2 }
+] satisfies ReadonlyArray<{ readonly path: string; readonly step: number }>
 
-/**
- * Wiring diagram of the actual monorepo topology, drawn as an engineering
- * schematic. Every label is a real path in this repository. Amber pulses
- * trace request/job flow; they are hidden under prefers-reduced-motion
- * (see `.schematic-pulse` in index.css).
- *
- * Two variants of the same drawing: `full` (the default) is the scrollable
- * figure above the narrative spine; `dense` is the sticky rail's copy — a
- * compact redraw whose labels are pinned to 11 CSS pixels rather than scaled
- * down with the canvas. The rail renders at one fixed content width (the
- * 25rem column minus its card padding = 368px, which is also the dense
- * viewBox width), so 11 viewBox units land as 11px on screen — the difference
- * between a map that can be read and dark smudges at 5–7px.
- */
 export function ArchitectureSchematic({
-  activeNodes,
-  variant = 'full',
-  className
-}: {
-  /** Nodes currently under discussion; none renders the resting schematic. */
-  readonly activeNodes?: ReadonlyArray<SchematicNode>
-  /** `dense` redraws for the sticky rail at fixed 11px labels. */
-  readonly variant?: 'full' | 'dense'
-  /** Sizing override — `full` defaults to its natural width, `dense` fills. */
-  readonly className?: string
-}) {
-  return variant === 'dense' ? (
-    <DenseSchematic
-      {...(activeNodes === undefined ? {} : { activeNodes })}
-      className={className}
-    />
-  ) : (
-    <FullSchematic
-      {...(activeNodes === undefined ? {} : { activeNodes })}
-      className={className ?? 'w-full min-w-135'}
-    />
-  )
-}
-
-function FullSchematic({
-  activeNodes,
-  className
-}: {
-  readonly activeNodes?: ReadonlyArray<SchematicNode> | undefined
-  readonly className: string
-}) {
-  const active = new Set(activeNodes)
-  return (
-    <svg
-      viewBox="0 0 560 460"
-      role="img"
-      aria-label={m.public_architecture_aria()}
-      className={className}
-    >
-      <title>{m.public_architecture_title()}</title>
-
-      {/* wire routes (also used as pulse motion paths) — strokes at /60 clear
-          the 3:1 non-text contrast bar against the card surface; /45 did not */}
-      <g className="stroke-muted-foreground/60" fill="none" strokeWidth="1">
-        <path d="M128 66 H196" strokeDasharray="4 3" />
-        <path d="M128 146 H172 V152 H196" strokeDasharray="4 3" />
-        <path d="M128 206 H172 V196 H196" strokeDasharray="4 3" />
-        <path d="M128 312 H196" strokeDasharray="4 3" />
-        <path d="M336 66 H398" />
-        <path d="M336 174 H398" />
-        <path d="M336 312 H398" />
-        <path d="M424 80 H470" />
-        <path d="M424 200 H470" />
-        <path d="M424 300 H470" />
-      </g>
-
-      {/* invisible continuous routes for the pulses */}
-      <defs>
-        <path id="route-browser-d1" d="M128 66 H411 V80 H470" />
-        <path id="route-rest-d1" d="M128 146 H411 V80 H470" />
-        <path id="route-queue-webhooks" d="M128 312 H411 V200 H470" />
-        <path id="route-queue-email" d="M128 312 H411 V300 H470" />
-      </defs>
-
-      {/* clients (external world: dashed) */}
-      <g>
-        <ClientNode
-          x={16}
-          y={48}
-          label={m.shell_diagram_browser()}
-          active={active.has('browser')}
-        />
-        <ClientNode x={16} y={128} label="curl / SDK" active={active.has('curl')} />
-        <ClientNode
-          x={16}
-          y={188}
-          label={m.shell_diagram_mcp_client()}
-          active={active.has('mcp')}
-        />
-        <ClientNode
-          x={16}
-          y={294}
-          label={m.shell_diagram_queue_jobs()}
-          active={active.has('queue')}
-        />
-      </g>
-
-      {/* workers */}
-      <WorkerNode
-        x={196}
-        y={40}
-        h={52}
-        label="apps/web"
-        sub="Worker · TanStack Start"
-        active={active.has('web')}
-      />
-      <WorkerNode
-        x={196}
-        y={136}
-        h={76}
-        label="apps/api"
-        sub="Worker · REST + MCP"
-        active={active.has('api')}
-      />
-      <WorkerNode
-        x={196}
-        y={286}
-        h={52}
-        label="apps/background"
-        sub="Worker · queue consumer"
-        active={active.has('background')}
-      />
-
-      {/* capabilities spine */}
-      <g>
-        <rect
-          x="398"
-          y="40"
-          width="26"
-          height="298"
-          className={
-            active.has('capabilities')
-              ? `transition-colors duration-300 ${ACTIVE_NODE_CLASSES}`
-              : 'fill-primary/10 stroke-primary/60 transition-colors duration-300'
-          }
-          strokeWidth="1"
-        />
-        <text
-          transform="rotate(-90 411 189)"
-          x="411"
-          y="189"
-          textAnchor="middle"
-          dominantBaseline="central"
-          className={`font-mono text-3xs transition-colors duration-300 ${
-            active.has('capabilities') ? ACTIVE_TEXT_CLASSES : 'fill-primary'
-          }`}
-        >
-          packages/capabilities
-        </text>
-        {/* junction ports on the spine */}
-        {[66, 80, 174, 200, 300, 312].map((y) => (
-          <circle
-            key={y}
-            cx={y === 66 || y === 174 || y === 312 ? 398 : 424}
-            cy={y}
-            r="2.5"
-            className="fill-background stroke-primary/70"
-            strokeWidth="1"
-          />
-        ))}
-      </g>
-
-      {/* infrastructure */}
-      <InfraNode x={470} y={60} label="D1" active={active.has('d1')} />
-      <InfraNode x={470} y={180} label="Queues" active={active.has('queues')} />
-      <InfraNode x={470} y={280} label="Email" active={active.has('email')} />
-
-      {/* signal pulses */}
-      <g className="schematic-pulse">
-        <Pulse href="#route-browser-d1" dur="4s" begin="0s" />
-        <Pulse href="#route-rest-d1" dur="4.6s" begin="1.4s" />
-        <Pulse href="#route-queue-webhooks" dur="5.2s" begin="2.6s" />
-        <Pulse href="#route-queue-email" dur="5.8s" begin="3.8s" />
-      </g>
-
-      {/* registration marks */}
-      <g className="stroke-muted-foreground/60" strokeWidth="1">
-        <path d="M166 16 v8 M162 20 h8" />
-        <path d="M166 428 v8 M162 432 h8" />
-        <path d="M450 16 v8 M446 20 h8" />
-      </g>
-
-      {/* title block */}
-      <g className="font-mono">
-        <rect
-          x="336"
-          y="404"
-          width="208"
-          height="40"
-          className="fill-transparent stroke-border"
-          strokeWidth="1"
-        />
-        <line
-          x1="336"
-          y1="424"
-          x2="544"
-          y2="424"
-          className="stroke-border"
-          strokeWidth="1"
-        />
-        <text
-          x="344"
-          y="417"
-          className="fill-muted-foreground text-4xs"
-          dominantBaseline="middle"
-        >
-          {m.shell_diagram_topology()}
-        </text>
-        <text
-          x="344"
-          y="437"
-          className="fill-muted-foreground text-4xs"
-          dominantBaseline="middle"
-        >
-          {m.shell_diagram_sheet()}
-        </text>
-      </g>
-    </svg>
-  )
-}
-
-function ClientNode({
-  x,
-  y,
-  label,
-  active = false
-}: {
-  readonly x: number
-  readonly y: number
-  readonly label: string
-  readonly active?: boolean
-}) {
-  return (
-    <g>
-      <rect
-        x={x}
-        y={y}
-        width="112"
-        height="36"
-        className={
-          active
-            ? `transition-colors duration-300 ${ACTIVE_NODE_CLASSES}`
-            : 'fill-transparent stroke-muted-foreground/60 transition-colors duration-300'
-        }
-        strokeWidth="1"
-        strokeDasharray="4 3"
-      />
-      <text
-        x={x + 56}
-        y={y + 18}
-        textAnchor="middle"
-        dominantBaseline="central"
-        className={`font-mono text-3xs transition-colors duration-300 ${
-          active ? ACTIVE_TEXT_CLASSES : 'fill-muted-foreground'
-        }`}
-      >
-        {label}
-      </text>
-    </g>
-  )
-}
-
-function WorkerNode({
-  x,
-  y,
-  h,
-  label,
-  sub,
-  active = false
-}: {
-  readonly x: number
-  readonly y: number
-  readonly h: number
-  readonly label: string
-  readonly sub: string
-  readonly active?: boolean
-}) {
-  return (
-    <g>
-      <rect
-        x={x}
-        y={y}
-        width="140"
-        height={h}
-        className={
-          active
-            ? `transition-colors duration-300 ${ACTIVE_NODE_CLASSES}`
-            : 'fill-card stroke-foreground/60 transition-colors duration-300'
-        }
-        strokeWidth="1"
-      />
-      <rect x={x + 128} y={y + 6} width="5" height="5" className="fill-signal" />
-      <text
-        x={x + 12}
-        y={y + h / 2 - 7}
-        className={`font-mono text-2xs font-medium transition-colors duration-300 ${
-          active ? ACTIVE_TEXT_CLASSES : 'fill-foreground'
-        }`}
-      >
-        {label}
-      </text>
-      <text
-        x={x + 12}
-        y={y + h / 2 + 9}
-        className="fill-muted-foreground font-mono text-4xs"
-      >
-        {sub}
-      </text>
-    </g>
-  )
-}
-
-function InfraNode({
-  x,
-  y,
-  label,
-  active = false
-}: {
-  readonly x: number
-  readonly y: number
-  readonly label: string
-  readonly active?: boolean
-}) {
-  return (
-    <g>
-      <rect
-        x={x}
-        y={y}
-        width="74"
-        height="40"
-        className={
-          active
-            ? `transition-colors duration-300 ${ACTIVE_NODE_CLASSES}`
-            : 'fill-secondary stroke-muted-foreground/60 transition-colors duration-300'
-        }
-        strokeWidth="1"
-      />
-      <text
-        x={x + 37}
-        y={y + 20}
-        textAnchor="middle"
-        dominantBaseline="central"
-        className={`font-mono text-3xs transition-colors duration-300 ${
-          active ? ACTIVE_TEXT_CLASSES : 'fill-foreground'
-        }`}
-      >
-        {label}
-      </text>
-    </g>
-  )
-}
-
-function Pulse({
-  href,
-  dur,
-  begin
-}: {
-  readonly href: string
-  readonly dur: string
-  readonly begin: string
-}) {
-  return (
-    <circle r="3" className="fill-signal">
-      <animateMotion dur={dur} begin={begin} repeatCount="indefinite">
-        <mpath href={href} />
-      </animateMotion>
-    </circle>
-  )
-}
-
-/**
- * The rail's redraw of the same topology: same nodes, same wires, same
- * highlight vocabulary — sized so every label is exactly 11px. No sub-labels,
- * no title block (the rail's caption below the drawing does that work), and
- * wires only where a dense canvas keeps them legible.
- */
-function DenseSchematic({
   activeNodes,
   className = 'w-full'
 }: {
-  readonly activeNodes?: ReadonlyArray<SchematicNode> | undefined
-  readonly className?: string | undefined
+  readonly activeNodes?: ReadonlyArray<SchematicNode>
+  readonly className?: string
 }) {
   const active = new Set(activeNodes)
-  // Node geometry: clients x=0 w=84 h=26; workers x=132 w=112; spine x=272
-  // w=14; infra x=306 w=62 h=32. Rows keep the full variant's pairing.
   return (
     <svg
-      viewBox="0 0 368 278"
+      viewBox="0 0 408 460"
       role="img"
       aria-label={m.public_architecture_aria()}
       className={className}
     >
       <title>{m.public_architecture_title()}</title>
-
-      <g className="stroke-muted-foreground/60" fill="none" strokeWidth="1">
-        <path d="M84 25 H132" strokeDasharray="4 3" />
-        <path d="M84 101 H132" strokeDasharray="4 3" />
-        <path d="M84 161 H132" strokeDasharray="4 3" />
-        <path d="M84 245 H132" strokeDasharray="4 3" />
-        <path d="M244 25 H272" />
-        <path d="M244 124 H272" />
-        <path d="M244 245 H272" />
-        <path d="M286 52 H306" />
-        <path d="M286 152 H306" />
-        <path d="M286 245 H306" />
+      <g fill="none" strokeWidth="1" className="stroke-muted-foreground/50">
+        {CONNECTIONS.map(({ path }) => (
+          <path key={path} d={path} />
+        ))}
       </g>
-
-      <defs>
-        <path
-          id="dense-route-browser-d1"
-          d="M84 25 H244 V124 H272 M286 52 H296 V245 H306"
-        />
-        <path id="dense-route-rest-d1" d="M84 101 H132 M244 124 H272 M286 52 H306" />
-        <path id="dense-route-queue-email" d="M84 245 H244 V245 H272 M286 245 H306" />
-      </defs>
-
-      <g>
-        <DenseNode
-          x={0}
-          y={12}
-          w={84}
-          label={m.shell_diagram_browser()}
-          dashed
-          active={active.has('browser')}
-        />
-        <DenseNode
-          x={0}
-          y={88}
-          w={84}
-          label="curl / SDK"
-          dashed
-          active={active.has('curl')}
-        />
-        <DenseNode
-          x={0}
-          y={148}
-          w={84}
-          label={m.shell_diagram_mcp_client()}
-          dashed
-          active={active.has('mcp')}
-        />
-        <DenseNode
-          x={0}
-          y={232}
-          w={84}
-          label={m.shell_diagram_queue_jobs()}
-          dashed
-          active={active.has('queue')}
-        />
+      <g
+        fill="none"
+        strokeWidth="2"
+        strokeLinecap="round"
+        className="schematic-pulse stroke-signal"
+      >
+        {CONNECTIONS.map(({ path, step }) => (
+          <path
+            key={path}
+            d={path}
+            pathLength="100"
+            className="trace-signal"
+            style={{ animationDelay: `${step * 1.8}s` }}
+          />
+        ))}
       </g>
+      <TraceNode
+        x={8}
+        y={26}
+        width={88}
+        label={m.shell_diagram_browser()}
+        active={active.has('browser')}
+        external
+      />
+      <TraceNode
+        x={106}
+        y={26}
+        width={88}
+        label="HTTP client"
+        active={active.has('curl')}
+        external
+      />
+      <TraceNode
+        x={204}
+        y={26}
+        width={88}
+        label={m.shell_diagram_mcp_client()}
+        active={active.has('mcp')}
+        external
+      />
+      <TraceNode
+        x={302}
+        y={26}
+        width={92}
+        label={m.shell_diagram_queue_jobs()}
+        active={active.has('queue')}
+        external
+      />
 
-      <g>
-        <DenseNode x={132} y={12} w={112} label="apps/web" active={active.has('web')} />
-        <DenseNode x={132} y={76} w={112} label="apps/api" active={active.has('api')} />
-        <DenseNode
-          x={132}
-          y={232}
-          w={112}
-          label="apps/background"
-          active={active.has('background')}
-        />
-      </g>
+      <TraceNode
+        x={8}
+        y={108}
+        width={88}
+        label="web"
+        sub="TanStack Start"
+        active={active.has('web')}
+      />
+      <TraceNode
+        x={144}
+        y={108}
+        width={112}
+        label="api"
+        sub="REST + MCP"
+        active={active.has('api')}
+      />
+      <TraceNode
+        x={296}
+        y={108}
+        width={104}
+        label="background"
+        sub="queue consumer"
+        active={active.has('background')}
+      />
 
-      <g>
+      <g className="trace-node" data-active={active.has('capabilities')}>
         <rect
-          x="272"
-          y="12"
-          width="14"
-          height="246"
-          className={
-            active.has('capabilities')
-              ? `transition-colors duration-300 ${ACTIVE_NODE_CLASSES}`
-              : 'fill-primary/10 stroke-primary/60 transition-colors duration-300'
-          }
-          strokeWidth="1"
+          x="56"
+          y="250"
+          width="288"
+          height="72"
+          className="trace-node-body fill-signal/5 stroke-signal/50"
         />
         <text
-          transform="rotate(-90 279 135)"
-          x="279"
-          y="135"
+          x="200"
+          y="278"
           textAnchor="middle"
-          dominantBaseline="central"
+          className="fill-muted-foreground font-mono"
           fontSize="11"
-          className={`font-mono transition-colors duration-300 ${
-            active.has('capabilities') ? ACTIVE_TEXT_CLASSES : 'fill-primary'
-          }`}
+        >
+          packages/
+        </text>
+        <text
+          x="200"
+          y="301"
+          textAnchor="middle"
+          className="fill-signal font-mono font-medium"
+          fontSize="18"
         >
           capabilities
         </text>
-        {[25, 124, 245].map((y) => (
-          <circle
-            key={`l${y}`}
-            cx="272"
-            cy={y}
-            r="2.5"
-            className="fill-background stroke-primary/70"
-            strokeWidth="1"
-          />
-        ))}
-        {[52, 152, 245].map((y) => (
-          <circle
-            key={`r${y}`}
-            cx="286"
-            cy={y}
-            r="2.5"
-            className="fill-background stroke-primary/70"
-            strokeWidth="1"
-          />
-        ))}
+        <circle cx="200" cy="250" r="3" className="fill-signal" />
+        <circle cx="200" cy="322" r="3" className="fill-signal" />
       </g>
 
-      <g>
-        <DenseNode x={306} y={36} w={62} label="D1" active={active.has('d1')} />
-        <DenseNode
-          x={306}
-          y={136}
-          w={62}
-          label="Queues"
-          active={active.has('queues')}
-        />
-        <DenseNode x={306} y={229} w={62} label="Email" active={active.has('email')} />
-      </g>
-
-      <g className="schematic-pulse">
-        <Pulse href="#dense-route-browser-d1" dur="4s" begin="0s" />
-        <Pulse href="#dense-route-rest-d1" dur="4.6s" begin="1.4s" />
-        <Pulse href="#dense-route-queue-email" dur="5.2s" begin="2.6s" />
-      </g>
+      <TraceNode
+        x={8}
+        y={402}
+        width={88}
+        label="D1"
+        active={active.has('d1')}
+        external
+      />
+      <TraceNode
+        x={144}
+        y={402}
+        width={112}
+        label="Queues"
+        active={active.has('queues')}
+        external
+      />
+      <TraceNode
+        x={296}
+        y={402}
+        width={104}
+        label="Email"
+        active={active.has('email')}
+        external
+      />
     </svg>
   )
 }
 
-/** One dense box's resting classes: active lights it, dashed marks the
- * external world, otherwise it is a worker on the card surface. */
-function denseNodeClasses(active: boolean, dashed: boolean): string {
-  if (active) {
-    return `transition-colors duration-300 ${ACTIVE_NODE_CLASSES}`
-  }
-  if (dashed) {
-    return 'fill-transparent stroke-muted-foreground/60 transition-colors duration-300'
-  }
-  return 'fill-card stroke-foreground/60 transition-colors duration-300'
-}
-
-/**
- * One dense box: label centered, 11px by attribute (not token) so the rail's
- * fixed-width canvas keeps it exactly that — Tailwind's `text-3xs` is 10px
- * before scaling and invisible at rail scale, which is what this variant
- * exists to fix.
- */
-function DenseNode({
+function TraceNode({
   x,
   y,
-  w,
+  width,
   label,
-  dashed = false,
-  active = false
+  sub,
+  active,
+  external = false
 }: {
   readonly x: number
   readonly y: number
-  readonly w: number
+  readonly width: number
   readonly label: string
-  readonly dashed?: boolean
-  readonly active?: boolean
+  readonly sub?: string
+  readonly active: boolean
+  readonly external?: boolean
 }) {
-  const height = 26
+  const height = external ? 40 : 62
   return (
-    <g>
+    <g className="trace-node" data-active={active}>
       <rect
         x={x}
         y={y}
-        width={w}
+        width={width}
         height={height}
-        className={denseNodeClasses(active, dashed)}
-        strokeWidth="1"
-        strokeDasharray={dashed ? '4 3' : undefined}
+        className="trace-node-body fill-card stroke-border"
       />
       <text
-        x={x + w / 2}
-        y={y + height / 2}
+        x={x + width / 2}
+        y={y + (external ? 24 : 27)}
         textAnchor="middle"
-        dominantBaseline="central"
-        fontSize="11"
-        className={`font-mono transition-colors duration-300 ${
-          active ? ACTIVE_TEXT_CLASSES : 'fill-foreground'
-        }`}
+        className="trace-node-label fill-foreground font-mono"
+        fontSize={external ? 11 : 12}
       >
         {label}
       </text>
+      {sub && (
+        <text
+          x={x + width / 2}
+          y={y + 46}
+          textAnchor="middle"
+          className="fill-muted-foreground font-mono"
+          fontSize="10"
+        >
+          {sub}
+        </text>
+      )}
+      {!external && (
+        <circle cx={x + width / 2} cy={y} r="2" className="fill-muted-foreground" />
+      )}
     </g>
   )
 }

--- a/apps/web/src/components/landing/request-trace-section.tsx
+++ b/apps/web/src/components/landing/request-trace-section.tsx
@@ -5,9 +5,7 @@ import {
   type SchematicNode
 } from '@/components/landing/architecture-schematic'
 import { SnippetPanel } from '@/components/landing/snippet-panel'
-import { useOverflowFade } from '@/hooks/use-overflow-fade'
 import { DEPLOY_COMMAND } from '@/lib/toolchain'
-import { cn } from '@/lib/utils'
 import { m } from '@b2b-saas-starter/i18n/messages'
 
 /**
@@ -172,10 +170,6 @@ function RequestTraceSection({
 }) {
   const sectionRef = useRef<HTMLElement | null>(null)
   const [activeStage, setActiveStage] = useState<StageId>('request')
-  // The mobile schematic's width hides behind its horizontal scroll; the
-  // fade mask marks the hidden width as scrollable while any of it remains.
-  const { ref: schematicRef, fadeRight: schematicFadeRight } =
-    useOverflowFade<HTMLElement>()
 
   // Which stage is "current" is decided by a focus band around the top third
   // of the viewport; the rail lights that stage's node. A keyboard reader
@@ -221,23 +215,9 @@ function RequestTraceSection({
           </p>
         </div>
 
-        {/* The schematic as a map, not just an artifact: once, scrollable,
-            above the spine on small screens; sticky at reduced scale beside
-            it from `lg`. Identical drawing, one text alternative. The fade
-            mask is on only while drawing hides past the right edge, so the
-            hidden width reads as scrollable. */}
         <figure
-          ref={schematicRef}
-          // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- <figure> is the semantic element; role="region" exposes the scrollable area without losing figure semantics.
-          role="region"
           aria-label={m.public_architecture_aria()}
-          // oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- keyboard users need a focus stop to pan the horizontally overflowing schematic.
-          tabIndex={0}
-          className={cn(
-            'mt-10 min-w-0 overflow-x-auto border border-border bg-card p-3 lg:hidden',
-            schematicFadeRight &&
-              '[mask-image:linear-gradient(to_right,black_calc(100%_-_2.5rem),transparent_100%)]'
-          )}
+          className="mx-auto mt-10 max-w-md lg:hidden"
         >
           <ArchitectureSchematic activeNodes={activeNodes} />
         </figure>
@@ -276,7 +256,7 @@ function RequestTraceSection({
             }}
           >
             <article data-stage="request" className="pt-2">
-              <StageMarker index="01" node="curl / SDK" />
+              <StageMarker index="01" node="HTTP client" />
               <h3 className="mt-3 text-xl font-semibold text-balance">
                 {m.public_request_stage_request()}
               </h3>
@@ -398,19 +378,9 @@ function RequestTraceSection({
             </article>
           </div>
 
-          {/* The sticky rail: the schematic's dense redraw, the node under
-              discussion lit. Fixed 11px labels — see `DenseSchematic`. Pure
-              color-state; nothing here gates content. */}
           <div className="hidden lg:block">
-            <div className="sticky top-24 border border-border bg-card p-4">
-              <ArchitectureSchematic
-                variant="dense"
-                activeNodes={activeNodes}
-                className="w-full transition-colors duration-300"
-              />
-              <p className="mt-3 font-mono text-2xs text-muted-foreground">
-                {m.public_request_rail()}
-              </p>
+            <div className="sticky top-24">
+              <ArchitectureSchematic activeNodes={activeNodes} />
             </div>
           </div>
         </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -370,7 +370,51 @@
   animation-delay: 280ms;
 }
 
+.trace-signal {
+  stroke-dasharray: 12 112;
+  stroke-dashoffset: 12;
+  animation: trace-travel 7.2s linear infinite;
+}
+
+@keyframes trace-travel {
+  0% {
+    stroke-dashoffset: 12;
+    opacity: 0;
+  }
+  3% {
+    opacity: 1;
+  }
+  25% {
+    stroke-dashoffset: -100;
+    opacity: 1;
+  }
+  28%,
+  100% {
+    stroke-dashoffset: -112;
+    opacity: 0;
+  }
+}
+
+.trace-node-body,
+.trace-node-label {
+  transition:
+    fill 350ms ease,
+    stroke 350ms ease;
+}
+
+.trace-node[data-active='true'] .trace-node-body {
+  fill: color-mix(in oklab, var(--signal) 12%, var(--card));
+  stroke: var(--signal);
+}
+
+.trace-node[data-active='true'] .trace-node-label {
+  fill: var(--signal);
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .trace-signal {
+    animation: none;
+  }
   .rise {
     animation: none;
   }

--- a/lint.config.ts
+++ b/lint.config.ts
@@ -677,6 +677,7 @@ const { lint = {} } = defineConfig({
                 '^grid-paper$',
                 '^band-deep$',
                 '^schematic-pulse$',
+                '^trace-(signal|node|node-body|node-label)$',
                 '^rise(-[0-9]+)?$',
                 '^(bg|text)-brand$'
               ]


### PR DESCRIPTION
## Outcome

Rebuild the landing page's request-trace diagram as a vertical flow from clients through workers and shared capabilities to infrastructure. Curved wires and sequenced peach pulses replace the cramped horizontal diagram, and the same responsive drawing now fits mobile without horizontal scrolling.

Keep scroll-driven stage highlighting, equalize client spacing, rename the request client to "HTTP client", and remove the decorative plus symbols and footer caption/border.

## Validation

Validated commit `c9c0fd4` with `pnpm run validate`: checks, build, Wrangler drift detection, local database migration/seed, and all 39 browser tests passed. The initial sandboxed attempt could not start local test servers; the rerun with the required access passed.

Manually inspected the section at 1440px desktop and 390px mobile. Verified no mobile horizontal overflow, capabilities highlighting on scroll, and disabled pulses under reduced motion. Targeted code review found no blockers.

To reproduce: run `pnpm run dev:web`, open `/en`, and scroll to "One request, traced end to end." Check the diagram across reading stages, then repeat at mobile width and with reduced motion enabled.

## Risks and remaining work

Small technical subtitles remain compact on narrow screens. Capabilities retains a peach accent between stages by design; the active stage uses a stronger border and fill. GitHub CI has not completed yet.
