### PR TITLE
docs(agents): trim scoped guidance and defer workflow details

### DIFF
--- a/apps/background/AGENTS.md
+++ b/apps/background/AGENTS.md
@@ -18,41 +18,13 @@ Cloudflare Worker for queued, scheduled and inbound-provider work: webhook fan-o
   the event) with no monitor check-in, instead of reporting under another
   trigger's slug.
 
-## Usage Patterns
-
-Per queue the outcome table is the contract; the non-obvious parts:
-
-- Webhooks retry a retryable failure (5xx, 408, 429, network, timeout) at `backoffSeconds(attempts)`; a 4xx or SSRF rejection is `failed_permanent`; undispatchable or malformed acks.
-- [Webhook Attempt completion](../../packages/capabilities/src/developer-platform/webhook-attempt-completion.ts) owns planning, recording and accepted-only warnings. The worker owns signing and HTTP dispatch; it follows completion's queue disposition, including for duplicate or late observations.
-- The DLQ consumer acks after writing the terminal `dead_lettered` row, but retries if that write fails, so a D1 blip cannot lose the evidence.
-- Exports use the capability-owned generation workflow after resolving
-  `WorkspaceContext` from the slug with no actor, ownership having been checked
-  at request time; a slug naming another `workspaceId` fails the row. The queue
-  adapter keeps decoding, tracing, and platform retry scheduling; generation
-  owns snapshot/build/completion and terminal settlement. No DLQ, the row is
-  the record. `WORKSPACE_EXPORT_RETENTION_DAYS` is declared twice, in
-  `infra/bindings.ts` (R2 lifecycle rule) and the capability;
-  `export-consumer.test.ts` fails if they diverge.
-- Seat sync uses the billing queue and its dead-letter queue. The primary queue
-  retries six times; the dead-letter consumer calls `Billing.reconcileWorkspace`
-  so recovery does not require a later mutation. A failed recovery takes the
-  webhook DLQ's shape: `boundedRecoveryOutcome` retries while the platform will
-  redeliver, then acks with the loss annotated. `onFailure` is that same
-  bounded arm, so a defect cannot ack a dead letter on its first delivery.
-  Both billing entries and the Stripe endpoint build their env with
-  `billingCapabilitiesEnv` (`billing-runtime.ts`), which adds the Stripe bag
-  because `starterEnv` projects bindings only, and share one
-  `applyProviderEvent` for a queued provider event. The operator-retry audit
-  row is written after the reconcile settles, so a redelivery cannot append a
-  second one.
-- Notification email messages carry ids only, so re-read notification and preferences before claiming. Email delivery owns retry timing; use its completion decision even when an active lease skips sending. Digest sends are never fatal, and failed reads retry the run.
+Read [delivery guidance](../../docs/agents/background-delivery.md) before changing webhook dispatch/signing, queue-specific outcomes, export generation, billing recovery, or notification/digest delivery.
 
 ## Anti-patterns
 
 - Do not mint a trace id or set `traceparent`/`b3`: `currentTraceId` is the only source, and `HttpClient` injects the headers on the delivery POST.
 - Do not emit terminal delivery audit events here: the capability batches that row with the attempt so both commit together.
 - Do not infer queue disposition from delivery evidence or repeat failure notifications after completion.
-- Do not give `webhook-signing.ts` dependencies; a test imports it directly against a fixed HMAC vector.
 - Do not edit the generated `wrangler.jsonc`, and build no OTLP exporter at isolate level (ADR 0050): `runInvocation` provides it per invocation, so exporters flush before the handler settles.
 
 ## Dependencies & Edges
@@ -68,8 +40,5 @@ Per queue the outcome table is the contract; the non-obvious parts:
   is the only predicate for it: the export consumer's `finalAttempt`, both DLQ
   retry bounds, and `exhaustedQueueDelivery` read it.
 - The fold sits outside `withTriggerScope`, so the wide event exits carrying the failure cause before it becomes a queue outcome. `onFailure: 'retry'` except the dead-letter entries, which bound it by attempt.
