### PR TITLE
fix(ops): target isolated recovery sanitation explicitly

### DIFF
--- a/docs/backup-recovery.md
+++ b/docs/backup-recovery.md
@@ -15,8 +15,12 @@ checks its SHA-256 digest. Change the first schedule to the deployment's measure
 low-traffic window.
 
 Create a GitHub `backup` environment with no required reviewers. Required
-reviewers would leave unattended scheduled backups waiting for approval. Set
-`BACKUP_ENABLED=true` in that environment only after the following values work:
+reviewers would leave unattended scheduled backups waiting for approval. Store
+the following secrets and variables in that environment. After verifying them,
+set the **repository variable** `BACKUP_ENABLED=true` to enable both jobs.
+GitHub evaluates their job-level conditions before environment variables become
+available, so an environment-only flag leaves the jobs skipped. See
+[GitHub's variable availability rules](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#configuration-variable-precedence).
 
 | Setting                                                             | Purpose                                                 |
 | ------------------------------------------------------------------- | ------------------------------------------------------- |
@@ -158,10 +162,25 @@ node scripts/recovery-security.ts apply \
   --restore-point=2026-09-07T12:00:00Z \
   --freeze-time=2026-09-07T12:15:00Z \
   --database=b2b-saas-starter-recovery-drill \
+  --persist-to=/private/tmp/b2b-saas-starter-recovery-drill \
   --local
 ```
 
-For a remote run, replace `--local` with
+For a local drill, import the backup into the same `--persist-to` directory
+with Wrangler before applying this command. For example, after decrypting the
+export to `recovery.sql`, run:
+
+```sh
+pnpm exec wrangler d1 execute DB --local \
+  --config=apps/api/wrangler.jsonc \
+  --persist-to=/private/tmp/b2b-saas-starter-recovery-drill \
+  --file=recovery.sql
+```
+
+The sanitizer uses the API worker's `DB` binding and requires the operator to
+identify the restored persisted store.
+
+For a remote run, omit `--persist-to` and `--local`, and use
 `--confirm-target="$CLOUDFLARE_ACCOUNT_ID/<database-name>"`. Evidence must cover
 the restore point through the maintenance freeze. The command invalidates
 restored sessions and OAuth grants and reapplies deletion/revocation evidence.

--- a/scripts/recovery-security.test.ts
+++ b/scripts/recovery-security.test.ts
@@ -1,9 +1,20 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
 import { describe, expect, it } from 'vite-plus/test'
+import { listMigrations } from '../packages/db/src/migrations-fs.ts'
 
 import {
   buildRecoverySecuritySql,
   type SecurityEvidenceBundle
 } from './recovery-security.ts'
+
+const run = promisify(execFile)
+const ROOT = join(import.meta.dirname, '..')
+const CONFIG = join(ROOT, 'apps', 'api', 'wrangler.jsonc')
 
 const bundle: SecurityEvidenceBundle = {
   version: 1,
@@ -31,6 +42,115 @@ const bundle: SecurityEvidenceBundle = {
 }
 
 describe('recovery security sanitation', () => {
+  it('requires an explicit local persistence path', async () => {
+    await expect(
+      run(
+        'node',
+        [
+          'scripts/recovery-security.ts',
+          'apply',
+          '--evidence=missing.json',
+          '--restore-point=2026-09-07T00:00:00Z',
+          '--freeze-time=2026-09-07T23:00:00Z',
+          '--database=recovery-drill',
+          '--local'
+        ],
+        { cwd: ROOT }
+      )
+    ).rejects.toThrow(/persist-to/)
+  })
+
+  it('requires an account identity before remote target confirmation', async () => {
+    const environment = { ...process.env }
+    delete environment.CLOUDFLARE_ACCOUNT_ID
+    await expect(
+      run(
+        'node',
+        [
+          'scripts/recovery-security.ts',
+          'apply',
+          '--evidence=missing.json',
+          '--restore-point=2026-09-07T00:00:00Z',
+          '--freeze-time=2026-09-07T23:00:00Z',
+          '--database=recovery-drill',
+          '--confirm-target=/recovery-drill'
+        ],
+        { cwd: ROOT, env: environment }
+      )
+    ).rejects.toThrow(/CLOUDFLARE_ACCOUNT_ID/)
+  })
+
+  it('sanitizes an isolated persisted D1 store through the CLI', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'recovery-security-test-'))
+    const persist = join(directory, 'd1')
+    const seed = join(directory, 'seed.sql')
+    const evidence = join(directory, 'evidence.json')
+    const environment = {
+      ...process.env,
+      WRANGLER_LOG_PATH: join(directory, 'wrangler.log')
+    }
+    try {
+      const schema = listMigrations()
+        .flatMap(({ sql }) => sql.split('--> statement-breakpoint'))
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0)
+        .join(';\n')
+      await writeFile(
+        seed,
+        `${schema};\nINSERT INTO user (id,email,name) VALUES ('usr_keep','keep@example.com','Keep'); INSERT INTO session (id,expiresAt,token,userId) VALUES ('ses_restore',4102444800,'restore-token','usr_keep');`
+      )
+      await run(
+        'pnpm',
+        [
+          'exec',
+          'wrangler',
+          'd1',
+          'execute',
+          'DB',
+          '--local',
+          `--config=${CONFIG}`,
+          `--persist-to=${persist}`,
+          `--file=${seed}`
+        ],
+        { cwd: ROOT, env: environment }
+      )
+      await writeFile(evidence, JSON.stringify(bundle))
+      await run(
+        'node',
+        [
+          'scripts/recovery-security.ts',
+          'apply',
+          `--evidence=${evidence}`,
+          '--restore-point=2026-09-07T00:00:00Z',
+          '--freeze-time=2026-09-07T23:00:00Z',
+          '--database=recovery-drill',
+          `--persist-to=${persist}`,
+          '--local'
+        ],
+        { cwd: ROOT, env: environment }
+      )
+      const result = await run(
+        'pnpm',
+        [
+          'exec',
+          'wrangler',
+          'd1',
+          'execute',
+          'DB',
+          '--local',
+          `--config=${CONFIG}`,
+          `--persist-to=${persist}`,
+          "--command=SELECT (SELECT COUNT(*) FROM session) AS sessions, (SELECT COUNT(*) FROM user WHERE id = 'usr_keep') AS users"
+        ],
+        { cwd: ROOT, env: environment }
+      )
+      expect(result.stdout).toContain('"sessions": 0')
+      expect(result.stdout).toContain('"users": 1')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }, 60_000)
+
   it('invalidates restored authorization state and reapplies later access deletion', () => {
     const sql = buildRecoverySecuritySql(
       bundle,

--- a/scripts/recovery-security.ts
+++ b/scripts/recovery-security.ts
@@ -7,6 +7,8 @@ import { promisify } from 'node:util'
 import { SecurityEvidenceRecord } from '@b2b-saas-starter/capabilities/governance/security-recovery-evidence'
 import { Schema } from 'effect'
 
+const CONFIG = join(import.meta.dirname, '..', 'apps', 'api', 'wrangler.jsonc')
+
 const execFilePromise = promisify(execFile)
 
 const SecurityEvidenceGap = Schema.Struct({
@@ -141,6 +143,7 @@ type ApplyOptions = {
   readonly freezeTime: string
   readonly database: string
   readonly local: boolean
+  readonly persistTo?: string | undefined
   readonly confirmTarget?: string | undefined
 }
 
@@ -157,24 +160,39 @@ function parseApplyOptions(): ApplyOptions {
   const database = readOption('--database')
   const local = process.argv.includes('--local')
   const confirmTarget = readOption('--confirm-target')
+  const persistTo = readOption('--persist-to')
   if (
     !evidence ||
     !restorePoint ||
     !freezeTime ||
     !database ||
-    (local && confirmTarget)
+    (local && confirmTarget) ||
+    (local && !persistTo) ||
+    (!local && persistTo)
   ) {
     throw new Error(
-      'usage: recovery-security.ts apply --evidence=<bundle.json> --restore-point=<ISO> --freeze-time=<ISO> --database=<name> (--local | --confirm-target=<account-id>/<name>)'
+      'usage: recovery-security.ts apply --evidence=<bundle.json> --restore-point=<ISO> --freeze-time=<ISO> --database=<name> (--local --persist-to=<path> | --confirm-target=<account-id>/<name>)'
     )
   }
   if (!local) {
-    const expected = `${process.env.CLOUDFLARE_ACCOUNT_ID ?? ''}/${database}`
+    const account = process.env.CLOUDFLARE_ACCOUNT_ID
+    if (account === undefined || account.trim().length === 0) {
+      throw new Error('CLOUDFLARE_ACCOUNT_ID is required for remote sanitation')
+    }
+    const expected = `${account}/${database}`
     if (confirmTarget !== expected) {
       throw new Error(`remote sanitation requires --confirm-target=${expected}`)
     }
   }
-  return { evidence, restorePoint, freezeTime, database, local, confirmTarget }
+  return {
+    evidence,
+    restorePoint,
+    freezeTime,
+    database,
+    local,
+    confirmTarget,
+    persistTo
+  }
 }
 
 async function apply(options: ApplyOptions): Promise<void> {
@@ -189,14 +207,18 @@ async function apply(options: ApplyOptions): Promise<void> {
       buildRecoverySecuritySql(decoded, options.restorePoint, options.freezeTime),
       { mode: 0o600 }
     )
+    const target = options.local ? 'DB' : options.database
     const targetFlag = options.local ? '--local' : '--remote'
+    const persistence = options.local ? [`--persist-to=${options.persistTo}`] : []
     await execFilePromise('pnpm', [
       'exec',
       'wrangler',
       'd1',
       'execute',
-      options.database,
+      target,
       targetFlag,
+      `--config=${CONFIG}`,
+      ...persistence,
       `--file=${sqlPath}`
     ])
   } finally {


### PR DESCRIPTION
## Outcome

Addresses two executable setup gaps found while continuing #286 after #305. Local recovery sanitation previously invoked Wrangler without a configuration or an explicit restored database store. It now uses the API `DB` binding and requires `--persist-to`, so operators can sanitize the same isolated database they imported. Remote runs require a nonempty Cloudflare account ID and exact account/database confirmation.

The backup guide now places `BACKUP_ENABLED` at repository scope, where the workflow's job conditions can read it, and provides matching import and sanitation commands.

## Validation

Tested revision: `dedd52c56219d86b9c8fe45af6e660394051ca43`.

- `pnpm run validate` passed, including repository checks, build, Wrangler drift detection, local migration/seed, and browser tests. The mobile language-picker and passkey-verification tests passed on retry; 37 other browser tests passed without retry.
- Operations tests passed: 24 Vitest tests and 3 Node tests. The sanitation suite includes a real CLI invocation against a temporary D1 store with every committed migration. It verifies restored sessions are removed while the synthetic user remains, and checks missing local persistence and remote account guards.
- `git diff --check` passed.
- Independent Standards and Spec reviews completed on this revision. No documented standard violations or specification defects were found. The coordinator declined optional option-type and shared migration-helper refactors because the private parser enforces the target invariants and neither suggestion fixes a demonstrated defect in this bounded repair.
- [CI](https://github.com/brandhaug/b2b-saas-starter/actions/runs/34378725907) passed quality, build, all three test groups, both browser shards, and the aggregate `ci` and `e2e` checks. Dependency audit and the conventional-title gate passed. Deployment jobs were skipped.

Issue evidence mapping: the new integration test strengthens isolated recovery and restored-session invalidation evidence. It does not establish remote sign-in, lost-account recovery, recovery-time/data-loss targets, or delivered alert notifications. Existing monitoring remains optional and no production restore or destructive drill ran.

## Risks and remaining work

#286 remains open. Independent S3 backup/key recovery, a full isolated account-loss rebuild, remote queue failures, Sentry alert opening/recovery/deduplication, and full service recovery targets remain unverified. The inspected repository has no backup or operations-monitoring environment and no configured S3/Sentry secret names. The approved isolated targets, separately recoverable credentials/configuration, monitor setup, and operator notification destinations are needed to complete those drills.

Local sanitation callers must now supply the restored store's `--persist-to` path. Remote calls must omit local persistence flags. This PR does not approve customer-data recovery or destructive scheduled cleanup.
