### PR TITLE
fix(exports): share generation policy across Seed and Live

### DIFF
--- a/packages/capabilities/src/governance/workspace-export-generation.seed.test.ts
+++ b/packages/capabilities/src/governance/workspace-export-generation.seed.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from '@effect/vitest'
+import { Effect, Layer, Option, Result, Schema } from 'effect'
+
+import { CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
+
+import { SeedLayer } from '../layers.ts'
+import { demoUserIdentity, seedWorkspaceRecord } from '../seed-fixture.ts'
+import { Notification, NotificationFeed } from '../notifications/notification-feed.ts'
+import { testWorkspaceContext } from '../workspace-context.ts'
+import { AuditEventLog } from './audit-event-log.ts'
+import { SeedWorkspaceExports } from './workspace-export.seed.ts'
+import { WorkspaceExports } from './workspace-export.ts'
+
+const ownerContext = testWorkspaceContext(seedWorkspaceRecord, {
+  userId: demoUserIdentity.id,
+  role: 'owner',
+  systemRole: 'admin'
+})
+const dependencies = Layer.merge(SeedLayer, ownerContext)
+const exportsLayer = SeedWorkspaceExports({ workspace: seedWorkspaceRecord })
+const decodeNotifications = Schema.decodeUnknownSync(
+  Schema.fromJsonString(Schema.Struct({ notifications: Schema.Array(Notification) }))
+)
+
+describe('Seed Workspace Export generation', () => {
+  it.effect('archives broadcasts and excludes private Notifications', () =>
+    Effect.gen(function* () {
+      const feed = yield* NotificationFeed
+      const broadcast = yield* feed.create({
+        workspaceId: seedWorkspaceRecord.id,
+        userId: null,
+        kind: 'announcement',
+        title: 'Workspace announcement',
+        message: 'This belongs in the Workspace archive.'
+      })
+      const personal = yield* feed.create({
+        workspaceId: seedWorkspaceRecord.id,
+        userId: demoUserIdentity.id,
+        kind: 'announcement',
+        title: 'Private account notice',
+        message: 'This belongs only to the requesting Member.'
+      })
+      const exports = yield* WorkspaceExports
+      const requested = yield* exports.request
+      expect(requested.status).toBe('pending')
+      const link = yield* exports.issueDownloadLink({
+        exportId: requested.id,
+        recipient: { type: 'api_token' }
+      })
+      if (Option.isNone(link)) {
+        return expect.fail('expected the generated archive to have a download link')
+      }
+      const url = new URL(link.value.path, 'https://api.test')
+      const download = yield* exports.openDownload({
+        exportId: requested.id,
+        expires: Number(url.searchParams.get('expires')),
+        signature: url.searchParams.get('signature') ?? ''
+      })
+      if (Option.isNone(download)) {
+        return expect.fail('expected the signed archive to download')
+      }
+      const body = download.value.body
+      const json = yield* Effect.promise(() => {
+        const compressed = new ReadableStream({
+          start(controller) {
+            controller.enqueue(body)
+            controller.close()
+          }
+        })
+        return new Response(
+          compressed.pipeThrough(new DecompressionStream('gzip'))
+        ).text()
+      })
+      const ids = decodeNotifications(json).notifications.map((notice) => notice.id)
+      expect(ids).toContain(broadcast.id)
+      expect(ids).not.toContain(personal.id)
+    }).pipe(Effect.provide(exportsLayer), Effect.provide(dependencies))
+  )
+
+  it.effect(
+    'settles an oversized audit trail as a failed export on the next read',
+    () =>
+      Effect.gen(function* () {
+        const audit = yield* AuditEventLog
+        // The documented archive walk is bounded at 2,500 audit events.
+        for (let index = 0; index < 2501; index += 1) {
+          yield* audit.record({
+            workspaceId: seedWorkspaceRecord.id,
+            actorUserId: demoUserIdentity.id,
+            actorType: 'user',
+            eventType: 'workspace.renamed',
+            targetType: 'workspace',
+            targetId: seedWorkspaceRecord.id,
+            metadata: {}
+          })
+        }
+        const exports = yield* WorkspaceExports
+        const requested = yield* exports.request
+        expect(requested.status).toBe('pending')
+        const settled = (yield* exports.list).find((row) => row.id === requested.id)
+        expect(settled?.status).toBe('failed')
+        expect(settled?.failureReason).toBe(
+          'unavailable: audit_trail_exceeds_export_walk_bound'
+        )
+        const failures = yield* audit.list({ eventType: 'workspace.export_failed' })
+        expect(
+          failures.items.filter((event) => event.targetId === requested.id)
+        ).toHaveLength(1)
+        expect(
+          (yield* exports.list).find((row) => row.id === requested.id)?.status
+        ).toBe('failed')
+        expect(
+          Option.isNone(
+            yield* exports.issueDownloadLink({
+              exportId: requested.id,
+              recipient: { type: 'api_token' }
+            })
+          )
+        ).toBe(true)
+      }).pipe(Effect.provide(exportsLayer), Effect.provide(dependencies))
+  )
+
+  it.effect('retries deferred failure settlement after audit storage recovers', () => {
+    const unavailableAudit = Layer.effect(AuditEventLog)(
+      Effect.gen(function* () {
+        const audit = yield* AuditEventLog
+        let rejectFailureEvidence = true
+        return AuditEventLog.of({
+          ...audit,
+          list: (input) => {
+            if (input?.eventType) {
+              return audit.list(input)
+            }
+            return Effect.fail(
+              new CapabilityUnavailable({
+                capability: 'audit-event-log',
+                reason: 'snapshot_read_unavailable'
+              })
+            )
+          },
+          record: (input) => {
+            if (
+              input.eventType === 'workspace.export_failed' &&
+              rejectFailureEvidence
+            ) {
+              rejectFailureEvidence = false
+              return Effect.fail(
+                new CapabilityUnavailable({
+                  capability: 'audit-event-log',
+                  reason: 'failure_evidence_unavailable'
+                })
+              )
+            }
+            return audit.record(input)
+          }
+        })
+      })
+    )
+    return Effect.gen(function* () {
+      const exports = yield* WorkspaceExports
+      const audit = yield* AuditEventLog
+      const requested = yield* exports.request
+      const firstRead = yield* Effect.result(exports.list)
+      expect(Result.isFailure(firstRead)).toBe(true)
+      if (Result.isFailure(firstRead)) {
+        expect(firstRead.failure).toMatchObject({
+          _tag: 'CapabilityUnavailable',
+          reason: 'failure_evidence_unavailable'
+        })
+      }
+      const retried = (yield* exports.list).find((row) => row.id === requested.id)
+      expect(retried?.status).toBe('failed')
+      expect(retried?.failureReason).toBe('unavailable: snapshot_read_unavailable')
+      yield* exports.list
+      const evidence = yield* audit.list({ eventType: 'workspace.export_failed' })
+      expect(
+        evidence.items.filter((event) => event.targetId === requested.id)
+      ).toHaveLength(1)
+    }).pipe(
+      Effect.provide(exportsLayer),
+      Effect.provide(unavailableAudit),
+      Effect.provide(dependencies)
+    )
+  })
+})

--- a/packages/capabilities/src/governance/workspace-export-generation.ts
+++ b/packages/capabilities/src/governance/workspace-export-generation.ts
@@ -1,4 +1,4 @@
-import { Context, DateTime, Effect, Layer, Result } from 'effect'
+import { Context, DateTime, Effect, Layer, Result, type Scope } from 'effect'
 
 import { CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
 import { type WorkspaceNotFound } from '../errors.ts'
@@ -113,6 +113,87 @@ function settledSuspension(
   return failed(input, 'workspace_suspended', exports)
 }
 
+/** Builds the shared generator with stable snapshot and lifecycle dependencies. */
+export function workspaceExportGenerationEffect(
+  resolveWorkspace: ResolveWorkspace
+): Effect.Effect<
+  WorkspaceExportGenerationInterface,
+  never,
+  GenerationDependencies | Scope.Scope
+> {
+  return Effect.gen(function* () {
+    const exports = yield* WorkspaceExports
+    const suspension = yield* WorkspaceSuspensionService
+    const scope = yield* Effect.scope
+    const snapshotContext = yield* workspaceExportSnapshotContextEffect()
+    const generate = Effect.fn('WorkspaceExportGeneration.generate')(function* (
+      input: WorkspaceExportGenerationInput
+    ) {
+      const message = input.message
+      const allowed = yield* Effect.result(
+        suspension.requireAllowed(message.workspaceId, 'product')
+      )
+      if (Result.isFailure(allowed)) {
+        if (allowed.failure._tag === 'WorkspaceSuspended') {
+          return yield* settledSuspension(input, exports)
+        }
+        return yield* unavailable(input, allowed.failure.reason, exports)
+      }
+
+      const built = yield* Effect.result(
+        Effect.gen(function* () {
+          const workspaceContext = yield* Layer.buildWithScope(
+            resolveWorkspace(message.workspaceSlug),
+            scope
+          )
+          return yield* buildWorkspaceExportArchiveEffect({
+            exportId: message.exportId,
+            generatedAt: yield* DateTime.now
+          }).pipe(
+            Effect.provide(snapshotContext),
+            Effect.provideContext(workspaceContext)
+          )
+        })
+      )
+
+      if (Result.isFailure(built)) {
+        if (built.failure._tag === 'WorkspaceNotFound') {
+          return yield* failed(input, 'workspace_not_found', exports)
+        }
+        return yield* unavailable(input, built.failure.reason, exports)
+      }
+      if (built.success.snapshot.workspace.id !== message.workspaceId) {
+        return yield* failed(input, 'workspace_mismatch', exports)
+      }
+
+      const completed = yield* Effect.result(
+        exports.complete({
+          exportId: message.exportId,
+          workspaceId: message.workspaceId,
+          archive: built.success.archive
+        })
+      )
+      if (Result.isFailure(completed)) {
+        if (completed.failure._tag === 'WorkspaceSuspended') {
+          return yield* settledSuspension(input, exports)
+        }
+        return yield* unavailable(input, completed.failure.reason, exports)
+      }
+      if (!completed.success) {
+        return {
+          _tag: 'skipped',
+          reason: 'already_settled'
+        } satisfies WorkspaceExportGenerationResult
+      }
+      return {
+        _tag: 'ready',
+        sizeBytes: built.success.archive.length
+      } satisfies WorkspaceExportGenerationResult
+    })
+    return WorkspaceExportGeneration.of({ generate })
+  })
+}
+
 /**
  * Builds and settles one queued export. The queue only supplies identity and
  * retry state; snapshot dependencies, archive ordering, and terminal row
@@ -122,78 +203,6 @@ export function WorkspaceExportGenerationLayer(
   resolveWorkspace: ResolveWorkspace
 ): Layer.Layer<WorkspaceExportGeneration, never, GenerationDependencies> {
   return Layer.effect(WorkspaceExportGeneration)(
-    Effect.gen(function* () {
-      const exports = yield* WorkspaceExports
-      const suspension = yield* WorkspaceSuspensionService
-      const scope = yield* Effect.scope
-      const snapshotContext = yield* workspaceExportSnapshotContextEffect()
-
-      const generate = Effect.fn('WorkspaceExportGeneration.generate')(function* (
-        input: WorkspaceExportGenerationInput
-      ) {
-        const message = input.message
-        const allowed = yield* Effect.result(
-          suspension.requireAllowed(message.workspaceId, 'product')
-        )
-        if (Result.isFailure(allowed)) {
-          if (allowed.failure._tag === 'WorkspaceSuspended') {
-            return yield* settledSuspension(input, exports)
-          }
-          return yield* unavailable(input, allowed.failure.reason, exports)
-        }
-
-        const built = yield* Effect.result(
-          Effect.gen(function* () {
-            const workspaceContext = yield* Layer.buildWithScope(
-              resolveWorkspace(message.workspaceSlug),
-              scope
-            )
-            return yield* buildWorkspaceExportArchiveEffect({
-              exportId: message.exportId,
-              generatedAt: yield* DateTime.now
-            }).pipe(
-              Effect.provide(snapshotContext),
-              Effect.provideContext(workspaceContext)
-            )
-          })
-        )
-
-        if (Result.isFailure(built)) {
-          if (built.failure._tag === 'WorkspaceNotFound') {
-            return yield* failed(input, 'workspace_not_found', exports)
-          }
-          return yield* unavailable(input, built.failure.reason, exports)
-        }
-        if (built.success.snapshot.workspace.id !== message.workspaceId) {
-          return yield* failed(input, 'workspace_mismatch', exports)
-        }
-
-        const completed = yield* Effect.result(
-          exports.complete({
-            exportId: message.exportId,
-            workspaceId: message.workspaceId,
-            archive: built.success.archive
-          })
-        )
-        if (Result.isFailure(completed)) {
-          if (completed.failure._tag === 'WorkspaceSuspended') {
-            return yield* settledSuspension(input, exports)
-          }
-          return yield* unavailable(input, completed.failure.reason, exports)
-        }
-        if (!completed.success) {
-          return {
-            _tag: 'skipped',
-            reason: 'already_settled'
-          } satisfies WorkspaceExportGenerationResult
-        }
-        return {
-          _tag: 'ready',
-          sizeBytes: built.success.archive.length
-        } satisfies WorkspaceExportGenerationResult
-      })
-
-      return WorkspaceExportGeneration.of({ generate })
-    })
+    workspaceExportGenerationEffect(resolveWorkspace)
   )
 }

--- a/packages/capabilities/src/governance/workspace-export-snapshot.ts
+++ b/packages/capabilities/src/governance/workspace-export-snapshot.ts
@@ -84,7 +84,7 @@ const allAuditEvents: Effect.Effect<
  * same projections the app renders, so an export never shows a field the UI
  * hides (signing secrets, token hashes, raw audit metadata). Runs against the
  * `WorkspaceContext` in scope: a trusted `actor: null` context on the queue
- * consumer, the requesting owner's on the Seed path. With no actor the
+ * consumer and Seed's deferred path. With no actor the
  * notification feed yields workspace broadcasts only, which is the intended
  * boundary — user-targeted notifications are the user's data.
  */

--- a/packages/capabilities/src/governance/workspace-export.AGENTS.md
+++ b/packages/capabilities/src/governance/workspace-export.AGENTS.md
@@ -10,9 +10,11 @@ Workspace export (ADR 0055): an owner requests an archive, the background consum
   adapter only decodes the message, selects the trusted context resolver,
   annotates the wide event, and turns a retry disposition into platform
   scheduling. Seed and Live use the same snapshot/archive recipe; Seed runs it
-  inline because it has no queue or bucket.
+  inline because it has no queue or bucket. Seed invokes the same generation
+  constructor on its next read with the request's workspace and a trusted
+  `actor: null` context, so private Member notifications stay out of archives.
 - `request` batches the `pending` row with `workspace.export_requested`, then enqueues, and answers the `pending` projection on both adapters — Seed defers its inline build to the next read rather than returning `ready`. An enqueue failure marks the row `failed` (`enqueue_failed`); unconfigured fails `CapabilityUnavailable('not_configured')`.
-- Settling an export as failed is audited `workspace.export_failed` and batched with the transition, so an operator sees why a pending export stopped.
+- Settling an export as failed is audited `workspace.export_failed` and batched with the transition, so an operator sees why a pending export stopped. Seed records that evidence before changing its in-memory row; an audit outage leaves deferred work pending for retry.
 - `issueDownloadLink` requires an explicit session or API Token recipient and returns a path and expiry, never an origin. TTL is 15 minutes, capped at the artifact's horizon. Human links sign the user, session and Workspace slug with the artifact identity. Issuance boundaries check recent authentication and download permission.
 - The API download boundary rechecks human session freshness and current Workspace membership/permission. `openDownload` verifies the complete signature, expiry and `isWorkspaceExportDownloadable`, then audits the signed recipient. Refusals answer 404 before artifact storage is read.
 

--- a/packages/capabilities/src/governance/workspace-export.seed.ts
+++ b/packages/capabilities/src/governance/workspace-export.seed.ts
@@ -1,4 +1,4 @@
-import { DateTime, Effect, Layer, Option, Result } from 'effect'
+import { DateTime, Effect, Layer, Option, Result, Scope } from 'effect'
 
 import { type CapabilityUnavailable } from '@b2b-saas-starter/failure/capability'
 import { newCapabilityId } from '../internal/ids.ts'
@@ -11,7 +11,11 @@ import { type SystemNotificationEvent } from '../notifications/notification-even
 import { testWorkspaceContext, WorkspaceContext } from '../workspace-context.ts'
 import { AuditEventLog, type AuditEventLogInterface } from './audit-event-log.ts'
 import { workspaceExportFileName } from './workspace-export-archive.ts'
-import { buildWorkspaceExportArchiveEffect } from './workspace-export-generation.ts'
+import {
+  buildWorkspaceExportArchiveEffect,
+  workspaceExportGenerationEffect,
+  type WorkspaceExportGenerationResult
+} from './workspace-export-generation.ts'
 import {
   workspaceExportSnapshotContextEffect,
   type WorkspaceExportSnapshotServices
@@ -28,7 +32,8 @@ import {
   type IssueWorkspaceExportDownloadInput,
   type OpenWorkspaceExportDownloadInput,
   type WorkspaceExport,
-  type WorkspaceExportAvailability
+  type WorkspaceExportAvailability,
+  type WorkspaceExportsInterface
 } from './workspace-export.ts'
 import { type Workspace } from './workspace-identity.ts'
 import { WorkspaceSuspensionService } from './workspace-suspension.ts'
@@ -72,9 +77,10 @@ type SeedExportRow = {
    * fixture's version of a worker that drained the queue immediately.
    * `null` once drained (or for a row that never had one).
    */
-  deferredBuild: Effect.Effect<Uint8Array, CapabilityUnavailable> | null
-  /** The instant the deferred build is stamped as completing at. */
-  deferredAt: DateTime.Utc | null
+  deferredBuild: Effect.Effect<
+    WorkspaceExportGenerationResult,
+    CapabilityUnavailable
+  > | null
 }
 
 /** Newest first, like Live's `ORDER BY created_at DESC`. */
@@ -102,10 +108,8 @@ function readyNotification(workspaceName: string, expiresAt: string) {
 
 /**
  * In-memory exports: the Seed adapter has no queue and no bucket, so
- * `request` collects the snapshot, builds the archive, and lands the row
- * `ready` in one step. The archive is the same bytes the background worker
- * would write (same `collectWorkspaceExportSnapshot`, same builder), so a test
- * against Seed asserts the real artifact shape.
+ * `request` leaves a pending row and drains the shared generation policy on
+ * the next read. The archive is the same bytes the background worker writes.
  *
  * Depends on the read services because it takes the snapshot itself; Live
  * leaves that to the consumer. `layers.ts` provides the shared seed instances
@@ -128,17 +132,11 @@ export function SeedWorkspaceExports(options: {
       const feed = yield* NotificationFeed
       const snapshotContext = yield* workspaceExportSnapshotContextEffect()
       const suspension = yield* WorkspaceSuspensionService
+      const scope = yield* Effect.scope
       function requireProduct(workspaceId: string) {
         return suspension.requireAllowed(workspaceId, 'product')
       }
       const rows: Array<SeedExportRow> = []
-
-      function buildArchive(exportId: string, generatedAt: DateTime.Utc) {
-        return buildWorkspaceExportArchiveEffect({ exportId, generatedAt }).pipe(
-          Effect.provide(snapshotContext),
-          Effect.map(({ archive }) => archive)
-        )
-      }
 
       if (options.fixture) {
         const now = yield* DateTime.now
@@ -154,7 +152,11 @@ export function SeedWorkspaceExports(options: {
         // lands `failed` with the reason rather than failing layer construction
         // for every other capability.
         const built = yield* Effect.result(
-          buildArchive(options.fixture.id, completedAt).pipe(
+          buildWorkspaceExportArchiveEffect({
+            exportId: options.fixture.id,
+            generatedAt: completedAt
+          }).pipe(
+            Effect.provide(snapshotContext),
             Effect.provide(testWorkspaceContext(options.workspace, null, 'system'))
           )
         )
@@ -174,12 +176,11 @@ export function SeedWorkspaceExports(options: {
               requestedAt: DateTime.formatIso(requestedAt),
               completedAt: DateTime.formatIso(completedAt),
               expiresAt: workspaceExportExpiresAt(completedAt),
-              sizeBytes: built.success.length,
+              sizeBytes: built.success.archive.length,
               failureReason: null
             },
-            archive: built.success,
-            deferredBuild: null,
-            deferredAt: null
+            archive: built.success.archive,
+            deferredBuild: null
           })
         } else {
           rows.push({
@@ -194,8 +195,7 @@ export function SeedWorkspaceExports(options: {
               failureReason: built.failure.reason
             },
             archive: null,
-            deferredBuild: null,
-            deferredAt: null
+            deferredBuild: null
           })
         }
       }
@@ -209,13 +209,11 @@ export function SeedWorkspaceExports(options: {
       const drainDeferredBuilds = Effect.gen(function* () {
         for (const row of rows) {
           const build = row.deferredBuild
-          const at = row.deferredAt
-          row.deferredBuild = null
-          row.deferredAt = null
-          if (build === null || at === null || row.record.status !== 'pending') {
+          if (build === null || row.record.status !== 'pending') {
             continue
           }
-          yield* completeRow(row, yield* build, at, audit, feed)
+          yield* build
+          row.deferredBuild = null
         }
       })
 
@@ -228,7 +226,7 @@ export function SeedWorkspaceExports(options: {
         )
       }
 
-      return {
+      const service: WorkspaceExportsInterface = {
         availability: Effect.fn('WorkspaceExports.availability')(() =>
           Effect.succeed({ available: true } satisfies WorkspaceExportAvailability)
         )(),
@@ -262,8 +260,7 @@ export function SeedWorkspaceExports(options: {
             requestedByUserId: ctx.actor?.userId ?? null,
             downloadSecret: yield* newCapabilityId('sec'),
             archive: null,
-            deferredBuild: null,
-            deferredAt: null
+            deferredBuild: null
           }
           rows.push(row)
           yield* audit.record({
@@ -279,12 +276,26 @@ export function SeedWorkspaceExports(options: {
           // a `pending` export whose artifact does not exist yet. The
           // fixture has no queue, so the build waits here and the next read
           // drains it — the state a caller sees is the same either way.
-          // The build reads the workspace's own data, so it carries the
-          // requester's context with it rather than the next reader's.
-          row.deferredBuild = buildArchive(id, requestedAt).pipe(
-            Effect.provideService(WorkspaceContext, ctx)
+          // The build reads the workspace's own data with a trusted system
+          // context, rather than inheriting the next reader's actor.
+          row.deferredBuild = workspaceExportGenerationEffect(() =>
+            testWorkspaceContext(ctx.workspace, null, 'system')
+          ).pipe(
+            Effect.provide(snapshotContext),
+            Effect.provideService(WorkspaceExports, service),
+            Effect.provideService(WorkspaceSuspensionService, suspension),
+            Effect.provideService(Scope.Scope, scope),
+            Effect.flatMap((generation) =>
+              generation.generate({
+                message: {
+                  exportId: id,
+                  workspaceId: ctx.workspace.id,
+                  workspaceSlug: ctx.workspace.slug
+                },
+                finalAttempt: true
+              })
+            )
           )
-          row.deferredAt = requestedAt
           return row.record
         })(),
         issueDownloadLink: Effect.fn('WorkspaceExports.issueDownloadLink')(function* (
@@ -327,14 +338,8 @@ export function SeedWorkspaceExports(options: {
             return false
           }
           const completedAt = yield* DateTime.now
-          row.record = {
-            ...row.record,
-            status: 'failed',
-            completedAt: DateTime.formatIso(completedAt),
-            failureReason: input.reason
-          }
-          // The same event Live commits beside the transition: a settled
-          // failure is the outcome an operator most needs a trail for.
+          // Record the evidence before changing the row so an unavailable
+          // audit service leaves the deferred export pending for retry.
           yield* audit.record({
             workspaceId: row.workspaceId,
             actorUserId: null,
@@ -344,6 +349,14 @@ export function SeedWorkspaceExports(options: {
             targetId: row.record.id,
             metadata: { reason: input.reason }
           })
+          row.record = {
+            ...row.record,
+            status: 'failed',
+            completedAt: DateTime.formatIso(completedAt),
+            failureReason: input.reason
+          }
+          // The same event Live commits beside the transition: a settled
+          // failure is the outcome an operator most needs a trail for.
           return true
         }),
         openDownload: Effect.fn('WorkspaceExports.openDownload')(function* (
@@ -393,6 +406,7 @@ export function SeedWorkspaceExports(options: {
           })
         })
       }
+      return service
     })
   )
 }


### PR DESCRIPTION
## Outcome

Closes #395.

Seed Workspace Export requests previously built archives with the requesting Member's context and discarded deferred work before generation succeeded. That included private Notifications in Workspace archives and left failed builds pending without work to retry.

Seed and queued Live execution now use the same generation constructor. Seed keeps its pending request and deferred read behavior, uses a trusted context without an actor, and settles build failures through the shared policy. Failed audit writes leave the pending work available for a later read.

## Decisions

Keep the existing public export and generation interfaces, queue scheduling, and R2 storage. Seed treats a deferred run as its final generation attempt. The shared Effect constructor acquires dependencies without a circular construction dependency.

Webhook admission was explored and deferred: its one production caller and existing behavior coverage do not currently justify another module.

## Validation

Validated head: `786568ce08b2ca08f3eb08b4b921483369491d63`. The export diff remains byte-for-byte identical to the independently reviewed snapshot after merging the documentation-only master update.

- `pnpm run check` passed.
- The final Seed regression suite passed all 3 tests; repository checks also passed the existing Seed and Live export suites.
- Independent Standards and Spec reviews found no actionable issues. The Standards pass included strict maintainability review.
- `pnpm run validate` passed on the final integrated tree, including builds, generated Wrangler drift checks, local D1 migration/seed, and all 41 browser tests.
- GitHub build, quality, all three test groups, both E2E shards, the E2E summary, and the audit passed. [CI run](https://github.com/brandhaug/b2b-saas-starter/actions/runs/34714762347).

Acceptance evidence:
- AC1: Both execution paths use `workspaceExportGenerationEffect`; the queue retains its existing generation Layer.
- AC2: `workspace-export-generation.seed.test.ts` requests and downloads an archive, verifies a pending receipt, and checks broadcast inclusion and private Notification exclusion.
- AC3: The same suite verifies audited failure for an oversized audit trail and retry after failure-evidence storage recovers. Both original defects fail against the original Seed adapter; restoring the old state-before-audit ordering fails the recovery assertion.
- AC4: Existing Seed and Live export suites cover retry/final settlement, failed settlement persistence, suspension, and duplicate completion.
- AC5: Independent Standards and Spec reviews passed; full integrated validation passed.

## Risks and remaining work

No known code issues or outstanding review findings. Current required-check status is shown in PR Checks. No schema changes or reseed required.

An earlier audit setup attempt failed with a toolchain-download connection reset; the replacement audit passed on the same head. Preview deployment is skipped by the existing workflow conditions.
