### PR TITLE
feat(web): simplify workspace and sign-in screens

### DIFF
--- a/apps/web/e2e/demo-preview.spec.ts
+++ b/apps/web/e2e/demo-preview.spec.ts
@@ -52,6 +52,7 @@ test('preview forms and destructive dialogs explain refusal without sending or c
   await page
     .locator('header [data-slot="select-trigger"]:enabled')
     .waitFor({ state: 'attached' })
+  await page.getByRole('button', { name: 'Invite a member', exact: true }).click()
   await page.getByLabel('Invite by email', { exact: true }).fill('visitor@example.com')
   await page.getByRole('button', { name: 'Send invitation', exact: true }).click()
   await expect(
@@ -96,11 +97,16 @@ test('token creation, replacement, and webhook creation refuse locally', async (
   await page
     .locator('header [data-slot="select-trigger"]:enabled')
     .waitFor({ state: 'attached' })
+  await page.getByRole('button', { name: 'Create a token', exact: true }).click()
   await page.getByLabel('Token name', { exact: true }).fill('Visitor token')
   await page.getByRole('button', { name: 'Create token', exact: true }).click()
   await expect(
     page.getByText(/This preview is read-only. No changes were made./)
   ).toBeVisible()
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Close', exact: true })
+    .click()
   await page
     .getByRole('listitem')
     .filter({ hasText: 'Local admin token' })
@@ -120,6 +126,7 @@ test('token creation, replacement, and webhook creation refuse locally', async (
   await page
     .locator('header [data-slot="select-trigger"]:enabled')
     .waitFor({ state: 'attached' })
+  await page.getByRole('button', { name: 'Register an endpoint', exact: true }).click()
   await page
     .getByLabel('Endpoint URL', { exact: true })
     .fill('https://example.com/visitor')

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -129,7 +129,7 @@ test('seeded demo user can request a magic link', async ({ page }) => {
   await page.goto('/sign-in')
   await page.locator('form[data-hydrated="true"]').waitFor()
   // The second Local Auth Path: switch the form to email-only and send.
-  await page.getByRole('button', { name: 'Email me a sign-in link' }).click()
+  await page.getByRole('button', { name: 'Email link', exact: true }).click()
   await expect(
     page.getByRole('heading', { name: 'Sign in with an email link' })
   ).toBeVisible()

--- a/apps/web/src/components/api-tokens-panel.test.tsx
+++ b/apps/web/src/components/api-tokens-panel.test.tsx
@@ -45,16 +45,16 @@ describe('ApiTokensPanel', () => {
 
   it('offers the create form and the revoke control to a role that holds both', async () => {
     await renderPanel({ role: 'owner' })
-    expect(screen.getByRole('heading', { name: 'Create a token' })).toBeTruthy()
-    expect(screen.getByLabelText('Token name')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Revoke' })).toBeTruthy()
     expect(screen.queryByText('Your role cannot mint tokens.')).toBeNull()
     expect(screen.queryByText('Your role cannot revoke tokens.')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Create a token' }))
+    expect(screen.getByLabelText('Token name')).toBeTruthy()
   })
 
   it('keeps revoke but removes mint and replacement controls in recovery mode', async () => {
     await renderPanel({ role: 'owner', creation: 'hidden' })
-    expect(screen.queryByRole('heading', { name: 'Create a token' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Create a token' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Replace' })).toBeNull()
     expect(screen.getByRole('button', { name: 'Revoke' })).toBeTruthy()
   })

--- a/apps/web/src/components/api-tokens-panel.tsx
+++ b/apps/web/src/components/api-tokens-panel.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/item'
 import { ConfirmButton } from '@/components/confirm-button'
 import { ActionFeedback } from '@/components/page/action-feedback'
-import { CreateSection, ListSection, Panel } from '@/components/page/panel'
+import { CreateAction, ListSection, Panel } from '@/components/page/panel'
 import { Identifier } from '@/components/page/identifier'
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty'
 import { formatTimestampOr } from '@/lib/format-date'
@@ -106,7 +106,7 @@ export function ApiTokensPanel({
   return (
     <Panel>
       {creation === 'visible' ? (
-        <CreateSection
+        <CreateAction
           allowed={canCreate}
           title={m.tokens_create_title()}
           deniedReason={m.token_mint_denied()}
@@ -118,7 +118,7 @@ export function ApiTokensPanel({
             }}
             {...(createToken === undefined ? {} : { createToken })}
           />
-        </CreateSection>
+        </CreateAction>
       ) : null}
 
       {replacing ? (
@@ -132,6 +132,7 @@ export function ApiTokensPanel({
         />
       ) : null}
       <ListSection
+        as="h2"
         title={m.tokens_title()}
         footer={
           canRevoke ? undefined : (

--- a/apps/web/src/components/attention-feed.tsx
+++ b/apps/web/src/components/attention-feed.tsx
@@ -26,11 +26,11 @@ export function AttentionFeed({
   }
   return (
     <Panel title={m.needs_attention()} className="min-w-0">
-      <ol className="grid gap-2">
+      <ol className="grid divide-y divide-border">
         {items.map((item) => (
           <li
             key={item.id}
-            className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 rounded-sm border border-border bg-muted/40 px-3 py-2"
+            className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 py-3 first:pt-0 last:pb-0"
           >
             <div className="grid min-w-0 flex-1 gap-0.5 max-md:basis-full">
               <p className="flex min-w-0 items-center gap-2 text-sm font-medium">
@@ -42,7 +42,7 @@ export function AttentionFeed({
                   {item.title}
                 </span>
               </p>
-              <p className="min-w-0 truncate text-xs text-muted-foreground">
+              <p className="min-w-0 text-sm text-muted-foreground">
                 {item.description}
               </p>
             </div>

--- a/apps/web/src/components/auth/demo-credentials-footer.tsx
+++ b/apps/web/src/components/auth/demo-credentials-footer.tsx
@@ -1,3 +1,11 @@
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
 import { Link } from '@tanstack/react-router'
 import {
   DEMO_CREDENTIALS,
@@ -17,36 +25,46 @@ import { m } from '@b2b-saas-starter/i18n/messages'
  */
 export function DemoCredentialsFooter() {
   return (
-    <>
-      <p className="text-xs text-muted-foreground">
-        {m.public_auth_seeded_database_hint()}{' '}
-        <code className="rounded-sm bg-muted px-1 py-0.5">
-          {DEMO_CREDENTIALS.email}
-        </code>{' '}
-        /{' '}
-        <code className="rounded-sm bg-muted px-1 py-0.5">
-          {DEMO_CREDENTIALS.password}
-        </code>
-        .
-      </p>
-      <p className="text-xs text-muted-foreground">
-        {m.public_auth_member_hint()}{' '}
-        <code className="rounded-sm bg-muted px-1 py-0.5">
-          {DEMO_MEMBER_CREDENTIALS.email}
-        </code>{' '}
-        /{' '}
-        <code className="rounded-sm bg-muted px-1 py-0.5">
-          {DEMO_MEMBER_CREDENTIALS.password}
-        </code>
-        .
-      </p>
-      <Link
-        to="/workspaces/$workspaceSlug"
-        params={{ workspaceSlug: DEMO_WORKSPACE_SLUG }}
-        className="text-center text-sm text-primary underline underline-offset-4"
-      >
-        {m.public_auth_open_seeded_workspace()}
-      </Link>
-    </>
+    <Sheet>
+      <SheetTrigger render={<Button variant="link" />}>
+        {m.auth_view_demo_credentials()}
+      </SheetTrigger>
+      <SheetContent className="overflow-y-auto data-[side=right]:w-full data-[side=right]:sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle>{m.auth_demo_credentials()}</SheetTitle>
+        </SheetHeader>
+        <div className="grid gap-4 px-4 pb-6">
+          <p className="text-xs text-muted-foreground">
+            {m.public_auth_seeded_database_hint()}{' '}
+            <code className="rounded-sm bg-muted px-1 py-0.5">
+              {DEMO_CREDENTIALS.email}
+            </code>{' '}
+            /{' '}
+            <code className="rounded-sm bg-muted px-1 py-0.5">
+              {DEMO_CREDENTIALS.password}
+            </code>
+            .
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {m.public_auth_member_hint()}{' '}
+            <code className="rounded-sm bg-muted px-1 py-0.5">
+              {DEMO_MEMBER_CREDENTIALS.email}
+            </code>{' '}
+            /{' '}
+            <code className="rounded-sm bg-muted px-1 py-0.5">
+              {DEMO_MEMBER_CREDENTIALS.password}
+            </code>
+            .
+          </p>
+          <Link
+            to="/workspaces/$workspaceSlug"
+            params={{ workspaceSlug: DEMO_WORKSPACE_SLUG }}
+            className="text-center text-sm text-primary underline underline-offset-4"
+          >
+            {m.public_auth_open_seeded_workspace()}
+          </Link>
+        </div>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/apps/web/src/components/auth/sign-in-page.tsx
+++ b/apps/web/src/components/auth/sign-in-page.tsx
@@ -393,7 +393,11 @@ export function SignInPage({
       footer={signInFooter({
         mode,
         redirect,
-        socialProviders
+        socialProviders,
+        onUseLink: () => {
+          setSubmitError(null)
+          setMode('link')
+        }
       })}
     >
       <LastSignInMethodHint />
@@ -445,18 +449,6 @@ export function SignInPage({
           />
         )}
       </passwordForm.Field>
-
-      <Button
-        type="button"
-        variant="link"
-        onClick={() => {
-          setSubmitError(null)
-          setMode('link')
-        }}
-        className="justify-start p-0 text-sm"
-      >
-        {m.email_me_sign_in_link()}
-      </Button>
     </AuthCardForm>
   )
 }
@@ -471,9 +463,11 @@ export function SignInPage({
 function signInFooter({
   mode,
   redirect,
-  socialProviders
+  socialProviders,
+  onUseLink
 }: {
   mode: 'password' | 'link'
+  onUseLink?: () => void
   redirect?: string | undefined
   socialProviders: ReadonlyArray<SocialProviderId>
 }) {
@@ -481,24 +475,26 @@ function signInFooter({
     <>
       {mode === 'password' ? (
         <>
-          {/* The passkey block sits at the point of action, after the form:
-              same destination, different credential. Conditional-UI browsers
-              also offer passkeys straight from the email field above. */}
-          <PasskeySignIn redirect={redirect} />
-          {socialProviders.length > 0 ? (
-            <p className="text-xs text-muted-foreground">
-              {m.social_sign_in_description()}
-            </p>
-          ) : null}
-          <p className="text-right">
-            <Link
-              to="/sign-in/email-code"
-              search={redirect ? { redirect } : {}}
-              className="text-sm text-primary underline underline-offset-4"
-            >
-              {m.email_code_instead()}
-            </Link>
-          </p>
+          <div className="grid gap-3">
+            <PasskeySignIn redirect={redirect} />
+            <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
+              <Button type="button" variant="link" onClick={onUseLink}>
+                {m.auth_email_link()}
+              </Button>
+              <Link
+                to="/sign-in/email-code"
+                search={redirect ? { redirect } : {}}
+                className="text-sm text-primary underline underline-offset-4"
+              >
+                {m.auth_email_code()}
+              </Link>
+            </div>
+            {socialProviders.length > 0 ? (
+              <p className="text-xs text-muted-foreground">
+                {m.social_sign_in_description()}
+              </p>
+            ) : null}
+          </div>
           <p className="text-right">
             <Link
               to="/forgot-password"

--- a/apps/web/src/components/invitation-panel.tsx
+++ b/apps/web/src/components/invitation-panel.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/item'
 import { ActionFeedback } from '@/components/page/action-feedback'
 import { Identifier } from '@/components/page/identifier'
-import { CreateSection, ListSection, Panel } from '@/components/page/panel'
+import { CreateAction, ListSection, Panel } from '@/components/page/panel'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Spinner } from '@/components/ui/spinner'
 import { viewerCan, WORKSPACE_ROLES, type Viewer } from '@/lib/permissions'
@@ -152,7 +152,7 @@ export function InvitationPanel({
       title={m.panel_invitations()}
       description={m.panel_invitations_description()}
     >
-      <CreateSection
+      <CreateAction
         allowed={canInvite}
         title={m.form_invite_member()}
         deniedReason={m.workspace_invite_denied()}
@@ -232,7 +232,7 @@ export function InvitationPanel({
           <ActionFeedback error={send.error} />
           <ActionFeedback error={resend.error} />
         </form>
-      </CreateSection>
+      </CreateAction>
 
       <ListSection title={m.pending_invitations()}>
         {invitations.length === 0 ? (

--- a/apps/web/src/components/onboarding-checklist.test.tsx
+++ b/apps/web/src/components/onboarding-checklist.test.tsx
@@ -26,7 +26,7 @@ async function renderChecklist(
   data: WorkspaceProgressProjection = progress,
   dismissalHint?: ReactNode
 ) {
-  return renderWithRouter(
+  const rendered = await renderWithRouter(
     <OnboardingChecklist
       workspaceSlug="starter-lab"
       progress={data}
@@ -39,6 +39,7 @@ async function renderChecklist(
       destinations: ['/workspaces/starter-lab/api-tokens', '/account']
     }
   )
+  return rendered
 }
 
 describe('OnboardingChecklist', () => {

--- a/apps/web/src/components/onboarding-checklist.tsx
+++ b/apps/web/src/components/onboarding-checklist.tsx
@@ -140,35 +140,28 @@ export function OnboardingChecklist({
   const allDone = progress.completedCount === progress.totalCount
 
   return (
-    // The page Panel anatomy, not a hand-rolled Card: the title owns its row
-    // and wraps to full width on a phone, and the action slot is Panel's own,
-    // so the count and Dismiss can never squeeze the title to three lines.
     <Panel
       title={m.setup_workspace()}
-      description={
-        allDone ? m.setup_workspace_complete() : m.setup_workspace_description()
-      }
-      actions={
-        <>
-          <span className="font-mono text-sm tabular-nums text-muted-foreground">
-            {m.onboarding_progress({
-              completedCount: progress.completedCount,
-              totalCount: progress.totalCount
-            })}
-          </span>
-          {canDismiss ? (
-            <Button
-              type="button"
-              variant="ghost"
-              disabled={dismissal.pending}
-              onClick={() => dismissal.run()}
-            >
-              {m.dismiss_action()}
-            </Button>
-          ) : null}
-        </>
-      }
+      {...(allDone ? { description: m.setup_workspace_complete() } : {})}
     >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <span className="text-sm tabular-nums text-muted-foreground">
+          {m.onboarding_progress({
+            completedCount: progress.completedCount,
+            totalCount: progress.totalCount
+          })}
+        </span>
+        {canDismiss ? (
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={dismissal.pending}
+            onClick={() => dismissal.run()}
+          >
+            {m.dismiss_action()}
+          </Button>
+        ) : null}
+      </div>
       <ul className="grid gap-2 text-sm">
         {progress.steps.map((step) => {
           const copy = stepCopy()[step.id]

--- a/apps/web/src/components/page/panel.tsx
+++ b/apps/web/src/components/page/panel.tsx
@@ -1,5 +1,14 @@
 import { type ReactNode, useId } from 'react'
 
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
+
 import { cn } from '@/lib/utils'
 
 /**
@@ -75,9 +84,11 @@ export function Panel({
  */
 export function ListSection({
   title,
+  as: Heading = 'h3',
   footer,
   children
 }: {
+  readonly as?: 'h2' | 'h3'
   readonly title: string
   /** Trailing copy under the rows, such as a denied-action reason. */
   readonly footer?: ReactNode
@@ -87,9 +98,9 @@ export function ListSection({
   const titleId = useId()
   return (
     <section aria-labelledby={titleId} className="grid gap-2">
-      <h3 id={titleId} className="text-sm font-semibold">
+      <Heading id={titleId} className="text-sm font-semibold">
         {title}
-      </h3>
+      </Heading>
       {children}
       {footer}
     </section>
@@ -127,5 +138,35 @@ export function CreateSection({
       </h3>
       {children}
     </section>
+  )
+}
+
+/** A focused creation form opened from an explicit action. */
+export function CreateAction({
+  allowed,
+  title,
+  deniedReason,
+  children
+}: {
+  readonly allowed: boolean
+  readonly title: string
+  readonly deniedReason: string
+  readonly children: ReactNode
+}) {
+  if (!allowed) {
+    return <p className="text-sm text-muted-foreground">{deniedReason}</p>
+  }
+  return (
+    <div className="flex justify-end">
+      <Sheet>
+        <SheetTrigger render={<Button />}>{title}</SheetTrigger>
+        <SheetContent className="overflow-y-auto data-[side=right]:w-full data-[side=right]:sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle>{title}</SheetTitle>
+          </SheetHeader>
+          <div className="grid gap-4 px-4 pb-6">{children}</div>
+        </SheetContent>
+      </Sheet>
+    </div>
   )
 }

--- a/apps/web/src/components/page/section-tabs.tsx
+++ b/apps/web/src/components/page/section-tabs.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode } from 'react'
+import { Tabs } from '@base-ui/react/tabs'
+
+/** Named views with keyboard navigation and persistent form state. */
+export function SectionTabs({
+  defaultValue,
+  sections
+}: {
+  readonly defaultValue: string
+  readonly sections: ReadonlyArray<{
+    readonly value: string
+    readonly label: string
+    readonly content: ReactNode
+  }>
+}) {
+  const firstSection = sections[0]
+  if (sections.length === 1 && firstSection !== undefined) {
+    return firstSection.content
+  }
+  return (
+    <Tabs.Root defaultValue={defaultValue} className="grid min-w-0 gap-6">
+      <Tabs.List className="flex gap-1 overflow-x-auto border-b border-border">
+        {sections.map(({ value, label }) => (
+          <Tabs.Tab
+            key={value}
+            value={value}
+            className="min-h-11 shrink-0 border-b-2 border-transparent px-4 py-2 text-sm text-muted-foreground hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-ring data-active:border-primary data-active:text-foreground"
+          >
+            {label}
+          </Tabs.Tab>
+        ))}
+      </Tabs.List>
+      {sections.map(({ value, content }) => (
+        <Tabs.Panel
+          key={value}
+          value={value}
+          keepMounted
+          className="min-w-0 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {content}
+        </Tabs.Panel>
+      ))}
+    </Tabs.Root>
+  )
+}

--- a/apps/web/src/components/page/section-tabs.tsx
+++ b/apps/web/src/components/page/section-tabs.tsx
@@ -11,6 +11,7 @@ export function SectionTabs({
     readonly value: string
     readonly label: string
     readonly content: ReactNode
+    readonly keepMounted?: boolean
   }>
 }) {
   const firstSection = sections[0]
@@ -30,11 +31,11 @@ export function SectionTabs({
           </Tabs.Tab>
         ))}
       </Tabs.List>
-      {sections.map(({ value, content }) => (
+      {sections.map(({ value, content, keepMounted = true }) => (
         <Tabs.Panel
           key={value}
           value={value}
-          keepMounted
+          keepMounted={keepMounted}
           className="min-w-0 outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {content}

--- a/apps/web/src/components/webhooks-panel.test.tsx
+++ b/apps/web/src/components/webhooks-panel.test.tsx
@@ -79,10 +79,10 @@ describe('WebhooksPanel', () => {
 
   it('offers the create form and the row controls to a role that holds them', async () => {
     await renderPanel({ role: 'owner' })
-    expect(screen.getByRole('heading', { name: 'Register an endpoint' })).toBeTruthy()
-    expect(screen.getByLabelText('Endpoint URL')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Disable' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Rotate secret' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Register an endpoint' }))
+    expect(screen.getByLabelText('Endpoint URL')).toBeTruthy()
   })
 
   it('replaces the form with its reason for a role that cannot register', async () => {

--- a/apps/web/src/components/webhooks-panel.tsx
+++ b/apps/web/src/components/webhooks-panel.tsx
@@ -21,7 +21,7 @@ import { Spinner } from '@/components/ui/spinner'
 import { WebhookForm, type CreateWebhookEndpoint } from '@/components/webhook-form'
 import { ConfirmButton } from '@/components/confirm-button'
 import { ActionFeedback } from '@/components/page/action-feedback'
-import { CreateSection, ListSection, Panel } from '@/components/page/panel'
+import { CreateAction, ListSection, Panel } from '@/components/page/panel'
 import { Identifier } from '@/components/page/identifier'
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty'
 import { SecretReveal } from '@/components/secret-reveal'
@@ -201,7 +201,7 @@ export function WebhooksPanel({
 
   return (
     <Panel>
-      <CreateSection
+      <CreateAction
         allowed={canCreate}
         title={m.register_endpoint()}
         deniedReason={m.endpoint_register_denied()}
@@ -211,9 +211,9 @@ export function WebhooksPanel({
           onCreated={() => void router.invalidate()}
           {...(createEndpoint === undefined ? {} : { createEndpoint })}
         />
-      </CreateSection>
+      </CreateAction>
 
-      <ListSection title={m.endpoints_title()}>
+      <ListSection as="h2" title={m.endpoints_title()}>
         {endpoints.length === 0 ? (
           <Empty>
             <EmptyHeader>

--- a/apps/web/src/components/workspace-dashboard-page.tsx
+++ b/apps/web/src/components/workspace-dashboard-page.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { AttentionFeed } from '@/components/attention-feed'
 import {
   LiveNotifications,
@@ -11,21 +11,9 @@ import {
 } from '@/components/onboarding-checklist'
 import { attentionItems } from '@/lib/attention'
 import { PageHeader } from '@/components/page/page-header'
-import { Panel } from '@/components/page/panel'
 import { WorkspaceShell } from '@/components/workspace-shell'
 import { type WorkspaceDashboardPayload } from '@/lib/server/workspace-dashboard'
 import { m } from '@b2b-saas-starter/i18n/messages'
-
-// Lazy: recharts (and its d3 dependencies) is the heaviest module on this
-// route, and the chart is below-fold secondary content — it must not sit in
-// the dashboard's first chunk. `defaultPreload: 'intent'` warms the chunk on
-// navigation intent.
-async function loadWebhookSuccessChart() {
-  const chart = await import('@/components/charts/webhook-success-chart')
-  return { default: chart.WebhookSuccessChart }
-}
-
-const WebhookSuccessChart = lazy(loadWebhookSuccessChart)
 
 /**
  * The workspace overview page. Lives beside the route file (not in it) so the
@@ -69,24 +57,13 @@ export function WorkspaceDashboardPage({
         title={workspace.name}
         description={m.dashboard_attention_description()}
       />
-      {/* Derived from live state on every load; renders nothing once an
-          owner or admin dismissed it for the workspace. */}
-      <OnboardingChecklist
-        workspaceSlug={workspace.slug}
-        progress={progress}
-        viewer={viewer}
-        dismissalHint={dismissalHint}
-        {...(ports?.dismissOnboardingChecklist === undefined
-          ? {}
-          : { dismiss: ports.dismissOnboardingChecklist })}
-      />
       <AttentionFeed
         workspaceSlug={workspace.slug}
         items={attentionItems({
           invitations: data.invitations,
           apiTokens: data.apiTokens,
           webhooks,
-          auditEvents: data.auditEvents
+          auditEvents: null
         })}
       />
       <LiveNotifications
@@ -99,15 +76,17 @@ export function WorkspaceDashboardPage({
           ? {}
           : { markRead: ports.markNotificationsRead })}
       />
-      {/* `null` means the actor holds no `webhook:list`, so the loader never
-          read the endpoints — there is nothing to chart and nothing to hide. */}
-      {webhooks === null ? null : (
-        <Panel title={m.webhook_delivery()}>
-          <Suspense fallback={null}>
-            <WebhookSuccessChart webhooks={webhooks} />
-          </Suspense>
-        </Panel>
-      )}
+      {/* Derived from live state on every load; renders nothing once an
+          owner or admin dismissed it for the workspace. */}
+      <OnboardingChecklist
+        workspaceSlug={workspace.slug}
+        progress={progress}
+        viewer={viewer}
+        dismissalHint={dismissalHint}
+        {...(ports?.dismissOnboardingChecklist === undefined
+          ? {}
+          : { dismiss: ports.dismissOnboardingChecklist })}
+      />
     </WorkspaceShell>
   )
 }

--- a/apps/web/src/components/workspace-members-page.tsx
+++ b/apps/web/src/components/workspace-members-page.tsx
@@ -1,3 +1,4 @@
+import { SectionTabs } from '@/components/page/section-tabs'
 import { WorkspaceLink } from '@/components/workspace-link'
 import { InvitationPanel } from '@/components/invitation-panel'
 import { EmailDeliveryPanel } from '@/components/email-delivery-panel'
@@ -65,25 +66,45 @@ export function WorkspaceMembersPage({
           </AlertDescription>
         </Alert>
       ) : null}
-      <MembersPanel
-        workspaceSlug={workspaceSlug}
-        members={members}
-        viewer={viewer}
-        actorUserId={actorUserId}
-      />
-      {/* `null` means this actor may not read the invitation segment; the
+      <SectionTabs
+        defaultValue="members"
+        sections={[
+          {
+            value: 'members',
+            label: m.nav_members(),
+            content: (
+              <div className="grid gap-6">
+                {' '}
+                <MembersPanel
+                  workspaceSlug={workspaceSlug}
+                  members={members}
+                  viewer={viewer}
+                  actorUserId={actorUserId}
+                />
+                {/* `null` means this actor may not read the invitation segment; the
           panel gates its own form against `invitation:create`. */}
-      {invitations === null ? null : (
-        <InvitationPanel
-          workspaceSlug={workspaceSlug}
-          viewer={viewer}
-          invitations={invitations}
-          emailDeliveries={data.emailDeliveries ?? []}
-        />
-      )}
-      {data.emailDeliveries === null ? null : (
-        <EmailDeliveryPanel records={data.emailDeliveries} />
-      )}
+                {invitations === null ? null : (
+                  <InvitationPanel
+                    workspaceSlug={workspaceSlug}
+                    viewer={viewer}
+                    invitations={invitations}
+                    emailDeliveries={data.emailDeliveries ?? []}
+                  />
+                )}
+              </div>
+            )
+          },
+          ...(data.emailDeliveries === null
+            ? []
+            : [
+                {
+                  value: 'delivery',
+                  label: m.email_delivery_title(),
+                  content: <EmailDeliveryPanel records={data.emailDeliveries} />
+                }
+              ])
+        ]}
+      />
     </WorkspaceShell>
   )
 }

--- a/apps/web/src/components/workspace-settings-page.tsx
+++ b/apps/web/src/components/workspace-settings-page.tsx
@@ -1,3 +1,4 @@
+import { SectionTabs } from '@/components/page/section-tabs'
 import { PageHeader } from '@/components/page/page-header'
 import { Panel } from '@/components/page/panel'
 import { WorkspaceCrumb } from '@/components/page/workspace-crumb'
@@ -65,59 +66,80 @@ export function WorkspaceSettingsPage({
         title={m.workspace_settings()}
         description={m.workspace_settings_description()}
       />
-      {/* Rename and delete are gated per action, not per page: an admin may
-          rename but never delete, a member sees neither. The server functions
-          enforce the same statements. */}
-      <Panel title={m.nav_general()}>
-        {canRename || canDelete ? (
-          <WorkspaceGeneralSettings
-            workspaceSlug={workspaceSlug}
-            currentName={workspaceName}
-            canRename={canRename}
-            canDelete={canDelete}
-            {...(ports === undefined
-              ? {}
-              : {
-                  ports: {
-                    rename: ports.renameWorkspace,
-                    remove: ports.deleteWorkspace
-                  }
-                })}
-          />
-        ) : (
-          <p className="text-xs text-muted-foreground">{m.workspace_manage_denied()}</p>
-        )}
-      </Panel>
-      {/* Single sign-on (ADR 0069): the segment is absent for an actor
-          without sso:list, and the panel degrades each control per statement
-          (sso:create/update/remove) against the payload's viewer. */}
-      {ssoConnections === null ? null : (
-        <Panel title={m.sso_title()}>
-          <div className="grid gap-3">
-            <p className="text-sm text-muted-foreground">{m.sso_description()}</p>
-            <SsoPanel
-              workspaceSlug={workspaceSlug}
-              connections={ssoConnections}
-              viewer={viewer}
-            />
-          </div>
-        </Panel>
-      )}
-      {/* Owner-only: the loader hands the segment to nobody else, so the whole
-          panel is absent for admins and members rather than disabled. When the
-          deployment has no export bucket, the panel explains that instead of
-          offering a button that would fail. */}
-      {exports === null ? null : (
-        <Panel title={m.data_export()}>
-          <WorkspaceExportPanel
-            workspaceSlug={workspaceSlug}
-            segment={exports}
-            {...(ports?.requestExport === undefined
-              ? {}
-              : { requestExport: ports.requestExport })}
-          />
-        </Panel>
-      )}
+      <SectionTabs
+        defaultValue="general"
+        sections={[
+          {
+            value: 'general',
+            label: m.nav_general(),
+            content: (
+              <Panel title={m.nav_general()}>
+                {canRename || canDelete ? (
+                  <WorkspaceGeneralSettings
+                    workspaceSlug={workspaceSlug}
+                    currentName={workspaceName}
+                    canRename={canRename}
+                    canDelete={canDelete}
+                    {...(ports === undefined
+                      ? {}
+                      : {
+                          ports: {
+                            rename: ports.renameWorkspace,
+                            remove: ports.deleteWorkspace
+                          }
+                        })}
+                  />
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    {m.workspace_manage_denied()}
+                  </p>
+                )}
+              </Panel>
+            )
+          },
+          ...(ssoConnections === null
+            ? []
+            : [
+                {
+                  value: 'sso',
+                  label: m.sso_title(),
+                  content: (
+                    <Panel title={m.sso_title()}>
+                      <div className="grid gap-3">
+                        <p className="text-sm text-muted-foreground">
+                          {m.sso_description()}
+                        </p>
+                        <SsoPanel
+                          workspaceSlug={workspaceSlug}
+                          connections={ssoConnections}
+                          viewer={viewer}
+                        />
+                      </div>
+                    </Panel>
+                  )
+                }
+              ]),
+          ...(exports === null
+            ? []
+            : [
+                {
+                  value: 'exports',
+                  label: m.data_export(),
+                  content: (
+                    <Panel title={m.data_export()}>
+                      <WorkspaceExportPanel
+                        workspaceSlug={workspaceSlug}
+                        segment={exports}
+                        {...(ports?.requestExport === undefined
+                          ? {}
+                          : { requestExport: ports.requestExport })}
+                      />
+                    </Panel>
+                  )
+                }
+              ])
+        ]}
+      />
     </WorkspaceShell>
   )
 }

--- a/apps/web/src/components/workspace-webhooks-page.tsx
+++ b/apps/web/src/components/workspace-webhooks-page.tsx
@@ -1,3 +1,6 @@
+import { lazy, Suspense } from 'react'
+import { SectionTabs } from '@/components/page/section-tabs'
+import { Panel } from '@/components/page/panel'
 import { PageHeader } from '@/components/page/page-header'
 import { WorkspaceCrumb } from '@/components/page/workspace-crumb'
 import { WebhooksPanel } from '@/components/webhooks-panel'
@@ -5,6 +8,14 @@ import { WorkspaceShell } from '@/components/workspace-shell'
 import { type WorkspaceWebhooksPayload } from '@/lib/server/webhooks'
 import { type ListDeliveryAttempts } from '@/components/webhook-delivery-timeline'
 import { m } from '@b2b-saas-starter/i18n/messages'
+
+// Keep recharts and d3 out of the page's initial bundle.
+async function loadWebhookSuccessChart() {
+  const chart = await import('@/components/charts/webhook-success-chart')
+  return { default: chart.WebhookSuccessChart }
+}
+
+const WebhookSuccessChart = lazy(loadWebhookSuccessChart)
 
 /**
  * The outbound-webhooks page. Lives beside the route file (not in it) so the
@@ -41,13 +52,35 @@ export function WorkspaceWebhooksPage({
         title={m.nav_webhook_endpoints()}
         description={m.webhooks_description()}
       />
-      <WebhooksPanel
-        workspaceSlug={workspaceSlug}
-        endpoints={endpoints}
-        viewer={viewer}
-        {...(ports?.listDeliveryAttempts === undefined
-          ? {}
-          : { listDeliveryAttempts: ports.listDeliveryAttempts })}
+      <SectionTabs
+        defaultValue="endpoints"
+        sections={[
+          {
+            value: 'endpoints',
+            label: m.endpoints_title(),
+            content: (
+              <WebhooksPanel
+                workspaceSlug={workspaceSlug}
+                endpoints={endpoints}
+                viewer={viewer}
+                {...(ports?.listDeliveryAttempts === undefined
+                  ? {}
+                  : { listDeliveryAttempts: ports.listDeliveryAttempts })}
+              />
+            )
+          },
+          {
+            value: 'delivery',
+            label: m.webhook_delivery(),
+            content: (
+              <Panel title={m.webhook_delivery()}>
+                <Suspense fallback={null}>
+                  <WebhookSuccessChart webhooks={endpoints} />
+                </Suspense>
+              </Panel>
+            )
+          }
+        ]}
       />
     </WorkspaceShell>
   )

--- a/apps/web/src/components/workspace-webhooks-page.tsx
+++ b/apps/web/src/components/workspace-webhooks-page.tsx
@@ -71,6 +71,7 @@ export function WorkspaceWebhooksPage({
           },
           {
             value: 'delivery',
+            keepMounted: false,
             label: m.webhook_delivery(),
             content: (
               <Panel title={m.webhook_delivery()}>

--- a/apps/web/src/routes/sign-in.test.tsx
+++ b/apps/web/src/routes/sign-in.test.tsx
@@ -426,7 +426,7 @@ describe('SignInPage', () => {
 
   it('offers the email-code path without touching the credential form', async () => {
     await renderPage('/workspaces')
-    const entry = screen.getByRole('link', { name: m.email_code_instead() })
+    const entry = screen.getByRole('link', { name: m.auth_email_code() })
     expect(entry.getAttribute('href')).toBe(
       '/sign-in/email-code?redirect=%2Fworkspaces'
     )
@@ -446,7 +446,7 @@ describe('SignInPage link mode', () => {
   })
 
   async function switchToLinkMode() {
-    fireEvent.click(screen.getByRole('button', { name: m.email_me_sign_in_link() }))
+    fireEvent.click(screen.getByRole('button', { name: m.auth_email_link() }))
     await screen.findByText('Sign in with password instead')
   }
 

--- a/apps/web/src/routes/workspaces.$workspaceSlug.index.test.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.index.test.tsx
@@ -74,15 +74,13 @@ async function renderDashboard(data: WorkspaceDashboardPayload) {
 }
 
 describe('WorkspaceDashboardPage', () => {
-  it('renders the attention feed, notifications, and webhook delivery for an owner', async () => {
+  it('renders attention and notifications without duplicating delivery reports', async () => {
     const rendered = await renderDashboard(await loadDashboard())
     await rendered.findByText('Needs attention')
-    // The seed's standing attention items: one token minted but never used,
-    // and the newest audit events as informational entries.
+    // Attention stays actionable; the audit page owns recent history.
     screen.getByText(/never used/)
-    screen.getByText('API token created')
-    // The chart trails the feed.
-    screen.getByText('Webhook delivery')
+    expect(screen.queryByText('API token created')).toBeNull()
+    expect(screen.queryByText('Webhook delivery')).toBeNull()
   })
 
   it('offers mark-as-read and reports the change through the port', async () => {
@@ -113,7 +111,6 @@ describe('WorkspaceDashboardPage', () => {
 
   it('shows the owner the Seed Workspace checklist with a dismiss control', async () => {
     await renderDashboard(await loadDashboard())
-    screen.getByText('Set up your workspace')
     screen.getByText('3 of 4')
     screen.getByRole('button', { name: 'Dismiss' })
   })
@@ -121,7 +118,6 @@ describe('WorkspaceDashboardPage', () => {
   it('shows a member the checklist read-only, without the developer-platform steps', async () => {
     actor.userId = 'usr_dev'
     await renderDashboard(await loadDashboard())
-    screen.getByText('Set up your workspace')
     expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
     expect(screen.queryByText('Create an API token')).toBeNull()
   })

--- a/apps/web/src/routes/workspaces.$workspaceSlug.settings.test.tsx
+++ b/apps/web/src/routes/workspaces.$workspaceSlug.settings.test.tsx
@@ -161,7 +161,7 @@ describe('WorkspaceSettingsPage lifecycle ports', () => {
 describe('WorkspaceSettingsPage data export', () => {
   it('offers explicit export and download actions to an owner', async () => {
     await renderPage()
-    screen.getByRole('heading', { name: 'Data export' })
+    fireEvent.click(screen.getByRole('tab', { name: 'Data export' }))
     screen.getByRole('button', { name: 'Request export' })
     expect(
       screen.getByRole('button', { name: 'Download archive' }).getAttribute('href')
@@ -187,6 +187,7 @@ describe('WorkspaceSettingsPage data export', () => {
       }
     })
     expect(screen.queryByRole('button', { name: 'Request export' })).toBeNull()
+    fireEvent.click(screen.getByRole('tab', { name: 'Data export' }))
     screen.getByText('Set WORKSPACE_EXPORT_BUCKET to enable.')
     screen.getByText('No exports yet')
   })
@@ -210,6 +211,7 @@ describe('WorkspaceSettingsPage data export', () => {
       { path: '/workspaces/starter-lab/settings', destinations: ['/sign-in'] }
     )
     await screen.findByRole('heading', { name: 'Workspace settings' })
+    fireEvent.click(screen.getByRole('tab', { name: 'Data export' }))
     fireEvent.click(screen.getByRole('button', { name: 'Request export' }))
     await waitFor(() =>
       expect(requestExport).toHaveBeenCalledWith({

--- a/packages/i18n/messages/web/en.json
+++ b/packages/i18n/messages/web/en.json
@@ -932,5 +932,9 @@
   "security_authenticator_code": "Authenticator code",
   "security_recovery_email_subject": "Account recovery started",
   "security_recovery_email_body": "A saved backup code was used to start a recovery session for your account. This session can repair sign-in methods for up to one hour. Privileged access requires a newly verified authenticator or passkey.",
-  "security_recovery_email_warning": "If this was not you, revoke your sessions and contact your operator immediately."
+  "security_recovery_email_warning": "If this was not you, revoke your sessions and contact your operator immediately.",
+  "auth_demo_credentials": "Demo credentials",
+  "auth_email_link": "Email link",
+  "auth_email_code": "Email code",
+  "auth_view_demo_credentials": "View demo credentials"
 }

--- a/packages/i18n/messages/web/nb.json
+++ b/packages/i18n/messages/web/nb.json
@@ -932,5 +932,9 @@
   "security_authenticator_code": "Kode fra autentiseringsappen",
   "security_recovery_email_subject": "Kontogjenoppretting startet",
   "security_recovery_email_body": "En lagret reservekode ble brukt til å starte en gjenopprettingsøkt for kontoen din. Økten kan reparere innloggingsmetoder i opptil én time. Privilegert tilgang krever en ny bekreftelse med autentiseringsapp eller passnøkkel.",
-  "security_recovery_email_warning": "Hvis dette ikke var deg, tilbakekall øktene dine og kontakt operatøren umiddelbart."
+  "security_recovery_email_warning": "Hvis dette ikke var deg, tilbakekall øktene dine og kontakt operatøren umiddelbart.",
+  "auth_demo_credentials": "Innlogging for demo",
+  "auth_email_link": "E-postlenke",
+  "auth_email_code": "E-postkode",
+  "auth_view_demo_credentials": "Vis innlogging for demo"
 }


### PR DESCRIPTION
## Outcome

Simplifies the workspace and sign-in screens. Workspace settings, member email history, and webhook delivery reporting are separated into tabs. Create and invite forms open from explicit actions in side sheets. The overview prioritizes attention items and notifications, with the setup checklist below them and audit history on its own page.

Sign-in keeps passkeys visible, shortens the email alternatives, and moves demo credentials into a sheet. This implements the conversation request to reduce workspace and login clutter without accordions.

## Decisions

- Uses the existing Sheet built on Base UI Dialog, rather than introducing Base UI Drawer.
- Form tabs retain entered values when switching views; the delivery chart mounts only when its tab opens.
- English and Norwegian labels are updated together.

## Validation

- Independent Standards and Spec reviews completed. The accepted chart-mounting finding was fixed and re-reviewed.
- `pnpm run validate` passed on `cf6dfd7f`: type checking, lint, formatting, dead-code checks, unit and operational tests, production build, generated Wrangler configuration, local migrations/seed, and all 41 browser tests.
- GitHub CI passed, including quality, package/web/capability tests, build, both browser shards, and audit. Preview deployment was skipped by repository configuration.
- The rebased web unit suite passed all 723 tests. Browser coverage includes the updated create/invite sheets, demo refusal behavior, and magic-link sign-in.
- Desktop and mobile screens were inspected locally, including workspace tabs, token creation sheets, and the sign-in/demo-credentials flow.

To reproduce: open the workspace preview, switch through Settings, Members, and Webhooks tabs, then open Create token, Create endpoint, and Invite a member. At a mobile viewport, confirm the sheets fit and scroll. On `/sign-in`, open Email link, Email code, and View demo credentials.

## Risks and remaining work

Local validation and CI passed. No known merge blockers. No schema migration or reseeding is needed for these UI changes.