-- The publisher persists a delivery before enqueueing its `deliveryId`. Both consumers bind that delivery to its endpoint and current workspace; stored contents supply dispatch and terminal evidence. Each observation is unique by delivery, attempt ordinal, and phase. Completion prevents repeated warnings ([ADR 0062](../../docs/adr/0062-webhook-protocol-and-operator-tooling.md)). Requester authorization stays at scheduling; execution checks current workspace suspension and resource availability.
-- `signatureHeaderValue` owns the signature format: Standard Webhooks HMAC-SHA256 over `"<deliveryId>.<unix>.<rawBody>"`, one space-separated `v1,<base64>` per active secret, current first, two only inside a rotation's grace window (ADR 0062).
-- The SSRF guard runs at endpoint creation _and again at dispatch_; DNS rebinding is out of scope.
 
 - The hourly retention invocation owns scheduled cleanup, including webhook/email history. Keep its approval gate separate from the daily digest; see [retention](../../packages/capabilities/src/governance/retention.AGENTS.md).

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -4,12 +4,11 @@ TanStack Start Worker for the public site, auth, workspaces, `/admin` and `/acco
 
 ## Contracts
 
+Before changing auth HTTP handling, session reads, workspace authentication gates, anonymous credential flows, or their rate limits, read [web auth guidance](../../docs/agents/web-auth.md).
+
 - `src/start.ts` runs the config gate before observability scopes SSR and server-fn calls; nested work joins that scope.
-- The Better Auth HTTP handler shares one `AuthExchange` URL parse and session read. `auth-request-guard.ts` owns classification, pre-handler context and guard order — impersonation (the specific refusal, so it wins over the generic one), strong authentication, then the two SSO sign-in refusals; a failed session read is a 503, never an anonymous request. Refusals skip the plugin and all post-handler processing, and answer through `auth-refusal.ts`. Rate limiting and Turnstile run first; two-factor enforcement, audit, notifications and evidence run only after a handled plugin response.
 - Every organization-product path is a `capability-route` refusal: workspace state changes through server functions, which carry authorization, suspension and audit context the plugin's HTTP surface has none of.
-- `auth-session-read.ts` owns the one session read: `server/auth.ts`'s gates and the catchall's guards share the request's `auth.session` memo slot; the two-factor gate reads a minted cookie unmemoized.
 - Gates live in `server/auth.ts`: `requireSession` runs once, in the `routes/workspaces.tsx` `beforeLoad`, children read `context.session`, and every server fn calls `requireRequestSession()`.
-- The `routes/workspaces.$workspaceSlug.tsx` `beforeLoad` reads one gate payload (suspension state plus `strongAuthenticationRequired`) and redirects: suspended workspaces to `/suspended`, unverified owners and admins to `/verify-authentication?redirect=…`. The authentication gate is subtree-wide by choice, wider than `authorize.ts`, where only `requireWorkspacePermission` hard-gates and dashboard segments take the soft `whenPermitted` path: an owner or admin whose strong-auth window lapsed verifies once at the boundary instead of meeting the gate halfway through a page. Members are never asked — `needsStrongAuthentication` names only owners, admins and system admins. `/suspended` is exempt, since it maps to the `credential_recovery` operation. The evidence read joins `strongAuthenticationStatusFor`'s per-request memo slot, so the gate costs no extra round trip.
 - `lib/capabilities.ts` maps capability errors to `notFound()` or `capability-error.ts` discriminants. Loaders catch nothing.
 
 ## Changes
@@ -35,8 +34,6 @@ TanStack Start Worker for the public site, auth, workspaces, `/admin` and `/acco
 
 - Read `cloudflare:workers` bindings, never hardcode empty env. `DB` selects Live, absence Seed; dev uses persisted local D1 (ADR 0049). Browser navigation depends on the root fixture-parity rule.
 - Two runtimes. `webRuntime` runs every server-side Effect, with isolate-level `WideEventLoggerLive` and OTLP per invocation (ADR 0050). `authRuntime` holds only `Auth`: merging `AuthLive` in drags the Better Auth server into the browser bundle.
