### PR TITLE
test(exports): cover generation failure settlement

### DIFF
--- a/apps/background/AGENTS.md
+++ b/apps/background/AGENTS.md
@@ -16,7 +16,14 @@ Per queue the outcome table is the contract; the non-obvious parts:
 - Webhooks retry a retryable failure (5xx, 408, 429, network, timeout) at `backoffSeconds(attempts)`; a 4xx or SSRF rejection is `failed_permanent`; undispatchable or malformed acks.
 - [Webhook Attempt completion](../../packages/capabilities/src/developer-platform/webhook-attempt-completion.ts) owns planning, recording and accepted-only warnings. The worker owns signing and HTTP dispatch; it follows completion's queue disposition, including for duplicate or late observations.
 - The DLQ consumer acks after writing the terminal `dead_lettered` row, but retries if that write fails, so a D1 blip cannot lose the evidence.
-- Exports resolve `WorkspaceContext` from the slug with no actor, ownership having been checked at request time; a slug naming another `workspaceId` fails the row. No DLQ, the row is the record. `WORKSPACE_EXPORT_RETENTION_DAYS` is declared twice, in `infra/bindings.ts` (R2 lifecycle rule) and the capability; `export-consumer.test.ts` fails if they diverge.
+- Exports use the capability-owned generation workflow after resolving
+  `WorkspaceContext` from the slug with no actor, ownership having been checked
+  at request time; a slug naming another `workspaceId` fails the row. The queue
+  adapter keeps decoding, tracing, and platform retry scheduling; generation
+  owns snapshot/build/completion and terminal settlement. No DLQ, the row is
+  the record. `WORKSPACE_EXPORT_RETENTION_DAYS` is declared twice, in
+  `infra/bindings.ts` (R2 lifecycle rule) and the capability;
+  `export-consumer.test.ts` fails if they diverge.
 - Seat sync uses the billing queue and its dead-letter queue. The primary queue
   retries six times; the dead-letter consumer calls `Billing.reconcileWorkspace`
   so recovery does not require a later mutation. Its Stripe env is

