### PR TITLE
docs(security): add short operator security runbooks

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -59,6 +59,91 @@ moves. Recovering SQL alone does not rebuild the service.
 For backup configuration and executable restore commands, see
 [D1 backup and recovery](backup-recovery.md).
 
+### Operator runbooks
+
+These runbooks describe the minimum operator actions and records. Keep contacts,
+contracts, escalation routes, and review schedules as deployment inputs in the
+private operations record. They are not a governance application or a library of
+evidence templates.
+
+#### Incident response
+
+The on-call operator starts this procedure when an alert, report, or suspected
+security event could affect availability, confidentiality, integrity, or
+credential safety. Start promptly, even when facts are incomplete.
+
+1. Declare the incident, assign an incident lead, preserve relevant logs and
+   provider records, and restrict discussion to the incident's access group.
+2. Establish what happened, when it may have started, which deployment,
+   Workspace or provider is involved, and whether containment is needed. Use
+   [monitoring](monitoring.md), [recovery](backup-recovery.md), and the
+   [retention policy](retention.md) to preserve the right evidence.
+3. Contain the affected path. Pause risky jobs or deployments, revoke or reset
+   exposed credentials, and keep access closed when its validity is uncertain.
+4. Assess impact and notification duties with qualified legal advice. Identify
+   the applicable role, jurisdictions, affected people or organizations,
+   processor/controller relationships, and any required regulator or individual
+   communications. Do not choose a blanket deadline or recipient list before
+   that assessment. The [EDPB personal-data breach guidance](https://www.edpb.europa.eu/topics/security-data-breaches/personal-data-breaches_en)
+   and its [SME guide](https://www.edpb.europa.eu/sme/assess-the-risks/data-breaches_en)
+   are discovery links, not legal advice.
+5. Recover or remediate using the applicable procedure. Reconcile external
+   provider state, verify fresh access and denied old credentials, and reopen
+   traffic only after the incident lead records the decision.
+6. Record follow-up actions, owners, and due dates chosen by the operator.
+
+The minimum restricted record is the incident ID, UTC discovery and decision
+times, attributable actors, affected scope, evidence references, containment and
+recovery actions, legal-advice reference, notification decision, and closure
+approval. Do not copy secrets, customer payloads, or raw provider responses.
+
+Worked record, hypothetical, 2026-09-09 UTC:
+
+- `INC-2026-0909-01` was discovered at 09:10 by on-call operator A-17 from
+  request-log reference `[evidence: request-log-2026-0909]`.
+- At 09:18, security operator B-04 revoked the token and paused the integration.
+  At 09:24, the API boundary denied a test request; review telemetry reference
+  `[evidence: access-review-2026-0909]` found no later accepted use, while the
+  record retained uncertainty about earlier activity.
+- At 09:40, privacy adviser C-09 assessed the available facts and legal duties.
+  At 09:48, incident lead A-17 recorded the notification decision as pending,
+  because the available evidence did not resolve whether earlier activity
+  affected personal data; C-09's advice reference is
+  `[evidence: legal-advice-2026-0909]`.
+- At 10:05, A-17 recorded that closure was not approved. C-09 and A-17 will
+  reassess notification duties at 14:00 UTC on 2026-09-09 or sooner if new facts
+  appear. B-04 owns a review of the integration's credential owner, due
+  2026-09-12.
+
+#### Access review
+
+The security or platform operator performs this review before customer use, after
+a privileged-role change or incident, and on the deployment's chosen recurring
+schedule. The operator records that schedule and the systems in scope privately.
+
+1. Export or inspect current privileged access for Cloudflare, GitHub Actions,
+   Sentry, backup and evidence stores, identity providers, billing, and other
+   enabled vendors. Include application System Admins, Workspace owners, admins,
+   and members, API tokens, MCP grants, break-glass accounts, service tokens,
+   and recovery contacts.
+2. For human accounts, confirm an attributable owner, current need, least
+   privilege, strong authentication, and an independent recovery path. For API
+   tokens and MCP grants, confirm an attributable owner, permitted scope,
+   expiry or rotation, revocation state, and last-use evidence. Do not treat
+   human MFA as evidence for a token or grant.
+3. Remove stale users, unused tokens, excess roles, and unneeded vendor access.
+   Rotate credentials when ownership or exposure is uncertain. Test the intended
+   human and machine access after the change.
+4. Reconcile the result with [strong authentication](strong-authentication.md),
+   [recovery custody](#operator-configuration), and the enabled rows in the
+   [provider register](security-checklist.md#provider-and-region-register).
+
+Keep a dated, attributable, access-controlled record containing the reviewer,
+review time, systems and accounts covered, removals or exceptions, verification
+result, and next review date. Store the record with the deployment's restricted
+operations evidence. This record shows that a review happened; it does not prove
+that access was continuously effective between reviews.
+
 ### Independent security evidence store
 
 Production web and API Workers can use `SECURITY_EVIDENCE_URL` and the

--- a/docs/security-checklist.md
+++ b/docs/security-checklist.md
@@ -27,6 +27,65 @@ for SOC 2, [ISO/IEC 27001:2022](https://www.iso.org/standard/27001) for an infor
 security management system, and the [European Commission's GDPR guidance for organizations](https://commission.europa.eu/law/law-topic/data-protection/information-business-and-organisations_en).
 These sources do not turn the rows below into an exhaustive standards mapping.
 
+## Operator assessment runbooks
+
+### Risk assessment
+
+The deployment owner leads this assessment before customer use, when a new data
+flow or material control changes, and on a review schedule chosen by the
+operator. The owner maps the change to the [data inventory](#data-inventory),
+provider register, retention policy, recovery procedure, and monitoring setup.
+
+1. Describe the intended processing, data categories, users, providers,
+   jurisdictions, access paths, retention, and failure modes.
+2. Rate confidentiality, integrity, availability, and rights impact using the
+   organization's chosen method. Identify affected people, dependencies,
+   plausible misuse, and safeguards already in place.
+3. Decide whether to enable, restrict, defer, or redesign the change. Escalate
+   legal, contractual, or high-impact questions to the responsible adviser.
+4. Assign each remaining action to an owner with a due date. Record the
+   likelihood, impact, remaining risk, and named decision owner who accepts or
+   rejects that remaining risk. Recheck the decision after implementation on a
+   named deployment and revision.
+
+Keep a dated, attributable, access-controlled record with the assessor, scope,
+method or rating, likelihood, impact, remaining risk, named risk decision owner,
+decision, evidence links, action owners and due dates, and next review date. This
+is an operator assessment, not proof that the controls operated effectively.
+
+### Vendor review
+
+The deployment owner reviews each enabled provider before activation, after a
+material service, region, subprocessor, contract, or data-flow change, and on a
+schedule the operator records. Optional providers with no configuration remain
+inactive. The owner uses the [provider and region register](#provider-and-region-register)
+as the inventory.
+
+1. Confirm the provider account, service, endpoint, region, data categories,
+   recipients, legal role, subprocessors, transfer mechanism, retention,
+   deletion path, security contact, and incident contact.
+2. Read the current provider terms, DPA or contract, security documentation,
+   and status or incident process. Check that the deployment's contacts,
+   credentials, budget, and recovery path are current.
+3. Decide whether the provider is approved, approved with restrictions, or
+   blocked. Update the register, privacy notice inputs, and deployment secrets
+   only after the decision is attributable.
+
+Keep a dated, attributable, access-controlled record with the reviewer, provider
+and service, documents and contract references, decision, restrictions, open
+actions, and next review date. Do not put credentials or provider payloads in the
+repository.
+
+### Discovery links
+
+Start with the [recovery and production monitoring runbook](operations.md),
+[D1 backup and recovery](backup-recovery.md), [retention policy](retention.md),
+[production monitoring](monitoring.md), and the [provider and region register](#provider-and-region-register).
+For legal and breach-notification orientation, use the [EDPB personal-data breach
+guidance](https://www.edpb.europa.eu/topics/security-data-breaches/personal-data-breaches_en)
+and [SME risk guide](https://www.edpb.europa.eu/sme/assess-the-risks/data-breaches_en),
+then obtain advice for the deployment's facts.
+
 ## Data inventory
 
 The [schema](../packages/db/src/schema.ts) owns stored fields; the


### PR DESCRIPTION
## Outcome

Closes #344, the next non-deferred sub-issue of #329.

Operators can follow short incident-response and access-review procedures in `docs/operations.md`, and risk-assessment and vendor-review procedures in `docs/security-checklist.md`. Each procedure identifies who acts, when, what to do, and the minimum restricted record to retain.

- AC-15.1: All four procedures specify actors, triggers, actions, and records, with references to existing mechanisms.
- AC-15.2: One hypothetical incident record shows timed actions, attributable decisions, evidence references, unresolved notification assessment, and owned follow-up.
- AC-15.3: Incident handling calls for legal assessment of roles, jurisdictions, and notification duties without prescribing a universal deadline or recipient. The example leaves closure unapproved while facts remain uncertain.
- AC-15.4: Procedures link existing recovery, retention, monitoring, strong-authentication, and provider documentation. Contacts, contracts, escalation routes, and review schedules remain deployment inputs.
- AC-15.5: Records are minimal, dated, attributable, and access-controlled. The docs distinguish recorded activity from operating effectiveness.

## Validation

Validated revision `87bf80752e3a70ffb99b25fb9f450b2949c08bfb` locally.

- `pnpm run validate` passed: check suite, build, generated Wrangler drift check, local D1 migration/seed, and all 39 Chromium E2E tests. Tests required local process and port access outside the sandbox.
- Independent targeted documentation review passed after repairing the worked record, human-versus-token access controls, and risk-action ownership.
- Verified all 67 local links and anchors in the changed documents.
- `git diff --check` passed.
- GitHub CI passed on the same head, including `ci`, `e2e`, quality, build, all workspace test jobs, the dependency audit, and the conventional-title gate. Deployment and preview jobs were skipped.

## Risks and remaining work

Operators must supply deployment-specific contacts, schedules, contracts, legal assessment, and evidence of actual execution. This change adds documentation only and does not establish operating effectiveness.
