### PR TITLE
test(auth): use Effect clocks for token fixtures

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -24,6 +24,7 @@
     "effectful-better-auth": "catalog:"
   },
   "devDependencies": {
+    "@better-auth/utils": "catalog:",
     "@effect/vitest": "catalog:",
     "jose": "catalog:",
     "typescript": "catalog:",

--- a/packages/auth/src/live-assurance.test.ts
+++ b/packages/auth/src/live-assurance.test.ts
@@ -6,7 +6,7 @@ import { eq } from 'drizzle-orm'
 import { cookieHeader, cookiePairs, mergeCookiePairs } from 'effectful-better-auth'
 import { vi } from 'vite-plus/test'
 import { Auth } from './index.ts'
-import { decodeUriSecret, withNextTotpWindow } from './test-totp.ts'
+import { decodeUriSecret, nextTotpCode } from './test-totp.ts'
 import {
   buildAuthLayer,
   enableTotp,
@@ -170,14 +170,7 @@ describe('session evidence lifecycle', () => {
           expect((yield* readSession(headers)).recoveryUntil).toEqual(
             original.recoveryUntil
           )
-          const { code } = yield* Effect.promise(() =>
-            withNextTotpWindow(() =>
-              // oxlint-disable-next-line starter/no-run-promise-in-tests -- bridge the Auth service effect into the native clock shim
-              Effect.runPromise(
-                auth.api.generateTOTP({ body: { secret: decodeUriSecret(secret) } })
-              )
-            )
-          )
+          const { code } = yield* nextTotpCode(decodeUriSecret(secret))
           yield* auth.api.verifyTOTP({ body: { code }, headers })
           const completed = yield* readSession(headers)
           expect(completed.recoveryUntil).toBeNull()
@@ -315,14 +308,7 @@ describe('session evidence lifecycle', () => {
           if (!secret) {
             return yield* Effect.die('Expected secret')
           }
-          const { code } = yield* Effect.promise(() =>
-            withNextTotpWindow(() =>
-              // oxlint-disable-next-line starter/no-run-promise-in-tests -- bridge the Auth service effect into the native clock shim
-              Effect.runPromise(
-                auth.api.generateTOTP({ body: { secret: decodeUriSecret(secret) } })
-              )
-            )
-          )
+          const { code } = yield* nextTotpCode(decodeUriSecret(secret))
           const verified = yield* auth.full.verifyTOTP({
             body: { code },
             headers: headersOf(challenge.headers)

--- a/packages/auth/src/live-totp-replay.test.ts
+++ b/packages/auth/src/live-totp-replay.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, expect, it } from '@effect/vitest'
 import { Effect, Result, type Layer } from 'effect'
 import { cookieHeader, cookiePairs, mergeCookiePairs } from 'effectful-better-auth'
 import { Auth } from './index.ts'
-import { decodeUriSecret, withNextTotpWindow } from './test-totp.ts'
+import { decodeUriSecret, nextTotpCode } from './test-totp.ts'
 import {
   buildAuthLayer,
   provisionAuthD1,
@@ -73,14 +73,7 @@ it.live(
         auth.api.verifyTOTP({ body: { code }, headers: challengeHeaders })
       )
       expect(Result.isFailure(anotherSession)).toBe(true)
-      const next = yield* Effect.promise(() =>
-        withNextTotpWindow(() =>
-          // oxlint-disable-next-line starter/no-run-promise-in-tests -- generate an authenticator code with the native library clock
-          Effect.runPromise(
-            auth.api.generateTOTP({ body: { secret: decodeUriSecret(secret) } })
-          )
-        )
-      )
+      const next = yield* nextTotpCode(decodeUriSecret(secret))
       const attempts = yield* Effect.all(
         [0, 1].map(() => Effect.result(auth.api.verifyTOTP({ body: next, headers }))),
         { concurrency: 'unbounded' }

--- a/packages/auth/src/live-two-factor.test.ts
+++ b/packages/auth/src/live-two-factor.test.ts
@@ -18,7 +18,7 @@ import {
   type AuthService,
   type ProvisionedAuthD1
 } from './test-auth-layer.ts'
-import { decodeUriSecret, withNextTotpWindow } from './test-totp.ts'
+import { decodeUriSecret, nextTotpCode } from './test-totp.ts'
 
 // The two-factor challenge hop is only observable end to end: whether a
 // credential sign-in leaves a working session or a pending challenge is
@@ -137,18 +137,6 @@ function totpUser(email: string) {
   })
 }
 
-/** A code the server itself generated for a stored secret. */
-function freshCode(secret: string) {
-  return Effect.flatMap(Auth.Tag, (auth) =>
-    Effect.promise(() =>
-      withNextTotpWindow(() =>
-        // oxlint-disable-next-line starter/no-run-promise-in-tests -- bridge the Auth service effect into the native clock shim
-        Effect.runPromise(auth.api.generateTOTP({ body: { secret } }))
-      )
-    )
-  )
-}
-
 /** The code the send endpoint generated for one email, most recent first. */
 function codeFor(email: string): string {
   const sent = sentCodes.toReversed().find((entry) => entry.email === email)
@@ -239,7 +227,7 @@ describe('the two-factor challenge hop', () => {
           const secondCookie = yield* weakEmailSession(email)
           const firstHeaders = new Headers({ cookie: firstCookie })
           const secondHeaders = new Headers({ cookie: secondCookie })
-          const { code } = yield* freshCode(secret)
+          const { code } = yield* nextTotpCode(secret)
           yield* auth.api.verifyTOTP({ body: { code }, headers: secondHeaders })
           expect((yield* storedSession(secondCookie)).strongAuthAt).toBeNull()
           yield* auth.api.verifyPassword({
@@ -281,7 +269,7 @@ describe('the two-factor challenge hop', () => {
           const { secret } = yield* totpUser(email)
           const auth = yield* Auth.Tag
           const challenge = yield* signInWithEmail(email)
-          const { code } = yield* freshCode(secret)
+          const { code } = yield* nextTotpCode(secret)
           const verified = yield* auth.full.verifyTOTP({
             body: { code, trustDevice: true },
             headers: new Headers({
@@ -343,7 +331,7 @@ describe('the two-factor challenge hop', () => {
             body: { password: PASSWORD },
             headers: new Headers({ cookie: recoveryCookie })
           })
-          const { code: oldFactorCode } = yield* freshCode(secret)
+          const { code: oldFactorCode } = yield* nextTotpCode(secret)
           yield* auth.api.verifyTOTP({
             body: { code: oldFactorCode },
             headers: new Headers({ cookie: recoveryCookie })
@@ -368,7 +356,7 @@ describe('the two-factor challenge hop', () => {
           if (enabled.response.method !== 'totp') {
             return yield* Effect.die('Expected TOTP')
           }
-          const { code: replacementCode } = yield* freshCode(
+          const { code: replacementCode } = yield* nextTotpCode(
             secretOf(enabled.response.totpURI)
           )
           const verified = yield* auth.full.verifyTOTP({
@@ -427,7 +415,7 @@ describe('the two-factor challenge hop', () => {
           // The challenge cookie the diverted sign-in set is the only thing
           // the verify step needs — no session exists yet at all.
           const signIn = yield* signInWithEmail(email)
-          const { code } = yield* freshCode(secret)
+          const { code } = yield* nextTotpCode(secret)
           const auth = yield* Auth.Tag
           const verified = yield* auth.full.verifyTOTP({
             body: { code },

--- a/packages/auth/src/sso.test.ts
+++ b/packages/auth/src/sso.test.ts
@@ -1,9 +1,11 @@
 import { type DrizzleDatabase } from './ports.ts'
 import { account, user, workspaceMembers } from '@b2b-saas-starter/db/schema'
-import { Effect, type Layer } from 'effect'
+import { Clock, Effect, type Layer } from 'effect'
+import { TestClock } from 'effect/testing'
 import { cookieHeader, cookiePairs } from 'effectful-better-auth'
 import { eq } from 'drizzle-orm'
 import { createSign, generateKeyPairSync } from 'node:crypto'
+import { decodeJwt, jwtVerify } from 'jose'
 import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest'
 import { Auth } from './index.ts'
 import {
@@ -47,16 +49,12 @@ function base64Url(value: Buffer | string): string {
   return Buffer.from(value).toString('base64url')
 }
 
-/**
- * Signs an RS256 ID token the plugin's `jose` verifier will accept. `exp` is
- * fixed relative to the real clock — the verifier reads the wall clock, so
- * `Clock` cannot control it.
- */
-// oxlint-disable-next-line effect/noGlobals -- jose verifies against the wall clock; the token's lifetime is a fixed offset from it, not a Clock read
-const issuedAt = Math.floor(Date.now() / 1000)
-
 // oxlint-disable effect/noGlobals -- this suite IS the JSON/serialization boundary: a fake IdP, not an app write path
-function signIdToken(claims: Record<string, unknown>): string {
+/** Read issuance time for each token, including exchanges after a delayed setup. */
+const signIdToken = Effect.fn('Test.signIdToken')(function* (
+  claims: Record<string, unknown>
+) {
+  const issuedAt = Math.floor((yield* Clock.currentTimeMillis) / 1000)
   const header = { alg: 'RS256', typ: 'JWT', kid: publicJwk.kid }
   const payload = { iat: issuedAt, exp: issuedAt + 600, ...claims }
   const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(
@@ -64,7 +62,7 @@ function signIdToken(claims: Record<string, unknown>): string {
   )}`
   const signature = createSign('RSA-SHA256').update(signingInput).sign(privateKey)
   return `${signingInput}.${base64Url(signature)}`
-}
+})
 
 let idTokenSubject = 'idp-user-1'
 let idTokenEmail = 'provisioned@roundtrip.test'
@@ -84,8 +82,7 @@ function requestUrl(input: RequestInfo | URL): string {
   return new Request(input).url
 }
 
-// The one async boundary this suite owns: the fetch seam itself, replaced on
-// globalThis. Effect wrappers would only re-wrap the same promise.
+// The native fetch stub runs the Effect signer with the live clock used by jose.
 // oxlint-disable-next-line effect/noAsyncFunction -- the global fetch seam is async by contract
 async function stubbedFetch(
   input: RequestInfo | URL,
@@ -97,14 +94,17 @@ async function stubbedFetch(
       access_token: 'rt-access-token',
       token_type: 'Bearer',
       scope: 'openid email profile',
-      id_token: signIdToken({
-        iss: ISSUER,
-        aud: 'rt-client',
-        sub: idTokenSubject,
-        email: idTokenEmail,
-        email_verified: true,
-        name: idTokenName
-      })
+      // oxlint-disable-next-line effect/noAsyncFunction, starter/no-run-promise-in-tests -- the native fetch callback is the boundary into the Effect token signer
+      id_token: await Effect.runPromise(
+        signIdToken({
+          iss: ISSUER,
+          aud: 'rt-client',
+          sub: idTokenSubject,
+          email: idTokenEmail,
+          email_verified: true,
+          name: idTokenName
+        })
+      )
     })
   }
   if (url === `${ISSUER}/jwks`) {
@@ -149,6 +149,24 @@ function run<A, E>(effect: Effect.Effect<A, E, AuthService>) {
 }
 
 describe('workspace SSO over the sso plugin', () => {
+  it.effect('issues a fresh token after an earlier token has expired', () =>
+    Effect.gen(function* () {
+      const earlier = yield* signIdToken({ sub: 'clock-test' })
+      expect(decodeJwt(earlier).exp).toBe(600)
+
+      yield* TestClock.adjust('11 minutes')
+      const current = yield* signIdToken({ sub: 'clock-test' })
+      const verified = yield* Effect.promise(() =>
+        jwtVerify(current, publicKey, { currentDate: new Date(660_000) })
+      )
+      expect(verified.payload).toMatchObject({
+        sub: 'clock-test',
+        iat: 660,
+        exp: 1260
+      })
+    })
+  )
+
   it.live(
     'round-trips a mocked OIDC connection and provisions the member with the connection’s role',
     () =>

--- a/packages/auth/src/test-totp.test.ts
+++ b/packages/auth/src/test-totp.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@effect/vitest'
+import { Effect } from 'effect'
+import { TestClock } from 'effect/testing'
+import { nextTotpCode } from './test-totp.ts'
+
+// RFC 4226 Appendix D: https://www.rfc-editor.org/rfc/rfc4226.html#appendix-D
+describe('nextTotpCode', () => {
+  it.effect('uses the RFC 4226 code on each side of the 30-second boundary', () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(29_999)
+      expect(yield* nextTotpCode('12345678901234567890')).toEqual({ code: '287082' })
+
+      yield* TestClock.setTime(30_000)
+      expect(yield* nextTotpCode('12345678901234567890')).toEqual({ code: '359152' })
+    })
+  )
+})

--- a/packages/auth/src/test-totp.ts
+++ b/packages/auth/src/test-totp.ts
@@ -1,4 +1,6 @@
-// oxlint-disable effect/noAsyncFunction, effect/noGlobals, effect/noTryCatch -- test-only clock shim advances the native authenticator without sleeping
+import { createOTP } from '@better-auth/utils/otp'
+import { Clock, Effect } from 'effect'
+
 /**
  * Base32 decode for the `secret` query parameter of a TOTP URI — shared by the
  * live suites that verify a generated code end to end.
@@ -24,14 +26,13 @@ export function decodeUriSecret(encoded: string): string {
   return new TextDecoder().decode(Uint8Array.from(bytes))
 }
 
-/** Run a test authenticator in the next TOTP time window without sleeping. */
-export async function withNextTotpWindow<A>(operation: () => Promise<A>): Promise<A> {
-  const originalNow = Date.now
-  const shiftedNow = originalNow() + 30_000
-  Date.now = () => shiftedNow
-  try {
-    return await operation()
-  } finally {
-    Date.now = originalNow
-  }
+/** Generate the code for the next TOTP window using the active Effect clock. */
+export function nextTotpCode(secret: string) {
+  return Effect.gen(function* () {
+    const milliseconds = yield* Clock.currentTimeMillis
+    const code = yield* Effect.promise(() =>
+      createOTP(secret).hotp(Math.floor(milliseconds / 30_000) + 1)
+    )
+    return { code }
+  })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@better-auth/sso':
       specifier: 1.7.2
       version: 1.7.2
+    '@better-auth/utils':
+      specifier: 0.4.2
+      version: 0.4.2
     '@cloudflare/vitest-pool-workers':
       specifier: 0.22.0
       version: 0.22.0
@@ -809,6 +812,9 @@ importers:
         specifier: 'catalog:'
         version: 1.0.0(better-auth@1.7.2(@cloudflare/workers-types@5.20260906.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.49(@voidzero-dev/vite-plus-core@0.3.0(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.63.1)(supports-color@10.2.2))(drizzle-kit@1.0.0-rc.5-ab785fc)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260906.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(bun-types@1.4.0)(effect@4.0.0-rc.112)(valibot@1.4.2(typescript@7.0.2))(zod@4.5.4))(next@16.3.3(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.63.0)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11))(effect@4.0.0-rc.112)
     devDependencies:
+      '@better-auth/utils':
+        specifier: 'catalog:'
+        version: 0.4.2
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.11)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ catalog:
   '@better-auth/oauth-provider': 1.7.2
   '@better-auth/passkey': 1.7.2
   '@better-auth/sso': 1.7.2
+  '@better-auth/utils': 0.4.2
   '@cloudflare/workers-types': 5.20260906.1
   '@cloudflare/vitest-pool-workers': 0.22.0
   '@effect/platform-node': 4.0.0-rc.112


### PR DESCRIPTION
## Outcome

Make auth test token generation use Effect clocks without changing the process clock.

- SSO ID tokens now read the clock at issuance instead of module load, so a delayed setup cannot make a newly signed token expire before use. A regression advances `TestClock` eleven minutes and verifies a fresh token with `jose`.
- TOTP fixtures generate the next 30-second code through the existing OTP library's explicit HOTP counter API. This removes the asynchronous `Date.now` override and the Promise/runtime bridges in two-factor, recovery, and replay tests. A deterministic boundary test uses the independent [RFC 4226 Appendix D vectors](https://www.rfc-editor.org/rfc/rfc4226.html#appendix-D).

`@better-auth/utils@0.4.2` is now an explicit test-only dependency, matching Better Auth's existing transitive version. Production auth code is unchanged.

## Validation

Tested revision `500e8d14`.

- Full `check` passed, including all 99 auth tests, workspace tests, lint, typechecking, formatting, dead-code checks, localization checks, and repository script tests.
- `pnpm run validate` passed build, client bundle boundary checks, generated Wrangler drift detection, and local database migration/seed. Its initial browser stage could not launch because the pinned Chromium binary was missing.
- After installing Chromium, `CI=1 E2E_PORT=3097 pnpm run test:e2e` completed successfully: 40 tests passed directly; the unchanged session-revocation test passed on retry after a navigation timeout.
- Independent Standards review: no findings. Independent Spec review: no findings.
- [CI passed on the same revision](https://github.com/brandhaug/b2b-saas-starter/actions/runs/34519287504): all test jobs, quality, build, and both E2E shards. Audit and all required checks passed; the PR is up to date with master and mergeable.

## Risks and remaining work

The local session-revocation E2E timeout is outside this test-helper diff and is recorded above. All CI checks passed. No remaining merge blockers.