--- a/apps/background/src/export-consumer.test.ts
+++ b/apps/background/src/export-consumer.test.ts
@@ -1,27 +1,13 @@
-import { ApiTokenRegistry } from '@b2b-saas-starter/capabilities/developer-platform/api-token-registry'
-import { WebhookEndpoints } from '@b2b-saas-starter/capabilities/developer-platform/webhook-endpoints'
-import { WorkspaceNotFound } from '@b2b-saas-starter/capabilities/errors'
-import { CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
-import { AuditEventLog } from '@b2b-saas-starter/capabilities/governance/audit-event-log'
+import {
+  WorkspaceExportGeneration,
+  type WorkspaceExportGenerationInterface,
+  type WorkspaceExportGenerationResult,
+  type WorkspaceExportGenerationInput
+} from '@b2b-saas-starter/capabilities/governance/workspace-export-generation'
 import {
   WORKSPACE_EXPORT_RETENTION_DAYS as CAPABILITY_RETENTION_DAYS,
-  WorkspaceExports,
-  type CompleteWorkspaceExportInput,
-  type FailWorkspaceExportInput,
-  WorkspaceExportQueueMessage,
-  type WorkspaceExportsInterface
+  WorkspaceExportQueueMessage
 } from '@b2b-saas-starter/capabilities/governance/workspace-export'
-import { WorkspaceInvitations } from '@b2b-saas-starter/capabilities/governance/workspace-invitations'
-import { WorkspaceMembership } from '@b2b-saas-starter/capabilities/governance/workspace-membership'
-import {
-  WorkspaceSuspended,
-  WorkspaceSuspensionService
-} from '@b2b-saas-starter/capabilities/governance/workspace-suspension'
-import { NotificationFeed } from '@b2b-saas-starter/capabilities/notifications/notification-feed'
-import {
-  testWorkspaceContext,
-  WorkspaceContext
-} from '@b2b-saas-starter/capabilities/workspace-context'
 import { describe, expect, it } from '@effect/vitest'
 import { Effect, Layer } from 'effect'
 
@@ -29,13 +15,8 @@ import {
   WORKSPACE_EXPORT_RETENTION_DAYS,
   workspaceExportConsumerSettings
 } from '../../../infra/bindings.ts'
-import {
-  processWorkspaceExportMessage,
-  type ResolveWorkspace
-} from './export-consumer.ts'
+import { processWorkspaceExportMessage } from './export-consumer.ts'
 import { readDelivery } from './queue-consumer.ts'
-
-const workspace = { id: 'wrk_1', slug: 'lab', name: 'Lab', planId: 'team' }
 
 const message: WorkspaceExportQueueMessage = {
   exportId: 'exp_1',
@@ -43,273 +24,94 @@ const message: WorkspaceExportQueueMessage = {
   workspaceSlug: 'lab'
 }
 
-/** What the stub export service saw: the completions and failures it was handed. */
-type Recorded = {
-  readonly completed: Array<CompleteWorkspaceExportInput>
-  readonly failed: Array<FailWorkspaceExportInput>
-}
-
-function stubExports(
-  recorded: Recorded,
-  completeSuspended = false
-): Layer.Layer<WorkspaceExports> {
-  const unused = Effect.die('unused in consumer tests')
-  const service: WorkspaceExportsInterface = {
-    availability: Effect.succeed({ available: true }),
-    list: unused,
-    request: unused,
-    issueDownloadLink: () => unused,
-    openDownload: () => unused,
-    complete: (input) => {
-      if (completeSuspended) {
-        return Effect.fail(new WorkspaceSuspended({ workspaceId: input.workspaceId }))
-      }
-      return Effect.sync(() => {
-        recorded.completed.push(input)
-        return true
-      })
-    },
-    fail: (input) =>
+function generationLayer(
+  result: WorkspaceExportGenerationResult,
+  seen: Array<WorkspaceExportGenerationInput> = []
+): Layer.Layer<WorkspaceExportGeneration> {
+  const service: WorkspaceExportGenerationInterface = {
+    generate: (input) =>
       Effect.sync(() => {
-        recorded.failed.push(input)
-        return true
+        seen.push(input)
+        return result
       })
   }
-  return Layer.succeed(WorkspaceExports)(service)
-}
-
-/**
- * Empty read services — the archive shape is the capability tests' business;
- * the consumer tests assert the orchestration. `failing` turns every read into
- * a store outage.
- */
-function stubReads(failing = false) {
-  const outage = new CapabilityUnavailable({ capability: 'test', reason: 'd1 down' })
-  function list<A>(value: A): Effect.Effect<A, CapabilityUnavailable> {
-    if (failing) {
-      return Effect.fail(outage)
-    }
-    return Effect.succeed(value)
-  }
-  const unused = Effect.die('unused in consumer tests')
-  return Layer.mergeAll(
-    Layer.succeed(WorkspaceMembership)({
-      listMembers: list([]),
-      listMembersPage: () => unused,
-      listWorkspacesForUser: () => unused,
-      addMember: () => unused,
-      removeMember: () => unused,
-      leave: unused,
-      changeRole: () => unused
-    }),
-    Layer.succeed(WorkspaceInvitations)({
-      list: list([]),
-      create: () => unused,
-      cancel: () => unused,
-      find: () => unused,
-      accept: () => unused
-    }),
-    Layer.succeed(ApiTokenRegistry)({
-      list: list([]),
-      listPage: () => unused,
-      create: () => unused,
-      replace: () => unused,
-      revoke: () => unused,
-      verifyBearerToken: () => unused
-    }),
-    Layer.succeed(WebhookEndpoints)({
-      list: list([]),
-      listPage: () => unused,
-      create: () => unused,
-      listDeliveryAttempts: () => Effect.die('unused in delivery tests'),
-      cleanupDeliveryHistory: () => Effect.die('unused in delivery tests'),
-      listDeliveries: () => unused,
-      listGlobalDeliveries: () => unused,
-      replayDeliveryAsAdmin: () => unused,
-      update: () => unused,
-      delete: () => unused,
-      replayDelivery: () => unused,
-      sendTestEvent: () => unused,
-      rotateSecret: () => unused,
-      isDeliverySettled: () => Effect.succeed(false),
-      getDispatchTarget: () => unused,
-      recordDeliveryAttempt: () => unused,
-      recordTerminalDeliveryAttempt: () => unused
-    }),
-    Layer.succeed(AuditEventLog)({
-      get: () => unused,
-      list: () => list({ items: [], nextCursor: null }),
-      listGlobal: unused,
-      record: () => unused,
-      prepareRecord: () => unused
-    }),
-    Layer.succeed(NotificationFeed)({
-      list: list([]),
-      listPage: () => unused,
-      unreadCount: list(0),
-      markRead: () => unused,
-      notifyUser: () => unused,
-      notifyWorkspaceOwners: () => unused,
-      prepareWorkspaceOwners: () => unused,
-      create: () => unused,
-      loadForEmail: () => unused,
-      listDigestCandidates: () => unused,
-      record: () => unused
-    })
-  )
-}
-
-function resolveLab(slug: string): ReturnType<ResolveWorkspace> {
-  if (slug === 'lab') {
-    return testWorkspaceContext(workspace)
-  }
-  return Layer.effect(WorkspaceContext)(Effect.fail(new WorkspaceNotFound({ slug })))
+  return Layer.succeed(WorkspaceExportGeneration)(service)
 }
 
 function run(
   body: unknown,
-  options: {
-    readonly attempts?: number
-    readonly resolve?: ResolveWorkspace
-    readonly failing?: boolean
-    readonly suspended?: boolean
-    readonly completeSuspended?: boolean
-  } = {}
+  result: WorkspaceExportGenerationResult,
+  attempts = 1,
+  seen: Array<WorkspaceExportGenerationInput> = []
 ) {
-  const recorded: Recorded = { completed: [], failed: [] }
-  const activeSuspension = Layer.succeed(WorkspaceSuspensionService)({
-    list: Effect.succeed([]),
-    get: () => Effect.die('unused'),
-    requireAllowed: () => Effect.void,
-    transition: () => Effect.die('unused')
-  })
-  let suspensionLayer = activeSuspension
-  if (options.suspended) {
-    suspensionLayer = Layer.succeed(WorkspaceSuspensionService)({
-      list: Effect.succeed([]),
-      get: () => Effect.die('unused'),
-      requireAllowed: () =>
-        Effect.fail(new WorkspaceSuspended({ workspaceId: 'wrk_1' })),
-      transition: () => Effect.die('unused')
-    })
-  }
   return processWorkspaceExportMessage(
     readDelivery(WorkspaceExportQueueMessage, {
       id: 'qmsg_export',
       body,
-      attempts: options.attempts ?? 1
+      attempts
     }),
-    options.resolve ?? resolveLab
-  ).pipe(
-    Effect.provide(
-      Layer.mergeAll(
-        stubExports(recorded, options.completeSuspended ?? false),
-        stubReads(options.failing ?? false),
-        suspensionLayer
-      )
-    ),
-    Effect.map((outcome) => ({ outcome, recorded }))
-  )
+    generationLayer(result, seen)
+  ).pipe(Effect.map((outcome) => ({ outcome, seen })))
 }
 
 describe('processWorkspaceExportMessage', () => {
-  it.effect('builds the archive and completes the export', () =>
+  it.effect('delegates a valid message to generation and acknowledges ready work', () =>
     Effect.gen(function* () {
-      const { outcome, recorded } = yield* run(message)
-      expect(outcome).toBe('ack')
-      expect(recorded.failed).toHaveLength(0)
-      expect(recorded.completed).toHaveLength(1)
-      const completed = recorded.completed[0]
-      expect(completed).toMatchObject({ exportId: 'exp_1', workspaceId: 'wrk_1' })
-      // A real gzip container: magic bytes first.
-      expect([...(completed?.archive.subarray(0, 2) ?? [])]).toEqual([0x1f, 0x8b])
-      expect(completed?.archive.length).toBeGreaterThan(22)
-    })
-  )
-
-  it.effect('settles a queued export while suspended', () =>
-    Effect.gen(function* () {
-      const { outcome, recorded } = yield* run(message, { suspended: true })
-      expect(outcome).toBe('ack')
-      expect(recorded.completed).toHaveLength(0)
-      expect(recorded.failed).toEqual([
-        expect.objectContaining({ reason: 'workspace_suspended' })
+      const seen: Array<WorkspaceExportGenerationInput> = []
+      const result = yield* run(message, { _tag: 'ready', sizeBytes: 42 }, 1, seen)
+      expect(result.outcome).toBe('ack')
+      expect(result.seen).toEqual([
+        {
+          message,
+          finalAttempt: false
+        }
       ])
     })
   )
 
-  it.effect('settles when suspension starts before completion', () =>
+  it.effect('returns retry when generation says the platform should retry', () =>
     Effect.gen(function* () {
-      const { outcome, recorded } = yield* run(message, {
-        completeSuspended: true
-      })
-      expect(outcome).toBe('ack')
-      expect(recorded.completed).toHaveLength(0)
-      expect(recorded.failed).toEqual([
-        expect.objectContaining({ reason: 'workspace_suspended' })
-      ])
+      const result = yield* run(message, { _tag: 'retry', reason: 'd1 down' })
+      expect(result.outcome).toBe('retry')
     })
   )
 
-  it.effect('acks a malformed message without touching any row', () =>
+  it.effect('acknowledges terminal skipped generation', () =>
     Effect.gen(function* () {
-      const { outcome, recorded } = yield* run({ exportId: 42 })
-      expect(outcome).toBe('ack')
-      expect(recorded.completed).toHaveLength(0)
-      expect(recorded.failed).toHaveLength(0)
+      const result = yield* run(message, {
+        _tag: 'skipped',
+        reason: 'workspace_mismatch'
+      })
+      expect(result.outcome).toBe('ack')
     })
   )
 
-  it.effect('marks the export failed when the slug no longer resolves', () =>
+  it.effect('marks the queue delivery final attempt for generation', () =>
     Effect.gen(function* () {
-      const { outcome, recorded } = yield* run({ ...message, workspaceSlug: 'gone' })
-      expect(outcome).toBe('ack')
-      expect(recorded.completed).toHaveLength(0)
-      expect(recorded.failed[0]).toMatchObject({
-        exportId: 'exp_1',
-        workspaceId: 'wrk_1',
-        reason: 'workspace_not_found'
-      })
+      const seen: Array<WorkspaceExportGenerationInput> = []
+      const result = yield* run(
+        message,
+        { _tag: 'skipped', reason: 'unavailable: d1 down' },
+        workspaceExportConsumerSettings.maxRetries,
+        seen
+      )
+      expect(result.outcome).toBe('ack')
+      expect(seen[0]?.finalAttempt).toBe(true)
     })
   )
 
-  it.effect(
-    'marks the export failed when the slug resolves to a different workspace',
-    () =>
-      Effect.gen(function* () {
-        const { outcome, recorded } = yield* run({ ...message, workspaceId: 'wrk_old' })
-        expect(outcome).toBe('ack')
-        expect(recorded.completed).toHaveLength(0)
-        expect(recorded.failed[0]).toMatchObject({
-          workspaceId: 'wrk_old',
-          reason: 'workspace_mismatch'
-        })
-      })
-  )
-
-  it.effect('retries a store outage while attempts remain', () =>
+  it.effect('acks malformed messages without invoking generation', () =>
     Effect.gen(function* () {
-      const { outcome, recorded } = yield* run(message, {
-        failing: true,
-        attempts: 1
-      })
-      expect(outcome).toBe('retry')
-      expect(recorded.failed).toHaveLength(0)
-      expect(recorded.completed).toHaveLength(0)
+      const seen: Array<WorkspaceExportGenerationInput> = []
+      const result = yield* run(
+        { exportId: 42 },
+        { _tag: 'ready', sizeBytes: 42 },
+        1,
+        seen
+      )
+      expect(result.outcome).toBe('ack')
+      expect(seen).toHaveLength(0)
     })
-  )
-
-  it.effect(
-    'marks the export failed on the last attempt instead of retrying forever',
-    () =>
-      Effect.gen(function* () {
-        const { outcome, recorded } = yield* run(message, {
-          failing: true,
-          attempts: workspaceExportConsumerSettings.maxRetries
-        })
-        expect(outcome).toBe('ack')
-        expect(recorded.failed[0]?.reason).toMatch(/^unavailable: /)
-      })
   )
 })
 
@@ -320,12 +122,9 @@ describe('readDelivery', () => {
       body: { ...message, traceparent: '00-abc-def-01' },
       attempts: 2
     })
-    expect(delivery).toEqual({
-      id: 'qmsg_1',
-      attempts: 2,
-      kind: 'message',
-      message: { ...message, traceparent: '00-abc-def-01' }
-    })
+    expect(delivery.kind).toBe('message')
+    expect(delivery.id).toBe('qmsg_1')
+    expect(delivery.attempts).toBe(2)
   })
 
   it('names a body that misses the workspace slug malformed', () => {

--- a/apps/background/src/export-consumer.ts
+++ b/apps/background/src/export-consumer.ts
@@ -3,21 +3,14 @@ import {
   selectWorkspaceContextLayer,
   starterEnv
 } from '@b2b-saas-starter/capabilities/runtime'
-import { type WorkspaceNotFound } from '@b2b-saas-starter/capabilities/errors'
-import { CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
-import { buildWorkspaceExportArchive } from '@b2b-saas-starter/capabilities/governance/workspace-export-archive'
-import { errorMessage } from '@b2b-saas-starter/failure'
 import {
-  collectWorkspaceExportSnapshot,
-  type WorkspaceExportSnapshotServices
-} from '@b2b-saas-starter/capabilities/governance/workspace-export-snapshot'
-import {
-  WorkspaceExportQueueMessage,
-  WorkspaceExports
-} from '@b2b-saas-starter/capabilities/governance/workspace-export'
-import { WorkspaceSuspensionService } from '@b2b-saas-starter/capabilities/governance/workspace-suspension'
-import { type WorkspaceContext } from '@b2b-saas-starter/capabilities/workspace-context'
-import { DateTime, Effect, type Layer, Result, type Scope } from 'effect'
+  WorkspaceExportGeneration,
+  WorkspaceExportGenerationLayer,
+  type WorkspaceExportGenerationResult
+} from '@b2b-saas-starter/capabilities/governance/workspace-export-generation'
+import { WorkspaceExportQueueMessage } from '@b2b-saas-starter/capabilities/governance/workspace-export'
+import { type CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
+import { Effect, Layer, type Scope } from 'effect'
 
 import { workspaceExportConsumerSettings } from '../../../infra/bindings.ts'
 import {
@@ -28,49 +21,21 @@ import {
   type QueueDelivery,
   type QueueEnvelope
 } from './queue-consumer.ts'
+
 /**
  * The workspace export consumer (ADR 0055). One message names one `pending`
- * export row; the consumer resolves the workspace the way a request would,
- * snapshots it through the capability services, builds the archive, and hands
- * the bytes to `WorkspaceExports.complete`, which stores them, flips the row,
- * audits, and notifies the requester.
+ * export row; the capability-owned generation workflow resolves the workspace,
+ * snapshots it, builds the archive, and settles the row.
  *
- * Same boundary shape as `webhook-consumer.ts`: the untrusted body is decoded
- * once (`readDelivery`), a malformed body is terminal, and the
- * orchestration is exported with its requirements open so tests inject stub
- * layers — `processWorkspaceExportMessage` takes the workspace resolver as an
- * argument for the same reason.
- */
-
-/**
- * How the consumer turns a slug into a trusted `WorkspaceContext` (no actor —
- * the queue message is the authorization; the requester was checked at request
- * time). The handler passes `selectWorkspaceContextLayer`; tests pass
- * `testWorkspaceContext`.
- */
-export type ResolveWorkspace = (
-  slug: string
-) => Layer.Layer<WorkspaceContext, WorkspaceNotFound | CapabilityUnavailable>
-
-/**
- * Builds one export. Outcomes:
- * - archive stored, row `ready` → ack;
- * - malformed body, unknown slug, or a slug that no longer names the message's
- *   workspace → the row is marked `failed` where one exists, ack;
- * - the store is unreachable → retry, or mark failed on the last attempt.
+ * The queue adapter decodes the untrusted body once, supplies tracing, selects
+ * the trusted workspace resolver, and keeps the platform retry schedule. It
+ * does not know snapshot dependencies or generation failure policy.
  */
 export function processWorkspaceExportMessage(
   delivery: QueueDelivery<WorkspaceExportQueueMessage>,
-  resolveWorkspace: ResolveWorkspace
-): Effect.Effect<
-  DeliveryOutcome,
-  CapabilityUnavailable,
-  | WorkspaceExports
-  | WorkspaceExportSnapshotServices
-  | WorkspaceSuspensionService
-  | Scope.Scope
-> {
-  return Effect.gen(function* () {
+  generationLayer: Layer.Layer<WorkspaceExportGeneration, never, never>
+): Effect.Effect<DeliveryOutcome, CapabilityUnavailable, Scope.Scope> {
+  const program = Effect.gen(function* () {
     if (delivery.kind === 'malformed') {
       yield* Effect.annotateLogsScoped({
         outcome: 'failed',
@@ -78,154 +43,46 @@ export function processWorkspaceExportMessage(
       })
       return 'ack' satisfies DeliveryOutcome
     }
+
     const message = delivery.message
     yield* Effect.annotateLogsScoped({
       exportId: message.exportId,
       workspaceId: message.workspaceId,
       workspaceSlug: message.workspaceSlug
     })
-    const exports = yield* WorkspaceExports
-    const suspension = yield* WorkspaceSuspensionService
-    {
-      const allowed = yield* Effect.result(
-        suspension.requireAllowed(message.workspaceId, 'product')
-      )
-      if (Result.isFailure(allowed) && allowed.failure._tag === 'WorkspaceSuspended') {
-        yield* exports.fail({
-          exportId: message.exportId,
-          workspaceId: message.workspaceId,
-          reason: 'workspace_suspended'
-        })
-        yield* Effect.annotateLogsScoped({
-          outcome: 'skipped',
-          skipReason: 'workspace_suspended'
-        })
-        return 'ack' satisfies DeliveryOutcome
-      }
-      if (Result.isFailure(allowed)) {
-        if (allowed.failure._tag === 'CapabilityUnavailable') {
-          return yield* Effect.fail(allowed.failure)
-        }
-        return yield* Effect.fail(
-          new CapabilityUnavailable({
-            capability: 'workspace-suspension',
-            reason: 'Suspension policy could not be evaluated'
-          })
-        )
-      }
-    }
-    const built = yield* Effect.result(
-      Effect.gen(function* () {
-        const snapshot = yield* collectWorkspaceExportSnapshot({
-          exportId: message.exportId,
-          generatedAt: yield* DateTime.now
-        })
-        // The slug resolved a workspace, but is it still the one that asked?
-        // A workspace deleted and re-created under the same slug must not
-        // receive the old request's archive.
-        if (snapshot.workspace.id !== message.workspaceId) {
-          return null
-        }
-        // The archive is gzipped JSON, so the builder is a promise; it folds
-        // into the effect channel with the same `CapabilityUnavailable` a
-        // failed read would surface, which the queue retries like any other
-        // store outage.
-        return yield* Effect.tryPromise({
-          try: () => buildWorkspaceExportArchive(snapshot),
-          catch: (cause) =>
-            new CapabilityUnavailable({
-              capability: 'workspace-export-archive',
-              reason: errorMessage(cause) ?? 'the archive build failed'
-            })
-        })
-      }).pipe(Effect.provide(resolveWorkspace(message.workspaceSlug)))
-    )
-
-    if (Result.isFailure(built)) {
-      const failure = built.failure
-      if (failure._tag === 'WorkspaceNotFound') {
-        yield* exports.fail({
-          exportId: message.exportId,
-          workspaceId: message.workspaceId,
-          reason: 'workspace_not_found'
-        })
-        yield* Effect.annotateLogsScoped({
-          outcome: 'failed',
-          skipReason: 'workspace_not_found'
-        })
-        return 'ack' satisfies DeliveryOutcome
-      }
-      // The queue's `maxRetries` is the source: on the final attempt the row
-      // is marked failed rather than retried, so the requester is not left
-      // waiting on a row that never moves.
-      if (delivery.attempts >= workspaceExportConsumerSettings.maxRetries) {
-        yield* exports.fail({
-          exportId: message.exportId,
-          workspaceId: message.workspaceId,
-          reason: `unavailable: ${failure.reason}`
-        })
-        yield* Effect.annotateLogsScoped({
-          outcome: 'failed',
-          skipReason: 'retries_exhausted'
-        })
-        return 'ack' satisfies DeliveryOutcome
-      }
-      yield* Effect.annotateLogsScoped({
-        outcome: 'retry',
-        capabilityReason: failure.reason
-      })
+    const generation = yield* WorkspaceExportGeneration
+    const result = yield* generation.generate({
+      message,
+      finalAttempt: delivery.attempts >= workspaceExportConsumerSettings.maxRetries
+    })
+    yield* annotateGenerationResult(result)
+    if (result._tag === 'retry') {
       return 'retry' satisfies DeliveryOutcome
     }
-
-    if (built.success === null) {
-      yield* exports.fail({
-        exportId: message.exportId,
-        workspaceId: message.workspaceId,
-        reason: 'workspace_mismatch'
-      })
-      yield* Effect.annotateLogsScoped({
-        outcome: 'failed',
-        skipReason: 'workspace_mismatch'
-      })
-      return 'ack' satisfies DeliveryOutcome
-    }
-
-    const completed = yield* exports
-      .complete({
-        exportId: message.exportId,
-        workspaceId: message.workspaceId,
-        archive: built.success
-      })
-      .pipe(
-        Effect.catchTag('WorkspaceSuspended', () =>
-          Effect.gen(function* () {
-            yield* exports.fail({
-              exportId: message.exportId,
-              workspaceId: message.workspaceId,
-              reason: 'workspace_suspended'
-            })
-            yield* Effect.annotateLogsScoped({
-              outcome: 'skipped',
-              skipReason: 'workspace_suspended'
-            })
-            return false
-          })
-        )
-      )
-    let outcome = 'skipped'
-    if (completed) {
-      outcome = 'ready'
-    }
-    yield* Effect.annotateLogsScoped({ outcome, sizeBytes: built.success.length })
     return 'ack' satisfies DeliveryOutcome
-  })
+  }).pipe(Effect.provide(generationLayer))
+
+  return program
+}
+
+function annotateGenerationResult(result: WorkspaceExportGenerationResult) {
+  if (result._tag === 'ready') {
+    return Effect.annotateLogsScoped({ outcome: 'ready', sizeBytes: result.sizeBytes })
+  }
+  if (result._tag === 'retry') {
+    return Effect.annotateLogsScoped({
+      outcome: 'retry',
+      capabilityReason: result.reason
+    })
+  }
+  return Effect.annotateLogsScoped({ outcome: 'skipped', skipReason: result.reason })
 }
 
 /**
  * Consumer entry: the real capability layer, the request-shaped workspace
- * resolver, and the wide-event scope. A defect or an unhandled store failure
- * retries — the queue's `maxRetries` bounds it and the last attempt marks the
- * row failed inside `processWorkspaceExportMessage`.
+ * resolver, and the wide-event scope. Generation returns a retry disposition
+ * while attempts remain; terminal persistence failures remain Effect failures
+ * so the platform can retry rather than falsely acknowledging the job.
  */
 export function buildWorkspaceExport(
   envelope: QueueEnvelope,
@@ -233,12 +90,14 @@ export function buildWorkspaceExport(
 ): Effect.Effect<DeliveryOutcome> {
   const delivery = readDelivery(WorkspaceExportQueueMessage, envelope)
   const capabilitiesEnv = starterEnv(env)
+  const generationLayer = WorkspaceExportGenerationLayer((slug) =>
+    selectWorkspaceContextLayer(capabilitiesEnv, slug, undefined, 'system')
+  ).pipe(Layer.provide(selectCapabilitiesLayer(capabilitiesEnv)))
+
   return consumerInvocation(env, {
     event: 'workspace_export',
     delivery,
     onFailure: 'retry',
-    program: processWorkspaceExportMessage(delivery, (slug) =>
-      selectWorkspaceContextLayer(capabilitiesEnv, slug, undefined, 'system')
-    ).pipe(Effect.provide(selectCapabilitiesLayer(capabilitiesEnv)))
+    program: processWorkspaceExportMessage(delivery, generationLayer)
   })
 }

--- a/packages/capabilities/src/governance/workspace-export-generation.ts
+++ b/packages/capabilities/src/governance/workspace-export-generation.ts
@@ -3,21 +3,15 @@ import { Context, DateTime, Effect, Layer, Result } from 'effect'
 import { CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
 import { type WorkspaceNotFound } from '../errors.ts'
 import { errorMessage } from '@b2b-saas-starter/failure'
-import { ApiTokenRegistry } from '../developer-platform/api-token-registry.ts'
-import { WebhookEndpoints } from '../developer-platform/webhook-endpoints.ts'
-import { NotificationFeed } from '../notifications/notification-feed.ts'
 import {
   buildWorkspaceExportArchive,
   type WorkspaceExportSnapshot
 } from './workspace-export-archive.ts'
 import {
   collectWorkspaceExportSnapshot,
-  workspaceExportSnapshotContext,
+  workspaceExportSnapshotContextEffect,
   type WorkspaceExportSnapshotServices
 } from './workspace-export-snapshot.ts'
-import { AuditEventLog } from './audit-event-log.ts'
-import { WorkspaceInvitations } from './workspace-invitations.ts'
-import { WorkspaceMembership } from './workspace-membership.ts'
 import {
   WorkspaceExports,
   type FailWorkspaceExportInput,
@@ -132,14 +126,7 @@ export function WorkspaceExportGenerationLayer(
       const exports = yield* WorkspaceExports
       const suspension = yield* WorkspaceSuspensionService
       const scope = yield* Effect.scope
-      const snapshotContext = workspaceExportSnapshotContext({
-        apiTokenRegistry: yield* ApiTokenRegistry,
-        auditEventLog: yield* AuditEventLog,
-        notificationFeed: yield* NotificationFeed,
-        webhookEndpoints: yield* WebhookEndpoints,
-        workspaceInvitations: yield* WorkspaceInvitations,
-        workspaceMembership: yield* WorkspaceMembership
-      })
+      const snapshotContext = yield* workspaceExportSnapshotContextEffect()
 
       const generate = Effect.fn('WorkspaceExportGeneration.generate')(function* (
         input: WorkspaceExportGenerationInput

--- a/packages/capabilities/src/governance/workspace-export-generation.ts
+++ b/packages/capabilities/src/governance/workspace-export-generation.ts
@@ -1,0 +1,212 @@
+import { Context, DateTime, Effect, Layer, Result } from 'effect'
+
+import { CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
+import { type WorkspaceNotFound } from '../errors.ts'
+import { errorMessage } from '@b2b-saas-starter/failure'
+import { ApiTokenRegistry } from '../developer-platform/api-token-registry.ts'
+import { WebhookEndpoints } from '../developer-platform/webhook-endpoints.ts'
+import { NotificationFeed } from '../notifications/notification-feed.ts'
+import {
+  buildWorkspaceExportArchive,
+  type WorkspaceExportSnapshot
+} from './workspace-export-archive.ts'
+import {
+  collectWorkspaceExportSnapshot,
+  workspaceExportSnapshotContext,
+  type WorkspaceExportSnapshotServices
+} from './workspace-export-snapshot.ts'
+import { AuditEventLog } from './audit-event-log.ts'
+import { WorkspaceInvitations } from './workspace-invitations.ts'
+import { WorkspaceMembership } from './workspace-membership.ts'
+import {
+  WorkspaceExports,
+  type FailWorkspaceExportInput,
+  type WorkspaceExportQueueMessage,
+  type WorkspaceExportsInterface
+} from './workspace-export.ts'
+import { type WorkspaceContext, type WorkspaceServices } from '../workspace-context.ts'
+import { WorkspaceSuspensionService } from './workspace-suspension.ts'
+
+/** The trusted context adapter selected by the queue composition root. */
+export type ResolveWorkspace = (
+  slug: string
+) => Layer.Layer<WorkspaceServices, WorkspaceNotFound | CapabilityUnavailable>
+
+export type WorkspaceExportGenerationInput = {
+  readonly message: WorkspaceExportQueueMessage
+  /** Supplied by the queue adapter from its configured retry limit. */
+  readonly finalAttempt: boolean
+}
+
+export type WorkspaceExportGenerationResult =
+  | { readonly _tag: 'ready'; readonly sizeBytes: number }
+  | { readonly _tag: 'skipped'; readonly reason: string }
+  | { readonly _tag: 'retry'; readonly reason: string }
+
+export type WorkspaceExportGenerationInterface = {
+  readonly generate: (
+    input: WorkspaceExportGenerationInput
+  ) => Effect.Effect<WorkspaceExportGenerationResult, CapabilityUnavailable>
+}
+
+export class WorkspaceExportGeneration extends Context.Service<
+  WorkspaceExportGeneration,
+  WorkspaceExportGenerationInterface
+>()('@b2b-saas-starter/capabilities/WorkspaceExportGeneration') {}
+
+type GenerationDependencies =
+  | WorkspaceExports
+  | WorkspaceExportSnapshotServices
+  | WorkspaceSuspensionService
+
+export type WorkspaceExportArchiveBuild = {
+  readonly snapshot: WorkspaceExportSnapshot
+  readonly archive: Uint8Array
+}
+
+/** The shared collect→gzip implementation used by Seed and the queue worker. */
+export function buildWorkspaceExportArchiveEffect(input: {
+  readonly exportId: string
+  readonly generatedAt: DateTime.Utc
+}): Effect.Effect<
+  WorkspaceExportArchiveBuild,
+  CapabilityUnavailable,
+  WorkspaceExportSnapshotServices | WorkspaceContext
+> {
+  return Effect.gen(function* () {
+    const snapshot = yield* collectWorkspaceExportSnapshot(input)
+    const archive = yield* Effect.tryPromise({
+      try: () => buildWorkspaceExportArchive(snapshot),
+      catch: (cause) =>
+        new CapabilityUnavailable({
+          capability: 'workspace-export-archive',
+          reason: errorMessage(cause) ?? 'the archive build failed'
+        })
+    })
+    return { snapshot, archive }
+  })
+}
+
+function failed(
+  input: WorkspaceExportGenerationInput,
+  reason: string,
+  exports: WorkspaceExportsInterface
+): Effect.Effect<WorkspaceExportGenerationResult, CapabilityUnavailable> {
+  const failure: FailWorkspaceExportInput = {
+    exportId: input.message.exportId,
+    workspaceId: input.message.workspaceId,
+    reason
+  }
+  const result = { _tag: 'skipped', reason } satisfies WorkspaceExportGenerationResult
+  return exports.fail(failure).pipe(Effect.map(() => result))
+}
+
+function unavailable(
+  input: WorkspaceExportGenerationInput,
+  reason: string,
+  exports: WorkspaceExportsInterface
+): Effect.Effect<WorkspaceExportGenerationResult, CapabilityUnavailable> {
+  if (!input.finalAttempt) {
+    return Effect.succeed({ _tag: 'retry', reason })
+  }
+  return failed(input, `unavailable: ${reason}`, exports)
+}
+
+function settledSuspension(
+  input: WorkspaceExportGenerationInput,
+  exports: WorkspaceExportsInterface
+) {
+  return failed(input, 'workspace_suspended', exports)
+}
+
+/**
+ * Builds and settles one queued export. The queue only supplies identity and
+ * retry state; snapshot dependencies, archive ordering, and terminal row
+ * settlement stay behind this interface.
+ */
+export function WorkspaceExportGenerationLayer(
+  resolveWorkspace: ResolveWorkspace
+): Layer.Layer<WorkspaceExportGeneration, never, GenerationDependencies> {
+  return Layer.effect(WorkspaceExportGeneration)(
+    Effect.gen(function* () {
+      const exports = yield* WorkspaceExports
+      const suspension = yield* WorkspaceSuspensionService
+      const scope = yield* Effect.scope
+      const snapshotContext = workspaceExportSnapshotContext({
+        apiTokenRegistry: yield* ApiTokenRegistry,
+        auditEventLog: yield* AuditEventLog,
+        notificationFeed: yield* NotificationFeed,
+        webhookEndpoints: yield* WebhookEndpoints,
+        workspaceInvitations: yield* WorkspaceInvitations,
+        workspaceMembership: yield* WorkspaceMembership
+      })
+
+      const generate = Effect.fn('WorkspaceExportGeneration.generate')(function* (
+        input: WorkspaceExportGenerationInput
+      ) {
+        const message = input.message
+        const allowed = yield* Effect.result(
+          suspension.requireAllowed(message.workspaceId, 'product')
+        )
+        if (Result.isFailure(allowed)) {
+          if (allowed.failure._tag === 'WorkspaceSuspended') {
+            return yield* settledSuspension(input, exports)
+          }
+          return yield* unavailable(input, allowed.failure.reason, exports)
+        }
+
+        const built = yield* Effect.result(
+          Effect.gen(function* () {
+            const workspaceContext = yield* Layer.buildWithScope(
+              resolveWorkspace(message.workspaceSlug),
+              scope
+            )
+            return yield* buildWorkspaceExportArchiveEffect({
+              exportId: message.exportId,
+              generatedAt: yield* DateTime.now
+            }).pipe(
+              Effect.provide(snapshotContext),
+              Effect.provideContext(workspaceContext)
+            )
+          })
+        )
+
+        if (Result.isFailure(built)) {
+          if (built.failure._tag === 'WorkspaceNotFound') {
+            return yield* failed(input, 'workspace_not_found', exports)
+          }
+          return yield* unavailable(input, built.failure.reason, exports)
+        }
+        if (built.success.snapshot.workspace.id !== message.workspaceId) {
+          return yield* failed(input, 'workspace_mismatch', exports)
+        }
+
+        const completed = yield* Effect.result(
+          exports.complete({
+            exportId: message.exportId,
+            workspaceId: message.workspaceId,
+            archive: built.success.archive
+          })
+        )
+        if (Result.isFailure(completed)) {
+          if (completed.failure._tag === 'WorkspaceSuspended') {
+            return yield* settledSuspension(input, exports)
+          }
+          return yield* unavailable(input, completed.failure.reason, exports)
+        }
+        if (!completed.success) {
+          return {
+            _tag: 'skipped',
+            reason: 'already_settled'
+          } satisfies WorkspaceExportGenerationResult
+        }
+        return {
+          _tag: 'ready',
+          sizeBytes: built.success.archive.length
+        } satisfies WorkspaceExportGenerationResult
+      })
+
+      return WorkspaceExportGeneration.of({ generate })
+    })
+  )
+}

--- a/packages/capabilities/src/governance/workspace-export-snapshot.ts
+++ b/packages/capabilities/src/governance/workspace-export-snapshot.ts
@@ -53,6 +53,28 @@ export function workspaceExportSnapshotContext(
 }
 
 /**
+ * Acquires the snapshot's explicit read allowlist once for an adapter. Keeping
+ * this recipe here makes Seed and queued generation agree when a snapshot
+ * service is added, without capturing ambient context such as WorkspaceContext.
+ */
+export function workspaceExportSnapshotContextEffect(): Effect.Effect<
+  Context.Context<WorkspaceExportSnapshotServices>,
+  never,
+  WorkspaceExportSnapshotServices
+> {
+  return Effect.gen(function* () {
+    return workspaceExportSnapshotContext({
+      apiTokenRegistry: yield* ApiTokenRegistry,
+      auditEventLog: yield* AuditEventLog,
+      notificationFeed: yield* NotificationFeed,
+      webhookEndpoints: yield* WebhookEndpoints,
+      workspaceInvitations: yield* WorkspaceInvitations,
+      workspaceMembership: yield* WorkspaceMembership
+    })
+  })
+}
+
+/**
  * Every page of the workspace's audit trail, newest first — complete or the
  * export fails. The walk's runaway guard stops at 25 pages of the read's own
  * default size, and a `workspace.export` that hit it would be a silent

--- a/packages/capabilities/src/governance/workspace-export-snapshot.ts
+++ b/packages/capabilities/src/governance/workspace-export-snapshot.ts
@@ -1,4 +1,4 @@
-import { DateTime, Effect } from 'effect'
+import { Context, DateTime, Effect } from 'effect'
 
 import { ApiTokenRegistry } from '../developer-platform/api-token-registry.ts'
 import { WebhookEndpoints } from '../developer-platform/webhook-endpoints.ts'
@@ -23,6 +23,34 @@ export type WorkspaceExportSnapshotServices =
   | WebhookEndpoints
   | WorkspaceInvitations
   | WorkspaceMembership
+
+export type WorkspaceExportSnapshotServiceValues = {
+  readonly apiTokenRegistry: typeof ApiTokenRegistry.Service
+  readonly auditEventLog: typeof AuditEventLog.Service
+  readonly notificationFeed: typeof NotificationFeed.Service
+  readonly webhookEndpoints: typeof WebhookEndpoints.Service
+  readonly workspaceInvitations: typeof WorkspaceInvitations.Service
+  readonly workspaceMembership: typeof WorkspaceMembership.Service
+}
+
+/**
+ * Keeps a snapshot's captured dependencies to the read services it declares.
+ * In particular, do not use `Effect.context` here: it retains every service
+ * in the ambient context, including a caller's `WorkspaceContext`, which can
+ * defeat a queue resolver supplied later.
+ */
+export function workspaceExportSnapshotContext(
+  services: WorkspaceExportSnapshotServiceValues
+): Context.Context<WorkspaceExportSnapshotServices> {
+  return Context.mergeAll(
+    Context.make(ApiTokenRegistry, services.apiTokenRegistry),
+    Context.make(AuditEventLog, services.auditEventLog),
+    Context.make(NotificationFeed, services.notificationFeed),
+    Context.make(WebhookEndpoints, services.webhookEndpoints),
+    Context.make(WorkspaceInvitations, services.workspaceInvitations),
+    Context.make(WorkspaceMembership, services.workspaceMembership)
+  )
+}
 
 /**
  * Every page of the workspace's audit trail, newest first — complete or the

--- a/packages/capabilities/src/governance/workspace-export.AGENTS.md
+++ b/packages/capabilities/src/governance/workspace-export.AGENTS.md
@@ -4,6 +4,13 @@ Workspace export (ADR 0055): an owner requests an archive, the background consum
 
 ## Contracts
 
+- `WorkspaceExportGeneration` owns queued generation: suspension re-check,
+  context resolution, snapshot collection, archive construction, workspace
+  identity matching, completion, and terminal failure settlement. The queue
+  adapter only decodes the message, selects the trusted context resolver,
+  annotates the wide event, and turns a retry disposition into platform
+  scheduling. Seed and Live use the same snapshot/archive recipe; Seed runs it
+  inline because it has no queue or bucket.
 - `request` batches the `pending` row with `workspace.export_requested`, then enqueues. An enqueue failure marks the row `failed` (`enqueue_failed`); unconfigured fails `CapabilityUnavailable('not_configured')`.
 - `issueDownloadLink` requires an explicit session or API Token recipient and returns a path and expiry, never an origin. TTL is 15 minutes, capped at the artifact's horizon. Human links sign the user, session and Workspace slug with the artifact identity. Issuance boundaries check recent authentication and download permission.
 - The API download boundary rechecks human session freshness and current Workspace membership/permission. `openDownload` verifies the complete signature, expiry and `isWorkspaceExportDownloadable`, then audits the signed recipient. Refusals answer 404 before artifact storage is read.
@@ -19,3 +26,8 @@ Workspace export (ADR 0055): an owner requests an archive, the background consum
 - No snapshot built from Drizzle rows, and no API worker origin inside the capability.
 - No skipping `isWorkspaceExportDownloadable` on verify because issue checked; the row can expire between them.
 - Queue execution rechecks the current workspace suspension and matches `(exportId, workspaceId, status = pending)` before writing an artifact. A stale or cross-workspace message cannot complete a row; Live checks pending before the bucket write so a duplicate ready message cannot overwrite an artifact.
+- A transient snapshot, archive, or completion failure returns a retry
+  disposition while attempts remain. On the final attempt the generation
+  workflow marks the pending row failed; if that settlement write is itself
+  unavailable, the typed failure remains visible so the queue retries and the
+  row honestly remains pending.

--- a/packages/capabilities/src/governance/workspace-export.live.test.ts
+++ b/packages/capabilities/src/governance/workspace-export.live.test.ts
@@ -3,12 +3,17 @@ import { TestClock } from 'effect/testing'
 import { describe, expect, layer } from '@effect/vitest'
 
 import { NotificationFeed } from '../notifications/notification-feed.ts'
+import { testWorkspaceContext } from '../workspace-context.ts'
 import {
   inWorkspace,
   LIVE_SUITE_TIMEOUT,
   TestDatabase
 } from '../testing/live-harness.ts'
 import { AuditEventLog } from './audit-event-log.ts'
+import {
+  WorkspaceExportGeneration,
+  WorkspaceExportGenerationLayer
+} from './workspace-export-generation.ts'
 import {
   WorkspaceExports,
   WORKSPACE_EXPORT_RETENTION_DAYS,
@@ -24,7 +29,7 @@ import { WorkspaceSuspensionService } from './workspace-suspension.ts'
  * reads back from. Together they let the whole request → complete → download
  * lifecycle run against a real D1 without Cloudflare.
  */
-function stubPorts() {
+function stubPorts(options: { readonly failPut?: boolean } = {}) {
   const sent: Array<WorkspaceExportQueueMessage> = []
   const objects = new Map<string, Uint8Array>()
   const queue: WorkspaceExportQueueBinding = {
@@ -35,6 +40,9 @@ function stubPorts() {
   }
   const bucket: WorkspaceExportBucketBinding = {
     put: (key, value) => {
+      if (options.failPut) {
+        return Promise.reject(new Error('bucket unavailable'))
+      }
       objects.set(key, value)
       return Promise.resolve()
     },
@@ -205,20 +213,35 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live workspace exports', (
         )
         expect(Option.isNone(early)).toBe(true)
 
-        // The background half: no WorkspaceContext, ids from the message.
-        const completed = yield* inWorkspace(
+        // The background half: the generation workflow resolves the context,
+        // snapshots through the real capability adapters, and completes the row.
+        const generated = yield* inWorkspace(
           'live-lab',
-          Effect.flatMap(WorkspaceExports, (exports) =>
-            exports.complete({
-              exportId: requested.id,
-              workspaceId: 'wrk_live',
-              archive
+          Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+            generation.generate({
+              message: {
+                exportId: requested.id,
+                workspaceId: 'wrk_live',
+                workspaceSlug: 'live-lab'
+              },
+              finalAttempt: false
             })
+          ).pipe(
+            Effect.provide(
+              WorkspaceExportGenerationLayer((slug) =>
+                testWorkspaceContext({
+                  id: 'wrk_live',
+                  slug,
+                  name: 'Live Lab',
+                  planId: 'team'
+                })
+              )
+            )
           ),
           undefined,
           bindings
         )
-        expect(completed).toBe(true)
+        expect(generated._tag).toBe('ready')
         expect([...ports.objects.keys()]).toEqual([
           `workspaces/wrk_live/${requested.id}.json.gz`
         ])
@@ -244,7 +267,8 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live workspace exports', (
           bindings
         )
         const ready = listed.find((row) => row.id === requested.id)
-        expect(ready).toMatchObject({ status: 'ready', sizeBytes: archive.length })
+        expect(ready).toMatchObject({ status: 'ready' })
+        expect(ready?.sizeBytes).toBeGreaterThan(0)
         expect(ready?.expiresAt).not.toBeNull()
 
         // The requester was notified.
@@ -286,7 +310,8 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live workspace exports', (
           expect.fail('expected the archive')
         }
         expect(download.value.fileName).toBe(`live-lab-export-${requested.id}.json.gz`)
-        expect([...download.value.body]).toEqual([...archive])
+        expect([...download.value.body.subarray(0, 2)]).toEqual([0x1f, 0x8b])
+        expect(download.value.sizeBytes).toBe(ready?.sizeBytes)
 
         const tampered = yield* inWorkspace(
           'live-lab',
@@ -346,6 +371,62 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live workspace exports', (
           )?.actorType
         ).toBe('api_token')
       })
+    )
+
+    it.effect(
+      'settles a resolver workspace mismatch instead of completing the row',
+      () =>
+        Effect.gen(function* () {
+          const ports = stubPorts()
+          const bindings = { workspaceExports: ports.workspaceExports }
+          const requested = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExports, (exports) => exports.request),
+            { userId: 'usr_owner' },
+            bindings
+          )
+          const generated = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+              generation.generate({
+                message: {
+                  exportId: requested.id,
+                  workspaceId: 'wrk_live',
+                  workspaceSlug: 'live-lab'
+                },
+                finalAttempt: true
+              })
+            ).pipe(
+              Effect.provide(
+                WorkspaceExportGenerationLayer((slug) =>
+                  testWorkspaceContext({
+                    id: 'wrk_recreated',
+                    slug,
+                    name: 'Recreated Live Lab',
+                    planId: 'team'
+                  })
+                )
+              )
+            ),
+            undefined,
+            bindings
+          )
+          expect(generated).toEqual({
+            _tag: 'skipped',
+            reason: 'workspace_mismatch'
+          })
+          const listed = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExports, (exports) => exports.list),
+            undefined,
+            bindings
+          )
+          expect(listed.find((row) => row.id === requested.id)).toMatchObject({
+            status: 'failed',
+            failureReason: 'workspace_mismatch'
+          })
+          expect(ports.objects.size).toBe(0)
+        })
     )
 
     it.effect('marks a pending export failed once, and only in its own workspace', () =>
@@ -411,6 +492,61 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live workspace exports', (
         )
         expect(twice).toBe(false)
       })
+    )
+
+    it.effect(
+      'settles a final completion failure instead of leaving the row pending',
+      () =>
+        Effect.gen(function* () {
+          const ports = stubPorts({ failPut: true })
+          const bindings = { workspaceExports: ports.workspaceExports }
+          const requested = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExports, (exports) => exports.request),
+            { userId: 'usr_owner' },
+            bindings
+          )
+          const generated = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+              generation.generate({
+                message: {
+                  exportId: requested.id,
+                  workspaceId: 'wrk_live',
+                  workspaceSlug: 'live-lab'
+                },
+                finalAttempt: true
+              })
+            ).pipe(
+              Effect.provide(
+                WorkspaceExportGenerationLayer((slug) =>
+                  testWorkspaceContext({
+                    id: 'wrk_live',
+                    slug,
+                    name: 'Live Lab',
+                    planId: 'team'
+                  })
+                )
+              )
+            ),
+            undefined,
+            bindings
+          )
+          expect(generated).toMatchObject({ _tag: 'skipped' })
+          if (generated._tag === 'skipped') {
+            expect(generated.reason).toMatch(/^unavailable: /)
+          }
+          const listed = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExports, (exports) => exports.list),
+            undefined,
+            bindings
+          )
+          expect(listed.find((row) => row.id === requested.id)).toMatchObject({
+            status: 'failed',
+            failureReason: 'unavailable: bucket unavailable'
+          })
+        })
     )
 
     it.effect('refuses export requests while the workspace is suspended', () =>

--- a/packages/capabilities/src/governance/workspace-export.live.test.ts
+++ b/packages/capabilities/src/governance/workspace-export.live.test.ts
@@ -1,9 +1,11 @@
-import { DateTime, Effect, Option } from 'effect'
+import { DateTime, Effect, Layer, Option } from 'effect'
 import { TestClock } from 'effect/testing'
 import { describe, expect, layer } from '@effect/vitest'
 
+import { CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
 import { NotificationFeed } from '../notifications/notification-feed.ts'
 import { testWorkspaceContext } from '../workspace-context.ts'
+import { WorkspaceSuspended, WorkspaceNotFound } from '../errors.ts'
 import {
   inWorkspace,
   LIVE_SUITE_TIMEOUT,
@@ -17,10 +19,12 @@ import {
 import {
   WorkspaceExports,
   WORKSPACE_EXPORT_RETENTION_DAYS,
+  type WorkspaceExportsInterface,
   type WorkspaceExportBucketBinding,
   type WorkspaceExportQueueBinding,
   type WorkspaceExportQueueMessage
 } from './workspace-export.ts'
+import { WorkspaceMembership } from './workspace-membership.ts'
 import { WorkspaceSuspensionService } from './workspace-suspension.ts'
 
 /**
@@ -427,6 +431,430 @@ layer(TestDatabase, { timeout: LIVE_SUITE_TIMEOUT })('live workspace exports', (
           })
           expect(ports.objects.size).toBe(0)
         })
+    )
+
+    it.effect('settles an unknown resolver workspace as a failed export', () =>
+      Effect.gen(function* () {
+        const ports = stubPorts()
+        const bindings = { workspaceExports: ports.workspaceExports }
+        const requested = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (exports) => exports.request),
+          { userId: 'usr_owner' },
+          bindings
+        )
+        const generated = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+            generation.generate({
+              message: {
+                exportId: requested.id,
+                workspaceId: 'wrk_live',
+                workspaceSlug: 'deleted-lab'
+              },
+              finalAttempt: false
+            })
+          ).pipe(
+            Effect.provide(
+              WorkspaceExportGenerationLayer((slug) =>
+                Layer.unwrap(Effect.fail(new WorkspaceNotFound({ slug })))
+              )
+            )
+          ),
+          undefined,
+          bindings
+        )
+        expect(generated).toEqual({
+          _tag: 'skipped',
+          reason: 'workspace_not_found'
+        })
+        const listed = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (exports) => exports.list),
+          undefined,
+          bindings
+        )
+        expect(listed.find((row) => row.id === requested.id)).toMatchObject({
+          status: 'failed',
+          failureReason: 'workspace_not_found'
+        })
+      })
+    )
+
+    it.effect('settles suspension before snapshot without writing an artifact', () =>
+      Effect.gen(function* () {
+        const ports = stubPorts()
+        const bindings = { workspaceExports: ports.workspaceExports }
+        const requested = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (exports) => exports.request),
+          { userId: 'usr_owner' },
+          bindings
+        )
+        yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceSuspensionService, (suspension) =>
+            suspension.transition({
+              workspaceId: 'wrk_live',
+              action: 'suspend',
+              actor: { userId: 'usr_sysadmin' },
+              internalReason: 'generation test',
+              customerExplanation: 'Exports are paused.'
+            })
+          )
+        )
+        const generated = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+            generation.generate({
+              message: {
+                exportId: requested.id,
+                workspaceId: 'wrk_live',
+                workspaceSlug: 'live-lab'
+              },
+              finalAttempt: true
+            })
+          ).pipe(
+            Effect.provide(
+              WorkspaceExportGenerationLayer((slug) =>
+                testWorkspaceContext({
+                  id: 'wrk_live',
+                  slug,
+                  name: 'Live Lab',
+                  planId: 'team'
+                })
+              )
+            )
+          ),
+          undefined,
+          bindings
+        )
+        expect(generated).toEqual({
+          _tag: 'skipped',
+          reason: 'workspace_suspended'
+        })
+        expect(ports.objects.size).toBe(0)
+        yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceSuspensionService, (suspension) =>
+            suspension.transition({
+              workspaceId: 'wrk_live',
+              action: 'unsuspend',
+              actor: { userId: 'usr_sysadmin' },
+              internalReason: 'generation test cleanup'
+            })
+          )
+        )
+        const listed = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (exports) => exports.list),
+          undefined,
+          bindings
+        )
+        expect(listed.find((row) => row.id === requested.id)).toMatchObject({
+          status: 'failed',
+          failureReason: 'workspace_suspended'
+        })
+      })
+    )
+
+    it.effect('settles suspension during completion without replacing the row', () =>
+      Effect.gen(function* () {
+        const ports = stubPorts()
+        const bindings = { workspaceExports: ports.workspaceExports }
+        const requested = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (exports) => exports.request),
+          { userId: 'usr_owner' },
+          bindings
+        )
+        const exports = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (service) => Effect.succeed(service)),
+          undefined,
+          bindings
+        )
+        const duringCompletion: WorkspaceExportsInterface = {
+          ...exports,
+          complete: () =>
+            Effect.fail(new WorkspaceSuspended({ workspaceId: 'wrk_live' }))
+        }
+        const generated = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+            generation.generate({
+              message: {
+                exportId: requested.id,
+                workspaceId: 'wrk_live',
+                workspaceSlug: 'live-lab'
+              },
+              finalAttempt: false
+            })
+          ).pipe(
+            Effect.provide(
+              WorkspaceExportGenerationLayer((slug) =>
+                testWorkspaceContext({
+                  id: 'wrk_live',
+                  slug,
+                  name: 'Live Lab',
+                  planId: 'team'
+                })
+              ).pipe(Layer.provide(Layer.succeed(WorkspaceExports)(duringCompletion)))
+            )
+          ),
+          undefined,
+          bindings
+        )
+        expect(generated).toEqual({
+          _tag: 'skipped',
+          reason: 'workspace_suspended'
+        })
+        expect(ports.objects.size).toBe(0)
+        const listed = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (service) => service.list),
+          undefined,
+          bindings
+        )
+        expect(listed.find((row) => row.id === requested.id)).toMatchObject({
+          status: 'failed',
+          failureReason: 'workspace_suspended'
+        })
+      })
+    )
+
+    it.effect(
+      'retries a transient snapshot failure and settles it on the final attempt',
+      () =>
+        Effect.gen(function* () {
+          const ports = stubPorts()
+          const bindings = { workspaceExports: ports.workspaceExports }
+          const requested = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExports, (exports) => exports.request),
+            { userId: 'usr_owner' },
+            bindings
+          )
+          const membership = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceMembership, (service) => Effect.succeed(service)),
+            undefined,
+            bindings
+          )
+          const failingMembership = WorkspaceMembership.of({
+            ...membership,
+            listMembers: Effect.fail(
+              new CapabilityUnavailable({
+                capability: 'workspace-membership',
+                reason: 'snapshot unavailable'
+              })
+            )
+          })
+          const generated = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+              generation.generate({
+                message: {
+                  exportId: requested.id,
+                  workspaceId: 'wrk_live',
+                  workspaceSlug: 'live-lab'
+                },
+                finalAttempt: false
+              })
+            ).pipe(
+              Effect.provide(
+                WorkspaceExportGenerationLayer((slug) =>
+                  testWorkspaceContext({
+                    id: 'wrk_live',
+                    slug,
+                    name: 'Live Lab',
+                    planId: 'team'
+                  })
+                ).pipe(
+                  Layer.provide(Layer.succeed(WorkspaceMembership)(failingMembership))
+                )
+              )
+            ),
+            undefined,
+            bindings
+          )
+          expect(generated).toMatchObject({
+            _tag: 'retry',
+            reason: 'snapshot unavailable'
+          })
+          const finalGenerated = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+              generation.generate({
+                message: {
+                  exportId: requested.id,
+                  workspaceId: 'wrk_live',
+                  workspaceSlug: 'live-lab'
+                },
+                finalAttempt: true
+              })
+            ).pipe(
+              Effect.provide(
+                WorkspaceExportGenerationLayer((slug) =>
+                  testWorkspaceContext({
+                    id: 'wrk_live',
+                    slug,
+                    name: 'Live Lab',
+                    planId: 'team'
+                  })
+                ).pipe(
+                  Layer.provide(Layer.succeed(WorkspaceMembership)(failingMembership))
+                )
+              )
+            ),
+            undefined,
+            bindings
+          )
+          expect(finalGenerated).toMatchObject({
+            _tag: 'skipped',
+            reason: 'unavailable: snapshot unavailable'
+          })
+          const listed = yield* inWorkspace(
+            'live-lab',
+            Effect.flatMap(WorkspaceExports, (exports) => exports.list),
+            undefined,
+            bindings
+          )
+          expect(listed.find((row) => row.id === requested.id)).toMatchObject({
+            status: 'failed',
+            failureReason: 'unavailable: snapshot unavailable'
+          })
+        })
+    )
+
+    it.effect('returns retry for a transient completion failure', () =>
+      Effect.gen(function* () {
+        const ports = stubPorts({ failPut: true })
+        const bindings = { workspaceExports: ports.workspaceExports }
+        const requested = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (exports) => exports.request),
+          { userId: 'usr_owner' },
+          bindings
+        )
+        const generated = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+            generation.generate({
+              message: {
+                exportId: requested.id,
+                workspaceId: 'wrk_live',
+                workspaceSlug: 'live-lab'
+              },
+              finalAttempt: false
+            })
+          ).pipe(
+            Effect.provide(
+              WorkspaceExportGenerationLayer((slug) =>
+                testWorkspaceContext({
+                  id: 'wrk_live',
+                  slug,
+                  name: 'Live Lab',
+                  planId: 'team'
+                })
+              )
+            )
+          ),
+          undefined,
+          bindings
+        )
+        expect(generated).toMatchObject({ _tag: 'retry' })
+        const listed = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (exports) => exports.list),
+          undefined,
+          bindings
+        )
+        expect(listed.find((row) => row.id === requested.id)?.status).toBe('pending')
+      })
+    )
+
+    it.effect('keeps a pending row and exposes a terminal settlement outage', () =>
+      Effect.gen(function* () {
+        const ports = stubPorts()
+        const bindings = { workspaceExports: ports.workspaceExports }
+        const requested = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (exports) => exports.request),
+          { userId: 'usr_owner' },
+          bindings
+        )
+        const exports = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (service) => Effect.succeed(service)),
+          undefined,
+          bindings
+        )
+        const membership = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceMembership, (service) => Effect.succeed(service)),
+          undefined,
+          bindings
+        )
+        const failingMembership = WorkspaceMembership.of({
+          ...membership,
+          listMembers: Effect.fail(
+            new CapabilityUnavailable({
+              capability: 'workspace-membership',
+              reason: 'snapshot unavailable'
+            })
+          )
+        })
+        const failingSettlement: WorkspaceExportsInterface = {
+          ...exports,
+          fail: () =>
+            Effect.fail(
+              new CapabilityUnavailable({
+                capability: 'workspace-exports',
+                reason: 'settlement unavailable'
+              })
+            )
+        }
+        const exited = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExportGeneration, (generation) =>
+            Effect.exit(
+              generation.generate({
+                message: {
+                  exportId: requested.id,
+                  workspaceId: 'wrk_live',
+                  workspaceSlug: 'live-lab'
+                },
+                finalAttempt: true
+              })
+            )
+          ).pipe(
+            Effect.provide(
+              WorkspaceExportGenerationLayer((slug) =>
+                testWorkspaceContext({
+                  id: 'wrk_live',
+                  slug,
+                  name: 'Live Lab',
+                  planId: 'team'
+                })
+              ).pipe(
+                Layer.provide(Layer.succeed(WorkspaceExports)(failingSettlement)),
+                Layer.provide(Layer.succeed(WorkspaceMembership)(failingMembership))
+              )
+            )
+          ),
+          undefined,
+          bindings
+        )
+        expect(exited._tag).toBe('Failure')
+        const listed = yield* inWorkspace(
+          'live-lab',
+          Effect.flatMap(WorkspaceExports, (service) => service.list),
+          undefined,
+          bindings
+        )
+        expect(listed.find((row) => row.id === requested.id)?.status).toBe('pending')
+      })
     )
 
     it.effect('marks a pending export failed once, and only in its own workspace', () =>

--- a/packages/capabilities/src/governance/workspace-export.seed.ts
+++ b/packages/capabilities/src/governance/workspace-export.seed.ts
@@ -1,11 +1,9 @@
 import { DateTime, Effect, Layer, Option, Result } from 'effect'
 
-import {
-  type CapabilityUnavailable,
-  orUnavailable
-} from '@b2b-saas-starter/failure/capability'
+import { type CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
 import { newCapabilityId } from '../internal/ids.ts'
 
+import { ApiTokenRegistry } from '../developer-platform/api-token-registry.ts'
 import {
   NotificationFeed,
   type NotificationFeedInterface
@@ -13,14 +11,15 @@ import {
 import { type NotificationEvent } from '../notifications/notification-events.ts'
 import { testWorkspaceContext, WorkspaceContext } from '../workspace-context.ts'
 import { AuditEventLog, type AuditEventLogInterface } from './audit-event-log.ts'
+import { WebhookEndpoints } from '../developer-platform/webhook-endpoints.ts'
+import { workspaceExportFileName } from './workspace-export-archive.ts'
+import { buildWorkspaceExportArchiveEffect } from './workspace-export-generation.ts'
 import {
-  buildWorkspaceExportArchive,
-  workspaceExportFileName
-} from './workspace-export-archive.ts'
-import {
-  collectWorkspaceExportSnapshot,
+  workspaceExportSnapshotContext,
   type WorkspaceExportSnapshotServices
 } from './workspace-export-snapshot.ts'
+import { WorkspaceInvitations } from './workspace-invitations.ts'
+import { WorkspaceMembership } from './workspace-membership.ts'
 import {
   issueWorkspaceExportDownloadLink,
   isWorkspaceExportDownloadable,
@@ -121,30 +120,24 @@ export function SeedWorkspaceExports(options: {
     Effect.gen(function* () {
       const audit = yield* AuditEventLog
       const feed = yield* NotificationFeed
-      const snapshotServices = yield* Effect.context<WorkspaceExportSnapshotServices>()
+      const snapshotContext = workspaceExportSnapshotContext({
+        apiTokenRegistry: yield* ApiTokenRegistry,
+        auditEventLog: audit,
+        notificationFeed: feed,
+        webhookEndpoints: yield* WebhookEndpoints,
+        workspaceInvitations: yield* WorkspaceInvitations,
+        workspaceMembership: yield* WorkspaceMembership
+      })
       const suspension = yield* WorkspaceSuspensionService
       function requireProduct(workspaceId: string) {
         return suspension.requireAllowed(workspaceId, 'product')
       }
       const rows: Array<SeedExportRow> = []
 
-      // The archive builder over the shared seed services, for the fixture
-      // export (a trusted context, like the queue consumer's) and for requests
-      // (the requester's own context). The gzip is a promise, so the builder
-      // folds it into the effect channel with the same `CapabilityUnavailable`
-      // a failed read would surface.
-      const archiveUnavailable = orUnavailable('workspace-export-archive')
       function buildArchive(exportId: string, generatedAt: DateTime.Utc) {
-        return collectWorkspaceExportSnapshot({ exportId, generatedAt }).pipe(
-          Effect.flatMap((snapshot) =>
-            archiveUnavailable(
-              Effect.tryPromise({
-                try: () => buildWorkspaceExportArchive(snapshot),
-                catch: (cause) => cause
-              })
-            )
-          ),
-          Effect.provide(snapshotServices)
+        return buildWorkspaceExportArchiveEffect({ exportId, generatedAt }).pipe(
+          Effect.provide(snapshotContext),
+          Effect.map(({ archive }) => archive)
         )
       }
 

--- a/packages/capabilities/src/governance/workspace-export.seed.ts
+++ b/packages/capabilities/src/governance/workspace-export.seed.ts
@@ -3,7 +3,6 @@ import { DateTime, Effect, Layer, Option, Result } from 'effect'
 import { type CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
 import { newCapabilityId } from '../internal/ids.ts'
 
-import { ApiTokenRegistry } from '../developer-platform/api-token-registry.ts'
 import {
   NotificationFeed,
   type NotificationFeedInterface
@@ -11,15 +10,12 @@ import {
 import { type NotificationEvent } from '../notifications/notification-events.ts'
 import { testWorkspaceContext, WorkspaceContext } from '../workspace-context.ts'
 import { AuditEventLog, type AuditEventLogInterface } from './audit-event-log.ts'
-import { WebhookEndpoints } from '../developer-platform/webhook-endpoints.ts'
 import { workspaceExportFileName } from './workspace-export-archive.ts'
 import { buildWorkspaceExportArchiveEffect } from './workspace-export-generation.ts'
 import {
-  workspaceExportSnapshotContext,
+  workspaceExportSnapshotContextEffect,
   type WorkspaceExportSnapshotServices
 } from './workspace-export-snapshot.ts'
-import { WorkspaceInvitations } from './workspace-invitations.ts'
-import { WorkspaceMembership } from './workspace-membership.ts'
 import {
   issueWorkspaceExportDownloadLink,
   isWorkspaceExportDownloadable,
@@ -120,14 +116,7 @@ export function SeedWorkspaceExports(options: {
     Effect.gen(function* () {
       const audit = yield* AuditEventLog
       const feed = yield* NotificationFeed
-      const snapshotContext = workspaceExportSnapshotContext({
-        apiTokenRegistry: yield* ApiTokenRegistry,
-        auditEventLog: audit,
-        notificationFeed: feed,
-        webhookEndpoints: yield* WebhookEndpoints,
-        workspaceInvitations: yield* WorkspaceInvitations,
-        workspaceMembership: yield* WorkspaceMembership
-      })
+      const snapshotContext = yield* workspaceExportSnapshotContextEffect()
       const suspension = yield* WorkspaceSuspensionService
       function requireProduct(workspaceId: string) {
         return suspension.requireAllowed(workspaceId, 'product')


### PR DESCRIPTION
## Outcome

Closes #380.

Deepens workspace export generation behind the capability-owned workflow. Seed and queued generation now share one explicit six-service snapshot acquisition recipe, while the Live generation suite covers resolver failures, suspension before and during completion, transient retry behavior, final-attempt settlement, and failed terminal settlement without falsely completing a pending row.

## Decisions

- Kept queue ownership unchanged: decoding, tracing, resolver selection, and platform retry scheduling remain in the background adapter.
- Kept the snapshot allowlist explicit; the shared acquisition helper never captures ambient `WorkspaceContext`.

## Validation

Validated revision `b020a1c927e37326156301c99e7cf7bdea11ee22`.

- Focused export suites: 39 tests passed, including 14 Live workspace-export tests.
- `pnpm run check`: passed. Capabilities: 605 tests; background: 122; web: 707; scripts: 39 passed with 2 optional binary skips; operations: 24 plus queue-health checks.
- `E2E_PORT=3197 pnpm run validate`: completed successfully. The browser run recorded 38 passes and one flaky retry pass in the existing strong-authentication scenario; the first attempt missed the verification redirect, and retry passed. Validation log: `/private/tmp/workspace-export-depth-validate-b020a1c.log`.

## Risks and remaining work

No known export-specific risks. The browser validation has one observed flaky retry in an unrelated strong-authentication path; no source changes were made for it.
