### PR TITLE
fix(web): reuse public layout in nested error pages

### DIFF
--- a/apps/web/src/components/fallback-page.test.tsx
+++ b/apps/web/src/components/fallback-page.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+import { renderWithRouter } from '@/test/router-harness'
+import { PublicLayout } from './public-layout'
+import { FallbackPage } from './fallback-page'
+
+describe('public fallback landmarks', () => {
+  it('provides the public shell for a standalone failure', async () => {
+    await renderWithRouter(
+      <FallbackPage>
+        <h1>Something went wrong</h1>
+      </FallbackPage>
+    )
+
+    expect(screen.getAllByRole('banner')).toHaveLength(1)
+    expect(screen.getAllByRole('main')).toHaveLength(1)
+    expect(screen.getAllByRole('contentinfo')).toHaveLength(1)
+    expect(document.querySelectorAll('#main-content')).toHaveLength(1)
+  })
+
+  it('keeps one shell when an article fails inside the public layout', async () => {
+    await renderWithRouter(
+      <PublicLayout>
+        <main id="main-content">
+          <FallbackPage>
+            <h1>Something went wrong</h1>
+          </FallbackPage>
+        </main>
+      </PublicLayout>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeTruthy()
+    expect(screen.getAllByRole('banner')).toHaveLength(1)
+    expect(screen.getAllByRole('main')).toHaveLength(1)
+    expect(screen.getAllByRole('contentinfo')).toHaveLength(1)
+    expect(document.querySelectorAll('#main-content')).toHaveLength(1)
+  })
+})

--- a/apps/web/src/components/fallback-page.tsx
+++ b/apps/web/src/components/fallback-page.tsx
@@ -1,20 +1,20 @@
-import { type ReactNode } from 'react'
+import { type ReactNode, useContext } from 'react'
 import { PublicLayout } from '@/components/public-layout'
+import { PublicLayoutContext } from './public-layout-context'
 
 /**
- * The shell the router's own fallback screens render into — "not found", the
- * application error, and any other state reached without a matched page.
- *
- * They are ordinary pages of the site, so they keep its landmarks (banner,
- * `<main>`, contentinfo) and the skip link `PublicLayout` owns, instead of
- * dropping the reader onto a bare centered heading. `PublicLayout` reads no
- * loader data, which is what lets a failed match still use it.
+ * Router fallbacks provide a public shell when no parent page survives.
+ * Nested failures reuse the parent's header, footer, main and skip link.
  *
  * `tabIndex={-1}` makes the `<main>` a programmatic focus target so the skip
  * link moves focus and not just the scroll position; the outline is suppressed
  * because the element is a destination, never an operable control.
  */
 export function FallbackPage({ children }: { readonly children: ReactNode }) {
+  const withinPublicLayout = useContext(PublicLayoutContext)
+  if (withinPublicLayout) {
+    return <div className="flex flex-col items-start gap-4 py-16">{children}</div>
+  }
   return (
     <PublicLayout>
       <main

--- a/apps/web/src/components/public-layout-context.ts
+++ b/apps/web/src/components/public-layout-context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react'
+
+/** Nested route fallbacks reuse the surrounding public page's landmarks. */
+export const PublicLayoutContext = createContext(false)

--- a/apps/web/src/components/public-layout.tsx
+++ b/apps/web/src/components/public-layout.tsx
@@ -20,6 +20,7 @@ import {
 import { publicLinks } from '@/lib/content'
 import { m } from '@b2b-saas-starter/i18n/messages'
 import { LanguageSwitcher } from '@/components/language-switcher'
+import { PublicLayoutContext } from './public-layout-context'
 
 /**
  * Whether this document was rendered for a signed-in visitor, from the root
@@ -152,7 +153,7 @@ export function PublicLayout({ children }: { readonly children: ReactNode }) {
           </Button>
         </div>
       </header>
-      {children}
+      <PublicLayoutContext value>{children}</PublicLayoutContext>
       <footer className="mt-auto border-t border-border">
         <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-8 text-sm text-muted-foreground sm:px-6 md:flex-row md:items-center md:justify-between">
           <span>{m.site_footer_tagline()}</span>


### PR DESCRIPTION
## Outcome

Nested error and not-found pages rendered a second public header, footer and main landmark inside the surviving page layout. Fallbacks now reuse that layout; standalone fallbacks retain their existing public shell.

Adds regression coverage for both cases, including a single `main-content` skip-link target. Scope is limited to the error page; database setup and navigation behavior are unchanged.

## Validation

Revision: `aab3faaa`.

- Focused fallback tests: 2 passed.
- Independent standards and behavior reviews: no findings.
- Typechecking, lint, formatting, dead-code and translation checks passed.
- Browser smoke check at desktop and mobile widths: a missing docs article shows one public header, one footer and one main landmark. Reproduce by opening `/en/docs/getting-started/missing`.
- `pnpm run validate` stopped on four authentication test timeouts. Rerunning the authentication suite with two workers passed all 97 tests.
- Final `pnpm run check` is running; build and full E2E validation have not completed in that run.

## Risks and remaining work

Await final local checks and CI. No known behavior issues in the error-page change.
