### PR TITLE
refactor(web): replace clsx and tailwind-merge with cn

### DIFF
--- a/apps/background/src/webhook-signing.test.ts
+++ b/apps/background/src/webhook-signing.test.ts
@@ -1,6 +1,6 @@
 import { activeSigningSecrets } from '@b2b-saas-starter/capabilities/developer-platform/webhook-delivery-plan'
 import { randomWebhookSecret } from '@b2b-saas-starter/capabilities/crypto'
-import { describe, expect, it } from '@effect/vitest'
+import { describe, expect, it, vi } from '@effect/vitest'
 import { DateTime, Effect } from 'effect'
 import { Webhook } from 'standardwebhooks'
 import { computeWebhookSignature, signatureHeaderValue } from './webhook-signing.ts'
@@ -26,12 +26,18 @@ const signedHeaders = Effect.fn('Test.signedHeaders')(function* (
 })
 
 describe('Standard Webhooks reference verifier interoperability', () => {
-  // The independent verifier checks wall-clock freshness internally.
-  it.live(
+  it.effect(
     'verifies exact UTF-8 bytes and rejects changed body, identity, and stale time',
     () =>
       Effect.gen(function* () {
         const now = yield* DateTime.now
+        // Match TestClock because the independent verifier reads Date.now().
+        yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            vi.spyOn(Date, 'now').mockReturnValue(DateTime.toEpochMillis(now))
+          ),
+          (clock) => Effect.sync(() => clock.mockRestore())
+        )
         const timestamp = Math.floor(DateTime.toEpochMillis(now) / 1000)
         const headers = yield* signedHeaders([currentSecret], timestamp)
         const verifier = new Webhook(currentSecret)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,8 +44,8 @@
     "@tanstack/react-table": "catalog:",
     "better-auth": "catalog:",
     "class-variance-authority": "catalog:",
-    "clsx": "catalog:",
     "cmdk": "catalog:",
+    "cn": "catalog:",
     "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "effectful-better-auth": "catalog:",
@@ -55,7 +55,6 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "sonner": "catalog:",
-    "tailwind-merge": "catalog:",
     "tw-animate-css": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,9 +1,4 @@
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
-
-export function cn(...inputs: Array<ClassValue>) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from 'cn'
 
 /**
  * Only allow same-origin path redirects (prevents open redirects via the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,12 +144,12 @@ catalogs:
     class-variance-authority:
       specifier: 0.7.1
       version: 0.7.1
-    clsx:
-      specifier: 2.1.1
-      version: 2.1.1
     cmdk:
       specifier: 1.1.1
       version: 1.1.1
+    cn:
+      specifier: 0.2.5
+      version: 0.2.5
     drizzle-kit:
       specifier: 1.0.0-rc.5-ab785fc
       version: 1.0.0-rc.5-ab785fc
@@ -228,9 +228,6 @@ catalogs:
     standardwebhooks:
       specifier: 1.1.1
       version: 1.1.1
-    tailwind-merge:
-      specifier: 3.6.0
-      version: 3.6.0
     tailwindcss:
       specifier: 4.3.3
       version: 4.3.3
@@ -580,12 +577,12 @@ importers:
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1
-      clsx:
-        specifier: 'catalog:'
-        version: 2.1.1
       cmdk:
         specifier: 'catalog:'
         version: 1.1.1(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      cn:
+        specifier: 'catalog:'
+        version: 0.2.5
       drizzle-orm:
         specifier: 'catalog:'
         version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260906.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(bun-types@1.4.0)(effect@4.0.0-rc.112)(valibot@1.4.2(typescript@7.0.2))(zod@4.5.4)
@@ -613,9 +610,6 @@ importers:
       sonner:
         specifier: 'catalog:'
         version: 2.0.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      tailwind-merge:
-        specifier: 'catalog:'
-        version: 3.6.0
       tw-animate-css:
         specifier: 'catalog:'
         version: 1.4.0
@@ -8536,9 +8530,6 @@ packages:
       '@eslint/css':
         optional: true
 
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
-
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
@@ -16292,8 +16283,6 @@ snapshots:
   tagged-tag@1.0.0: {}
 
   tailwind-csstree@0.3.3: {}
-
-  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,8 +59,8 @@ catalog:
   babel-plugin-react-compiler: 1.0.0
   better-auth: 1.7.2
   class-variance-authority: 0.7.1
-  clsx: 2.1.1
   cmdk: 1.1.1
+  cn: 0.2.5
   drizzle-kit: 1.0.0-rc.5-ab785fc
   drizzle-orm: 1.0.0-rc.5-ab785fc
   standardwebhooks: 1.1.1
@@ -87,7 +87,6 @@ catalog:
   remark-mdx-frontmatter: 5.2.0
   shadcn: 4.21.0
   sonner: 2.0.8
-  tailwind-merge: 3.6.0
   tailwindcss: 4.3.3
   tw-animate-css: 1.4.0
   typescript: 7.0.2


### PR DESCRIPTION
## Outcome

Replace the shared `clsx` + `tailwind-merge` wrapper with `cn@0.2.5` from [shadcn-ui/cn](https://github.com/shadcn-ui/cn). Existing component imports keep using `@/lib/utils`, which now re-exports `cn`.

Remove both direct dependencies from the web app and workspace catalog, add `cn`, and regenerate the lockfile. `tailwind-merge` leaves the dependency graph; `clsx` remains transitively required by other packages.

Fix the webhook interoperability test exposed by CI. Its future timestamp was only one second beyond the verifier's tolerance, so elapsed signing time could make it valid. The freshness test now uses Effect's test clock and scopes the reference verifier's `Date.now()` mock to the same instant, with automatic restoration. Production signing behavior is unchanged.

## Validation

Validated revision `fb3a2396`.

- `pnpm run check` passed locally, including workspace typechecking, type-aware lint, formatting, dead-code checks, localization checks, workspace tests, and repository script tests.
- All three webhook-signing interoperability tests passed separately.
- [CI passed](https://github.com/brandhaug/b2b-saas-starter/actions/runs/34517245263), including package, capabilities and web tests, quality, build, and both E2E shards. Audit and title checks also passed.
- The earlier local `pnpm run validate` attempt stopped at an integration-test timeout; that test passed alone and the later complete `check` passed. Build and browser validation are covered by CI on this revision.

## Risks and remaining work

None known.