-- Turnstile gates every anonymous mail-an-address POST (sign-up, magic link, one-time code, password reset, verification email); each gated path has a widget on the screen that drives it through `useTurnstileChallenge`, and the token rides `x-turnstile-token` from a port in `components/auth/auth-client-ports.ts`. With TURNSTILE unset the site key is `null`, no widget renders and the gate answers `inactive` (ADR 0031).
-- `lib/rate-limit.ts` trusts only `cf-connecting-ip`; email-OTP, magic-link and reset sends, the second-factor checks, and the session-free SSO routing server fn share sign-in's `auth_sign_in` bucket (ADR 0030).
 
 ## Pitfalls
 

--- a/docs/agents/background-delivery.md
+++ b/docs/agents/background-delivery.md
@@ -1,0 +1,42 @@
+# Background delivery
+
+Implementation guidance for `apps/background`. Source filenames below refer to that worker unless another package is named. Read this before changing webhook dispatch/signing, queue-specific outcomes, export generation, billing recovery, or notification/digest delivery.
+
+## Queue outcomes
+
+Per queue the outcome table is the contract; the non-obvious parts:
+
+- Webhooks retry a retryable failure (5xx, 408, 429, network, timeout) at `backoffSeconds(attempts)`; a 4xx or SSRF rejection is `failed_permanent`; undispatchable or malformed acks.
+- [Webhook Attempt completion](../../packages/capabilities/src/developer-platform/webhook-attempt-completion.ts) owns planning, recording and accepted-only warnings. The worker owns signing and HTTP dispatch; it follows completion's queue disposition, including for duplicate or late observations.
+- The DLQ consumer acks after writing the terminal `dead_lettered` row, but retries if that write fails, so a D1 blip cannot lose the evidence.
+- Exports use the capability-owned generation workflow after resolving
+  `WorkspaceContext` from the slug with no actor, ownership having been checked
+  at request time; a slug naming another `workspaceId` fails the row. The queue
+  adapter keeps decoding, tracing, and platform retry scheduling; generation
+  owns snapshot/build/completion and terminal settlement. No DLQ, the row is
+  the record. `WORKSPACE_EXPORT_RETENTION_DAYS` is declared twice, in
+  `infra/bindings.ts` (R2 lifecycle rule) and the capability;
+  `export-consumer.test.ts` fails if they diverge.
+- Seat sync uses the billing queue and its dead-letter queue. The primary queue
+  retries six times; the dead-letter consumer calls `Billing.reconcileWorkspace`
+  so recovery does not require a later mutation. A failed recovery takes the
+  webhook DLQ's shape: `boundedRecoveryOutcome` retries while the platform will
+  redeliver, then acks with the loss annotated. `onFailure` is that same
+  bounded arm, so a defect cannot ack a dead letter on its first delivery.
+  Both billing entries and the Stripe endpoint build their env with
+  `billingCapabilitiesEnv` (`billing-runtime.ts`), which adds the Stripe bag
+  because `starterEnv` projects bindings only, and share one
+  `applyProviderEvent` for a queued provider event. The operator-retry audit
+  row is written after the reconcile settles, so a redelivery cannot append a
+  second one.
+- Notification email messages carry ids only, so re-read notification and preferences before claiming. Email delivery owns retry timing; use its completion decision even when an active lease skips sending. Digest sends are never fatal, and failed reads retry the run.
+
+## Webhook dispatch and evidence
+
+- Do not give `webhook-signing.ts` dependencies; a test imports it directly against a fixed HMAC vector.
+
+- The publisher persists a delivery before enqueueing its `deliveryId`. Both consumers bind that delivery to its endpoint and current workspace; stored contents supply dispatch and terminal evidence. Each observation is unique by delivery, attempt ordinal, and phase. Completion prevents repeated warnings ([ADR 0062](../../docs/adr/0062-webhook-protocol-and-operator-tooling.md)). Requester authorization stays at scheduling; execution checks current workspace suspension and resource availability.
+
+- `signatureHeaderValue` owns the signature format: Standard Webhooks HMAC-SHA256 over `"<deliveryId>.<unix>.<rawBody>"`, one space-separated `v1,<base64>` per active secret, current first, two only inside a rotation's grace window (ADR 0062).
+
+- The SSRF guard runs at endpoint creation _and again at dispatch_; DNS rebinding is out of scope.

--- a/docs/agents/web-auth.md
+++ b/docs/agents/web-auth.md
@@ -1,0 +1,15 @@
+# Web auth request handling
+
+Implementation guidance for `apps/web`. Auth handler modules live in `apps/web/src/lib/server`; route and component paths are relative to `apps/web/src`. Read this when changing auth HTTP handling, session reads, workspace authentication gates, anonymous credential flows, or their rate limits.
+
+- The Better Auth HTTP handler shares one `AuthExchange` URL parse and session read. `auth-request-guard.ts` owns classification, pre-handler context and guard order — impersonation (the specific refusal, so it wins over the generic one), strong authentication, then the two SSO sign-in refusals; a failed session read is a 503, never an anonymous request. Refusals skip the plugin and all post-handler processing, and answer through `auth-refusal.ts`. Rate limiting and Turnstile run first; two-factor enforcement, audit, notifications and evidence run only after a handled plugin response.
+
+- `auth-session-read.ts` owns the one session read: `server/auth.ts`'s gates and the catchall's guards share the request's `auth.session` memo slot; the two-factor gate reads a minted cookie unmemoized.
+
+- The `routes/workspaces.$workspaceSlug.tsx` `beforeLoad` reads one gate payload (suspension state plus `strongAuthenticationRequired`) and redirects: suspended workspaces to `/suspended`, unverified owners and admins to `/verify-authentication?redirect=…`. The authentication gate is subtree-wide by choice, wider than `authorize.ts`, where only `requireWorkspacePermission` hard-gates and dashboard segments take the soft `whenPermitted` path: an owner or admin whose strong-auth window lapsed verifies once at the boundary instead of meeting the gate halfway through a page. Members are never asked — `needsStrongAuthentication` names only owners, admins and system admins. `/suspended` is exempt, since it maps to the `credential_recovery` operation. The evidence read joins `strongAuthenticationStatusFor`'s per-request memo slot, so the gate costs no extra round trip.
+
+- Turnstile gates every anonymous mail-an-address POST (sign-up, magic link, one-time code, password reset, verification email); each gated path has a widget on the screen that drives it through `useTurnstileChallenge`, and the token rides `x-turnstile-token` from a port in `components/auth/auth-client-ports.ts`. With TURNSTILE unset the site key is `null`, no widget renders and the gate answers `inactive` (ADR 0031).
+
+- `lib/rate-limit.ts` trusts only `cf-connecting-ip`; email-OTP, magic-link and reset sends, the second-factor checks, and the session-free SSO routing server fn share sign-in's `auth_sign_in` bucket (ADR 0030).
+
+- Non-disclosure is a rule: constant responses on `/forgot-password`, `disableSignUp` on email-OTP, one opaque failure on `/invitations/accept` and link landings.

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -4,51 +4,30 @@ Owns Drizzle schema, migrations, and D1 services. Stored enum vocabularies live 
 
 ## Migration changes
 
-Change schema and generated migration together. Migration readers share `migrations-fs.ts` so deploys and tests apply the same order. Use the repository migration scripts; Wrangler's flat-file migration command skips Drizzle's folder output.
+Edit `schema.ts`, run `db:generate`, and commit schema and generated migration together. `scripts/migrate.ts`, `scripts/baseline.ts`, and `./testing` share `migrations-fs.ts` for identical ordering. Use repository migration scripts: `wrangler d1 migrations apply` sees only flat SQL files and skips Drizzle's folder output.
 
-After a squash, reset obsolete local D1 state using [setup](../../docs/setup.md). Deployed databases use baseline bookkeeping before Alchemy deploys. A baseline records a migration only when all its created tables already exist; it cannot apply missing schema changes. Follow [operations](../../docs/operations.md) for recovery. Never destroy or reseed customer data as migration repair.
+After a squash, obsolete local D1 state still names deleted migrations. Follow [local reset setup](../../docs/setup.md): delete `packages/db/.wrangler/state/v3/d1`, run `db:migrate:local` and `db:seed`, then restart `pnpm run dev` (ADR 0049).
+
+Deploy workflows run `scripts/baseline.ts` before Alchemy to reconcile migration bookkeeping. It records a table-creating migration only when every created table exists; missing remote databases are skipped and created during deploy. It cannot apply missing schema changes, so squashes containing undeployed work cannot converge. Pre-production resets require explicit target confirmation. Customer-data deployments keep incremental migrations and follow [operations recovery](../../docs/operations.md); never destroy or reseed customer data as migration repair.
+
+Drizzle is pinned to a prerelease in the workspace catalog. Before changing APIs, check current v1 docs and the installed driver source; stable-version examples may differ. Verify Effect D1 behavior separately from `drizzle-orm/d1`.
 
 ## Storage invariants
 
 - Drizzle column builders are single-use. Helpers must return fresh builders.
-- Resolve `RawD1` at layer construction. D1 atomicity uses `batch` with compiled statements; explicit transactions are unsupported.
-- Better Auth and plugin tables use epoch timestamps; starter-owned tables use ISO strings. Do not decode workspace creation time as ISO storage.
-- Plugin-owned workspace tables retain camelCase columns and surrogate member IDs. The unique workspace/user index does not replace the member primary key.
+- Resolve `RawD1` at layer construction instead of threading the binding through application code. D1 atomicity uses `batch` with compiled statements; explicit transactions are unsupported.
+- Better Auth and plugin tables use epoch seconds; starter-owned tables use ISO strings. Do not decode workspace creation time as ISO storage.
+- Plugin-owned workspace tables retain camelCase columns and surrogate member IDs. `workspace_members` uses a unique `(workspaceId, userId)` index, not a composite primary key: the plugin addresses members by row ID (ADR 0051).
 - `workspaces.metadata` stays plain text because the plugin serializes it. Starter JSON columns use typed text and receive objects rather than pre-serialized strings.
-- Columns returned by organization endpoints need matching `additionalFields` in [auth](../auth/AGENTS.md). `onboardingDismissedAt` is capability-only and is excluded (ADR 0066).
+- Columns returned by organization endpoints need matching `additionalFields` in [auth](../auth/AGENTS.md), or the plugin strips them from responses. `onboardingDismissedAt` is capability-only and excluded (ADR 0066).
 - Workspace foreign keys cascade. Deletion audits use a null workspace ID so they survive that cascade.
-
-Edit `schema.ts`, run `db:generate`, commit schema and migration together (drizzle-kit folder style). `scripts/migrate.ts`, `scripts/baseline.ts`, and `./testing` share `migrations-fs.ts` for identical ordering.
-
-After a squash a stale local D1 cannot be migrated onto, its `d1_migrations` table naming deleted migrations: delete `packages/db/.wrangler/state/v3/d1`, re-run `db:migrate:local` and `db:seed`, restart `pnpm run dev` (ADR 0049).
-
-Deploy workflows run `scripts/baseline.ts` before Alchemy to reconcile folder-name bookkeeping after squashes. It records table-creating migrations only when every created table exists; missing remote databases are skipped and created during deploy. Squashes containing undeployed work cannot converge. Pre-production resets require explicit target confirmation. Customer-data deployments keep incremental migrations and follow [operations recovery](../../docs/operations.md); never destroy/reseed as migration repair.
-
-Drizzle is pinned to a prerelease in the workspace catalog. Check current v1 docs and the installed driver source before changing APIs; stable-version examples may differ. Verify Effect D1 behavior separately from `drizzle-orm/d1`.
-
-## Anti-patterns
-
-- Don't use `./testing` in app code, and don't thread the raw binding around; resolve `RawD1` where the layer is built. Better Auth's `drizzleAdapter` calls `drizzle(d1)` from `drizzle-orm/d1` directly — there is no promise-client wrapper to import.
-- Don't switch back to `wrangler d1 migrations apply`: it sees only flat `migrations/*.sql` and skips folder output.
-
-## Patterns & Pitfalls
-
-The three workspace tables are the `organization` plugin's (ADR 0051): starter names, plugin shape (camelCase columns, epoch dates, surrogate ids).
-
-- A new column needs an `additionalFields` entry in [`auth`](../auth/AGENTS.md), or the plugin strips it from every response. Exception: `workspaces.onboardingDismissedAt` (ADR 0066).
-- `workspaces.metadata` is plain `text`, never `mode: 'json'`; the plugin stringifies and parses it itself.
-- `workspace_members` uses a unique index on `(workspaceId, userId)`, not a composite PK: the plugin addresses members by row id.
-
-D1 gotchas:
-
 - Index child foreign-key columns, reusing the leftmost prefix of an existing non-partial composite index when possible. Preserve unique and partial constraints even when another index covers their columns. Verify index changes with `EXPLAIN QUERY PLAN` against migrated local D1; assert indexed access, not an exact index name.
-- No native boolean: `integer({ mode: 'boolean' })`. JSON columns are `text` with a `$type`, parsed on read; never write the string.
-- Timestamps split by ownership, not age: Better Auth tables (core and plugin-owned) store epoch seconds, starter tables ISO strings. Reading `workspaces.createdAt` as ISO is a stale contract.
-- FKs cascade from `workspaces.id`, but the audit log keeps removed-workspace rows as `workspaceId: null` system events. Keep that asymmetry.
+- D1 has no native boolean: use `integer({ mode: 'boolean' })`.
 
-The seed lives outside this package, at `scripts/seed.ts`; the Effect test fixture is `capabilities/src/seed-fixture.ts`. Its `insert` helper takes the table object and TS-property-keyed rows, so renames break the build.
+## Adapters and fixtures
 
-## Dependencies & Edges
+Better Auth uses `drizzle(d1)` from `drizzle-orm/d1` through its direct adapter; there is no promise-client wrapper. Application Effect services use `Database`.
 
-`drizzle-orm`, `@effect/sql-d1`, `effect`, `failure` (dev: `drizzle-kit`, `wrangler`). Consumed by `auth`, `authz`, `capabilities`, both workers, `scripts/seed.ts`.
-`src/testing.ts` provisions isolated migrated D1 databases and must stay out of app code. Better Auth uses its direct Drizzle adapter; application Effect services use `Database`.
+`src/testing.ts` provisions isolated migrated D1 databases. Keep `./testing` out of application code.
+
+The seed lives at `scripts/seed.ts`; the Effect fixture is `packages/capabilities/src/seed-fixture.ts`. Its `insert` helper takes table objects and TS-property-keyed rows, so renames break the build.


### PR DESCRIPTION
## Outcome

Reduce the instructions loaded for routine repository edits. Consolidate repeated database migration and storage rules, and move detailed web auth handling and background delivery guidance into task-specific documents linked from the app AGENTS.md files.

Preserve authorization, provider behavior, recovery, and retention constraints. Root guidance and application code are unchanged.

## Validation

Tested revision: `169ee0e59a86b3443744a70c68bbf37e58900999`.

- `pnpm run validate` passed, including checks, builds, generated Wrangler configuration verification, local migration/seed, and browser tests.
- Browser result: 40 passed, 1 flaky. The Norwegian mobile language-picker test initially exceeded the expected viewport width and passed on retry.
- Formatting, local Markdown link checks, and `git diff --check` passed.
- The first sandboxed validation attempt could not start a localhost test server. Validation completed after rerunning with localhost access.

## Risks and remaining work

No application behavior changes. The observed browser-test flake remains outside this documentation change. CI results are separate from the local validation above.
